### PR TITLE
add .autoupdate/preupdate hook so that our weekly dep updates can handle python deps for the project

### DIFF
--- a/.autoupdate/preupdate
+++ b/.autoupdate/preupdate
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script is called by our weekly dependency update job in Jenkins
+
+pip3 install uv > rialto-airflow.txt &&
+    ~/.local/bin/uv lock --upgrade >> rialto-airflow.txt &&     # Currently, local dev and CI use the uv.lock file for dependency resolution...
+    uv pip compile pyproject.toml -o requirements.txt --upgrade # ...but the Dockerfile for our Airflow image uses requirements.txt.
+
+retVal=$?
+
+git add uv.lock requirements.txt &&
+    git commit -m "Update Python dependencies"
+
+if [ $retVal -ne 0 ]; then
+    echo "ERROR UPDATING PYTHON (rialto-airflow)"
+    cat rialto-airflow.txt
+fi


### PR DESCRIPTION
hooks into https://github.com/sul-dlss/access-update-scripts/blob/7c998d85ef4e27fcfee9d5601f38893deb807506/autupdate.sh#L37-L42

see e.g. https://github.com/sul-dlss/speech-to-text/pull/81/files#diff-0a2ddddfdd28a062dadabf7ea9f86285bacbb09f2d9e53da056044905e673819

connects with https://github.com/sul-dlss/rialto-airflow/issues/132