### PR TITLE
Allow AIRFLOW_VAR_DEV_LIMIT to be undefined

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -18,9 +18,10 @@ sul_pub_host = Variable.get("sul_pub_host")
 sul_pub_key = Variable.get("sul_pub_key")
 
 # to artificially limit the API activity in development
-dev_limit = Variable.get("dev_limit", default_var=None)
-if dev_limit is not None:
-    dev_limit = int(dev_limit)
+try:
+    dev_limit = int(Variable.get("dev_limit", default_var=None))
+except ValueError:
+    dev_limit = None
 
 
 @dag(


### PR DESCRIPTION
When I removed `AIRFLOW_VAR_DEV_LIMIT` from my `.env` I got a DAG load error when Airflow started up because it was trying to cast an empty string as an `int`.