### PR TITLE
Add Snapshot class

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -64,6 +64,7 @@ x-airflow-common:
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     AIRFLOW__CORE__DAGS_FOLDER: '/opt/airflow/rialto_airflow/dags'
     AIRFLOW__CORE__PLUGINS_FOLDER: '/opt/airflow/rialto_airflow/plugins'
+    AIRFLOW__CORE__ENABLE_XCOM_PICKLING: 'true'
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
     AIRFLOW__SMTP__SMTP_USER: ${AIRFLOW__SMTP__SMTP_USER}
     AIRFLOW__SMTP__SMTP_HOST: ${AIRFLOW__SMTP__SMTP_HOST}

--- a/compose.yaml
+++ b/compose.yaml
@@ -62,6 +62,7 @@ x-airflow-common:
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     AIRFLOW__CORE__DAGS_FOLDER: '/opt/airflow/rialto_airflow/dags'
     AIRFLOW__CORE__PLUGINS_FOLDER: '/opt/airflow/rialto_airflow/plugins'
+    AIRFLOW__CORE__ENABLE_XCOM_PICKLING: 'true'
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from functools import cache
-from pathlib import Path
 
 from sqlalchemy import Table, Boolean, Column, ForeignKey, Integer, String
 from sqlalchemy import create_engine, text
@@ -33,10 +32,8 @@ def get_engine(database_name: str):
     return engine_setup(database_name)
 
 
-def create_database(snapshot_dir: str) -> str:
+def create_database(database_name: str) -> str:
     """Create a DAG-specific database for publications and author/orgs data"""
-    timestamp = Path(snapshot_dir).name
-    database_name = f"rialto_{timestamp}"
 
     # set up the connection using the default postgres database
     # see discussion here: https://stackoverflow.com/questions/6506578/how-to-create-a-new-database-using-sqlalchemy

--- a/rialto_airflow/harvest/authors.py
+++ b/rialto_airflow/harvest/authors.py
@@ -7,18 +7,19 @@ from rialto_airflow.database import get_engine, Author
 from rialto_airflow.utils import rialto_authors_file
 
 
-def load_authors_table(harvest_config) -> str:
+def load_authors_table(snapshot) -> str:
     """
     Load the authors data from the authors CSV into the database
     """
-    db_name = harvest_config["database_name"]
-    engine = get_engine(db_name)
+    engine = get_engine(snapshot.database_name)
     Session = sessionmaker(engine)
 
-    authors_file = rialto_authors_file(harvest_config["snapshot_dir"])
+    authors_file = rialto_authors_file(snapshot.path)
     check_headers(authors_file)
 
-    logging.info(f"Loading authors from {authors_file} into database {db_name}")
+    logging.info(
+        f"Loading authors from {authors_file} into database {snapshot.database_name}"
+    )
     with Session.begin() as session:
         with open(authors_file, "r") as file:
             csv_reader = csv.DictReader(file)

--- a/rialto_airflow/snapshot.py
+++ b/rialto_airflow/snapshot.py
@@ -1,0 +1,24 @@
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Snapshot:
+    """
+    A class representing a given snapshot and its associated data directory and
+    database name.
+    """
+
+    path: Path
+    time: str
+    database_name: str
+
+    def __init__(self, data_dir, database_name=None):
+        now = datetime.datetime.now()
+        self.time = now.strftime("%Y%m%d%H%M%S")
+
+        self.path = Path(data_dir) / "snapshots" / self.time
+        self.path.mkdir(parents=True)
+
+        self.database_name = database_name or f"rialto_{self.time}"

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -1,20 +1,6 @@
 import csv
-import datetime
 from pathlib import Path
 import re
-
-
-def create_snapshot_dir(data_dir):
-    snapshots_dir = Path(data_dir) / "snapshots"
-
-    if not snapshots_dir.is_dir():
-        snapshots_dir.mkdir()
-
-    now = datetime.datetime.now()
-    snapshot_dir = snapshots_dir / now.strftime("%Y%m%d%H%M%S")
-    snapshot_dir.mkdir()
-
-    return str(snapshot_dir)
 
 
 def rialto_authors_file(data_dir):

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -1,0 +1,30 @@
+import io
+import pickle
+
+from rialto_airflow.snapshot import Snapshot
+
+
+def test_snapshot(tmpdir):
+    """
+    Make sure we can create a Snapshot given a data directory.
+    """
+    s = Snapshot(tmpdir)
+    assert s.time
+    assert s.path.is_dir()
+    assert s.database_name == f"rialto_{s.time}"
+
+
+def test_serialize(tmpdir):
+    """
+    Make sure that Snapshot is serializable as a pickle file since we want to be
+    able to use it in XComs with AIRFLOW__CORE__ENABLE_XCOM_PICKLING set.
+    Otherwise the Snapshot would need to be JSON serializable.
+    """
+    s1 = Snapshot(tmpdir)
+
+    out = io.BytesIO()
+    pickle.dump(s1, out)
+
+    out.seek(0)
+    s2 = pickle.load(out)
+    assert s1 == s2

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -19,11 +19,6 @@ def authors_csv(tmp_path):
     return fixture_file
 
 
-def test_create_snapshot_dir(tmp_path):
-    snap_dir = Path(utils.create_snapshot_dir(tmp_path))
-    assert snap_dir.is_dir()
-
-
 def test_rialto_authors_orcids(tmp_path, authors_csv):
     orcids = utils.rialto_authors_orcids(authors_csv)
     assert len(orcids) == 2


### PR DESCRIPTION
The Snapshot class is an alternative to passing around a dictionary which should make it a bit easier to work with. I needed to update Airflow to use Pickling for XComs since the default was JSON and Snapshot couldn't be serialized to JSON without custom encoder/decoder.

The idea is you can create a Snapshot using the path to the data directory, and it will take care of creating the various properties and the snapshot path:

```python
>>> from rialto_airflow.snapshot import Snapshot
>>> s = Snapshot('data')
>>> s
Snapshot(path=PosixPath('data/snapshots/20250221182537'), time='20250221182537', database_name='rialto_20250221182537')
```