### PR TITLE
Remove doi_set task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ addopts = "-v"
 
 [dependency-groups]
 dev = [
-    "apache-airflow==2.10.4",
+    "apache-airflow==2.10.4", # aligned with base Docker image
     "pytest>=8.3.4",
     "python-dotenv>=1.0.1",
     "ruff>=0.9.4",

--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -90,26 +90,21 @@ def harvest():
         return str(pickle_file)
 
     @task()
-    def doi_set(doi_sunet_pickle):
+    def dimensions_harvest_pubs(doi_sunet, snapshot_dir):
         """
-        Use the DOI -> [SUNET] pickle to return a list of all DOIs.
+        Harvest publication metadata from Dimensions using the dois from doi_sunet.
         """
-        return list(pickle.load(open(doi_sunet_pickle, "rb")).keys())
-
-    @task()
-    def dimensions_harvest_pubs(dois, snapshot_dir):
-        """
-        Harvest publication metadata from Dimensions using the dois from doi_set.
-        """
+        dois = list(pickle.load(open(doi_sunet, "rb")).keys())
         csv_file = Path(snapshot_dir) / "dimensions-pubs.csv"
         dimensions.publications_csv(dois, csv_file)
         return str(csv_file)
 
     @task()
-    def openalex_harvest_pubs(dois, snapshot_dir):
+    def openalex_harvest_pubs(doi_sunet, snapshot_dir):
         """
         Harvest publication metadata from OpenAlex using the dois from doi_set.
         """
+        dois = list(pickle.load(open(doi_sunet, "rb")).keys())
         csv_file = Path(snapshot_dir) / "openalex-pubs.csv"
         openalex.publications_csv(dois, csv_file)
         return str(csv_file)
@@ -160,11 +155,9 @@ def harvest():
         dimensions_dois, openalex_dois, sul_pub, authors_csv, snapshot_dir
     )
 
-    dois = doi_set(doi_sunet)
+    dimensions_pubs = dimensions_harvest_pubs(doi_sunet, snapshot_dir)
 
-    dimensions_pubs = dimensions_harvest_pubs(dois, snapshot_dir)
-
-    openalex_pubs = openalex_harvest_pubs(dois, snapshot_dir)
+    openalex_pubs = openalex_harvest_pubs(doi_sunet, snapshot_dir)
 
     pubs = merge_publications(sul_pub, openalex_pubs, dimensions_pubs, snapshot_dir)
 


### PR DESCRIPTION
Since the doi_set task returns all of the DOIs to harvest, it also puts them in Xcoms, and its hundreds of thousands of DOIs. The recommended practice is that Xcoms not be used for passing large amounts of data between tasks, but just for metadata, in this case the path to the `doi-sunet.pickle` file that contains the DOIs.

I ran the Harvest DAG in my develpment environment to test, since the communication between tasks isn't really covered by our tests at the moment.

Fixes #149
