### PR TITLE
stage and prod data directory name change

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -90,7 +90,7 @@ x-airflow-common:
     AIRFLOW_VAR_PUBLISH_DIR: /opt/airflow/data/latest
   volumes:
     - /opt/app/rialto/rialto-airflow/current/rialto_airflow:/opt/airflow/rialto_airflow
-    - /data:/opt/airflow/data
+    - /rialto-data:/opt/airflow/data
     - /opt/app/rialto/rialto-airflow/shared/logs:/opt/airflow/logs
   user: "503:0"
   depends_on:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,7 +45,7 @@ set :honeybadger_env, fetch(:stage)
 # Set Rails env to production in all Cap environments
 set :rails_env, 'production'
 
-set :docker_compose_file, 'docker-compose.prod.yaml'
+set :docker_compose_file, 'compose.prod.yaml'
 set :docker_compose_migrate_use_hooks, false
 set :docker_compose_seed_use_hooks, false
 set :docker_compose_rabbitmq_use_hooks, false

--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -20,7 +20,7 @@ sul_pub_key = Variable.get("sul_pub_key")
 # to artificially limit the API activity in development
 try:
     dev_limit = int(Variable.get("dev_limit", default_var=None))
-except ValueError:
+except TypeError:
     dev_limit = None
 
 


### PR DESCRIPTION
*in draft until it works on stage*

The stage and production environments now have a share of `/rialto-data` rather than `/data`. Since we map this location as part of the docker compose configuration it should only need to be updated there.

Fixes #145
