### PR TITLE
Test database fixtures

### DIFF
--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -14,15 +14,16 @@ from sqlalchemy.types import DateTime
 Base = declarative_base()
 
 
+def db_uri(database_name):
+    return f"{os.environ.get('AIRFLOW_VAR_RIALTO_POSTGRES')}/{database_name}"
+
+
 def engine_setup(database_name: str):
     """
     When creating the database and its schema, use an engine and connection.
     Subsequent querying should be done through a session.
     """
-    engine = create_engine(
-        f"{os.environ.get('AIRFLOW_VAR_RIALTO_POSTGRES')}/{database_name}", echo=True
-    )
-    return engine
+    return create_engine(db_uri(database_name), echo=True)
 
 
 def create_database(snapshot_dir: str) -> str:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy_utils import create_database, database_exists, drop_database
+
+from rialto_airflow.database import create_schema, engine_setup
+
+
+@pytest.fixture
+def test_engine(monkeypatch):
+    """
+    This pytest fixture will ensure that the rialto_test database exists and has
+    the database schema configured. If the database exists it will be dropped
+    and readded.
+    """
+    db_host = "postgresql+psycopg2://airflow:airflow@localhost:5432"
+    monkeypatch.setenv("AIRFLOW_VAR_RIALTO_POSTGRES", db_host)
+
+    db_name = "rialto_test"
+    db_uri = f"{db_host}/{db_name}"
+
+    if database_exists(db_uri):
+        drop_database(db_uri)
+
+    create_database(db_uri)
+
+    # note: rialto_airflow.database.create_schema wants the database name not uri
+    create_schema(db_name)
+
+    return engine_setup(db_name)
+
+
+@pytest.fixture
+def test_conn(test_engine):
+    """
+    Returns a sqlalchemy connection for the test database.
+    """
+    return test_engine.connect()
+
+
+@pytest.fixture
+def test_session(test_engine):
+    """
+    Returns a sqlalchemy session for the test database.
+    """
+    return sessionmaker(test_engine)

--- a/test/harvest/test_sul_pub.py
+++ b/test/harvest/test_sul_pub.py
@@ -6,6 +6,7 @@ import pytest
 
 from rialto_airflow.harvest.sul_pub import sul_pub_csv
 
+
 dotenv.load_dotenv()
 
 sul_pub_host = os.environ.get("AIRFLOW_VAR_SUL_PUB_HOST")

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -6,6 +6,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
 from rialto_airflow import database
+from rialto_airflow.database import Author
 
 
 @pytest.fixture
@@ -119,3 +120,22 @@ def test_create_schema(tmp_path, mock_rialto_postgres, monkeypatch, teardown_dat
     finally:
         # even if exception raised, tear down the database
         teardown_database(db_name)
+
+
+@pytest.fixture
+def author(test_session):
+    with test_session.begin() as session:
+        session.add(
+            database.Author(
+                sunet="mjgiarlo",
+                orcid="0000-0002-2100-6108",
+                first_name="Mike",
+                last_name="Giarlo",
+                status="active",
+            )
+        )
+
+
+def test_author_fixture(test_session, author):
+    with test_session.begin() as session:
+        assert session.query(Author).where(Author.sunet == "mjgiarlo").count() == 1


### PR DESCRIPTION
This PR adds a few pytest fixtures for working with the test database. These have been added to the `test/conftest.py` module which makes them available to all the tests that pytest runs (nothing to import).

Most of the time we'll probably just want to use the test_session:

```python
from rialto_airflow.database import Author

def test_no_authors(test_session):
    with test_session.begin() as session:
        assert session.query(Author).count() == 0
```

Or if you want to set up the database with some data you can do something like this:

```python
from rialto_airflow.database import Author

@pytest.fixture
def author(test_session):
    with test_session.begin() as session:
        session.add(Author(
            sunet="mjgiarlo",
            orcid="0000-0002-2100-6108",
            first_name="Mike",
            last_name="Giarlo",
            status="active",
        ))

def test_author_fixture(test_session, author):
    with test_session() as session:
        assert session.query(Author).where(Author.sunet == 'mjgiarlo').count() == 1
```

Closes #171
