### PR TITLE
Getting Dimensions tests to work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Run tests
         run: pytest
+        env:
+          AIRFLOW_VAR_DIMENSIONS_API_USER: ${{ secrets.AIRFLOW_VAR_DIMENSIONS_API_USER }}
+          AIRFLOW_VAR_DIMENSIONS_API_PASS: ${{ secrets.AIRFLOW_VAR_DIMENSIONS_API_PASS }}

--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -11,8 +11,8 @@ import requests
 dotenv.load_dotenv()
 
 dimcli.login(
-    os.environ.get("DIMENSIONS_API_USER"),
-    os.environ.get("DIMENSIONS_API_PASS"),
+    os.environ.get("AIRFLOW_VAR_DIMENSIONS_API_USER"),
+    os.environ.get("AIRFLOW_VAR_DIMENSIONS_API_PASS"),
     "https://app.dimensions.ai",
 )
 
@@ -65,7 +65,8 @@ def dimensions_doi_orcids_dict(org_data_file, pickle_file, limit=None):
     orcids = df[df["orcidid"].notna()]["orcidid"]
     orcid_dois = {}
 
-    for orcid in orcids[:limit]:
+    for orcid_url in orcids[:limit]:
+        orcid = orcid_url.replace("https://orcid.org/", "")
         dois = list(dimensions_dois_from_orcid(orcid))
         orcid_dois.update({orcid: dois})
 

--- a/test/data/authors.csv
+++ b/test/data/authors.csv
@@ -1,0 +1,11 @@
+sunetid,orcidid
+sunet1,https://orcid.org/0000-0001-8705-1000
+sunet2,https://orcid.org/0000-0003-2150-5828
+sunet3,https://orcid.org/0000-0003-2150-5828
+sunet4,https://orcid.org/0000-0002-0770-2940
+sunet5,https://orcid.org/0000-0002-5270-1197
+sunet6,https://orcid.org/0000-0002-7636-9758
+sunet7,https://orcid.org/0000-0003-4670-0347
+sunet8,https://orcid.org/0000-0002-5969-1251
+sunet9,https://orcid.org/0000-0002-0426-2134
+sunet10,https://orcid.org/0000-0002-0455-2086

--- a/test/harvest/test_dimensions.py
+++ b/test/harvest/test_dimensions.py
@@ -7,8 +7,8 @@ from rialto_airflow.harvest.dimensions import dimensions_doi_orcids_dict, invert
 
 dotenv.load_dotenv()
 
-dimensions_user = os.environ.get("DIMENSIONS_API_USER")
-dimensions_password = os.environ.get("DIMENSIONS_API_PASS")
+dimensions_user = os.environ.get("AIRFLOW_VAR_DIMENSIONS_API_USER")
+dimensions_password = os.environ.get("AIRFLOW_VAR_DIMENSIONS_API_PASS")
 
 no_auth = not (dimensions_user and dimensions_password)
 
@@ -16,15 +16,16 @@ no_auth = not (dimensions_user and dimensions_password)
 @pytest.mark.skipif(no_auth, reason="no dimensions key")
 def test_dimensions_doi_orcids_dict(tmpdir):
     pickle_file = tmpdir / "dimensions.pickle"
-    dimensions_doi_orcids_dict(
-        "data/rialto_app/authors_2024-03-18.csv", pickle_file, limit=5
-    )
+    dimensions_doi_orcids_dict("test/data/authors.csv", pickle_file, limit=5)
     assert pickle_file.isfile()
 
     with open(pickle_file, "rb") as handle:
-        doi_orcids_dict = pickle.load(handle)
+        doi_orcids = pickle.load(handle)
 
-    assert len(doi_orcids_dict.keys()) == len(set(doi_orcids_dict.keys()))
+    assert len(doi_orcids) > 0
+    assert doi_orcids["https://doi.org/10.1109/lra.2018.2890209"] == [
+        "0000-0002-0770-2940"
+    ]
 
 
 def test_invert_dict():


### PR DESCRIPTION
This PR gets the Dimensions tests to work using environment variables that docker-compose sets. You can also set them your `.env` to run the tests locally. The Dimensions credentials were also added to Vault. These should hopefully work in Github Actions as well with the username/password stored as GitHub secrets.

I reformatted the input data to match what I think it will look like when rialto-orgs writes it out (using orcid URLs instead of bare ORCIDs). 

Closes #36 