### PR TITLE
Use pre-installed uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ FROM apache/airflow:2.9.2-python3.12
 USER root
 RUN apt-get update && apt-get install -y gcc git
 
-# install uv for dependency management
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
-RUN /install.sh && rm /install.sh
-
 ENV PYTHONPATH "${PYTHONPATH}:/opt/airflow/"
 
 USER airflow


### PR DESCRIPTION
Airflow already has `uv` in its base image as of Airflow 2.9, so we don't need to install it. The base image is configured so that the venv is created where needed. Note that it is still considered experimental. 

https://airflow.apache.org/docs/docker-stack/build.html#example-of-adding-pypi-package-with-uv

https://github.com/apache/airflow/pull/37796