### PR TITLE
remove dev environment for deployment

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# Roles are passed to docker-compose as profiles.
-server 'sul-rialto-airflow-dev.stanford.edu', user: 'rialto', roles: %w[app]
-
-Capistrano::OneTimeKey.generate_one_time_key!
-


### PR DESCRIPTION
Blocked by https://github.com/sul-dlss/operations-tasks/issues/3970 and #130, this removes the unused dev environment once stage and prod are setup