### PR TITLE
Remove tenacity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "requests",
     "python-dotenv",
     "dimcli",
-    "tenacity",
     "pyalex",
     "more-itertools"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,8 +107,6 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 stack-data==0.6.3
     # via ipython
-tenacity==8.4.1
-    # via rialto-airflow (pyproject.toml)
 tqdm==4.66.4
     # via dimcli
 traitlets==5.14.3


### PR DESCRIPTION
Since we're no longer using it for retrying (for now) removing from dependencies. 