### PR TITLE
tweaks to get sqlalchemy dependency and apache-airflow dev dependency working for running airflow locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM apache/airflow:2.10.4-python3.12
 
 USER root
-RUN apt-get update && apt-get install -y gcc git
+RUN apt-get update && apt-get install -y gcc git libpq-dev
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/airflow/"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dependencies = [
     "polars>=1.2",
     "pyalex",
     "more-itertools",
-    "sqlalchemy>=2.0.38",
     "psycopg2>=2.9.10",
+    "sqlalchemy>=1.4.36,<2.0",
 ]
 
 [tool.pytest.ini_options]
@@ -30,6 +30,7 @@ addopts = "-v"
 
 [dependency-groups]
 dev = [
+    "apache-airflow==2.10.4",
     "pytest>=8.3.4",
     "python-dotenv>=1.0.1",
     "ruff>=0.9.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.38
+sqlalchemy==1.4.54
     # via rialto-airflow (pyproject.toml)
 stack-data==0.6.3
     # via ipython
@@ -117,8 +117,6 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.12.2
-    # via sqlalchemy
 tzdata==2025.1
     # via pandas
 urllib3==2.3.0


### PR DESCRIPTION
* lined up compatible versions of sqlalchemy and apache-airflow, per https://github.com/sul-dlss/rialto-airflow/pull/153 and standup discussion yesterday
* add a package to the list of debian packages installed in our rialto-airflow docker image, per https://stackoverflow.com/a/78692169
* recompile requirements.txt with uv since pyproject.toml dep listing was updated