### PR TITLE
Only harvest approved publications from sul_pub

### DIFF
--- a/rialto_airflow/harvest/sul_pub.py
+++ b/rialto_airflow/harvest/sul_pub.py
@@ -54,6 +54,9 @@ def harvest(host, key, since, limit):
             more = False
 
         for record in records:
+            if not approved(record):
+                continue
+
             record_count += 1
             if limit is not None and record_count > limit:
                 logging.info(f"stopping with limit={limit}")
@@ -71,3 +74,13 @@ def extract_doi(record):
         if id.get("type") == "doi" and "id" in id:
             return id["id"].replace("https://doi.org/", "")
     return None
+
+
+def approved(pub):
+    """
+    Returns True if at least one author has approved the publication, and False if not.
+    """
+    for authorship in pub["authorship"]:
+        if authorship["status"] == "approved":
+            return True
+    return False

--- a/test/harvest/test_sul_pub.py
+++ b/test/harvest/test_sul_pub.py
@@ -28,3 +28,12 @@ def test_sul_pub_csv(tmpdir):
     dois = df.doi[df.doi.notna()]
     assert len(dois) > 1, "there should be at least a few DOIs?"
     assert not dois.iloc[0].startswith("http://"), "DOI IDs not URLs"
+
+    # all the publications should be approved by at least one author
+    for _, pub in df.iterrows():
+        approved = False
+        # the value in the authorship column is a serialized Python dictionary
+        for authorship in eval(pub["authorship"]):
+            if authorship["status"] == "approved":
+                approved = True
+        assert approved is True, f"sulpubid={pub['sulpubid']} is marked approved"


### PR DESCRIPTION
We are currently saving *all* publications from sul_pub in our `sul_pub.csv`, but we only want to include publications that have been *approved* by a Stanford author. Including all publications was causing there to be more publications in our publications.parquet than there were contributions in our contributions.parquet file.

Fixes #115

I tested by doing a full harvest on my workstation. As expected the number of rows in the `sulpub.csv` is much lower. Here are the before and after numbers:

```
$ wc -l data/snapshots/20250206192618/sulpub.csv
  662432 data/snapshots/20250206192618/sulpub.csv

$ wc -l data/snapshots/20250211165921/sulpub.csv
  357204 data/snapshots/20250211165921/sulpub.csv
```

The resulting `publications.parquet` and `contributions.parquet` files are in the right proportions now:

```python
>>> import pandas
>>> c = pandas.read_parquet('data/latest/contributions.parquet')
>>> p = pandas.read_parquet('data/latest/publications.parquet')
>>> len(c)
555793
>>> len(p)
484155
```
