### PR TITLE
Handle author load integrity error

### DIFF
--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -18,18 +18,18 @@ def db_uri(database_name):
     return f"{os.environ.get('AIRFLOW_VAR_RIALTO_POSTGRES')}/{database_name}"
 
 
-def engine_setup(database_name: str):
+def engine_setup(database_name: str, pool_pre_ping=False):
     """
     When creating the database and its schema, use an engine and connection.
     Subsequent querying should be done by accessing an engine via get_engine.
     """
-    return create_engine(db_uri(database_name), echo=True)
+    return create_engine(db_uri(database_name), pool_pre_ping=pool_pre_ping, echo=True)
 
 
 @cache
 def get_engine(database_name: str):
     """Memoized engine for use in other modules"""
-    return engine_setup(database_name)
+    return engine_setup(database_name, pool_pre_ping=True)
 
 
 def create_database(database_name: str) -> str:

--- a/rialto_airflow/harvest/authors.py
+++ b/rialto_airflow/harvest/authors.py
@@ -8,7 +8,7 @@ from rialto_airflow.database import get_engine, Author
 from rialto_airflow.utils import rialto_authors_file
 
 
-def load_authors_table(snapshot) -> str:
+def load_authors_table(snapshot) -> None:
     """
     Load the authors data from the authors CSV into the database
     """
@@ -26,7 +26,7 @@ def load_authors_table(snapshot) -> str:
         csv_reader = csv.DictReader(file)
         for row in csv_reader:
             try:
-                with Session.begin() as session:
+                with Session.begin() as session:  # type: ignore
                     author = Author(
                         sunet=row["sunetid"],
                         cap_profile_id=row["cap_profile_id"],
@@ -48,6 +48,8 @@ def load_authors_table(snapshot) -> str:
                 logging.warning(message)
                 errors.append(message)
                 continue
+            finally:
+                session.close()
 
     logging.info(f"Loaded {session.query(Author).count()} authors")
     if errors:

--- a/rialto_airflow/harvest/authors.py
+++ b/rialto_airflow/harvest/authors.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from rialto_airflow.database import get_engine, Author
@@ -20,30 +21,38 @@ def load_authors_table(snapshot) -> str:
     logging.info(
         f"Loading authors from {authors_file} into database {snapshot.database_name}"
     )
-    with Session.begin() as session:  # type: ignore
-        with open(authors_file, "r") as file:
-            csv_reader = csv.DictReader(file)
-            for row in csv_reader:
-                author = Author(
-                    sunet=row["sunetid"],
-                    cap_profile_id=row["cap_profile_id"],
-                    orcid=row["orcidid"] or None,
-                    first_name=row["first_name"],
-                    last_name=row["last_name"],
-                    status=to_boolean(row["active"]),
-                    academic_council=to_boolean(row["academic_council"]),
-                    primary_role=row["role"],
-                    schools=to_array(row["all_schools"]),
-                    departments=to_array(row["all_departments"]),
-                    primary_school=row["primary_school"],
-                    primary_dept=row["primary_department"],
-                    primary_division=row["primary_division"],
-                )
-                session.add(author)
-        logging.info(f"Loaded {session.query(Author).count()} authors")
-        # commits the transaction, closes the session
+    with open(authors_file, "r") as file:
+        errors = []
+        csv_reader = csv.DictReader(file)
+        for row in csv_reader:
+            try:
+                with Session.begin() as session:
+                    author = Author(
+                        sunet=row["sunetid"],
+                        cap_profile_id=row["cap_profile_id"],
+                        orcid=row["orcidid"] or None,
+                        first_name=row["first_name"],
+                        last_name=row["last_name"],
+                        status=to_boolean(row["active"]),
+                        academic_council=to_boolean(row["academic_council"]),
+                        primary_role=row["role"],
+                        schools=to_array(row["all_schools"]),
+                        departments=to_array(row["all_departments"]),
+                        primary_school=row["primary_school"],
+                        primary_dept=row["primary_department"],
+                        primary_division=row["primary_division"],
+                    )
+                    session.add(author)
+            except IntegrityError as e:
+                message = f"Skipping author: {row['sunetid'], row['orcidid']}: {e}"
+                logging.warning(message)
+                errors.append(message)
+                continue
 
-    return authors_file
+    logging.info(f"Loaded {session.query(Author).count()} authors")
+    if errors:
+        # show all errors at the end of the log
+        logging.warning(f"Errors: {errors}")
 
 
 def check_headers(authors_file: str) -> None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import close_all_sessions
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from rialto_airflow.database import create_schema, engine_setup
@@ -42,4 +43,7 @@ def test_session(test_engine):
     """
     Returns a sqlalchemy session for the test database.
     """
-    return sessionmaker(test_engine)
+    try:
+        yield sessionmaker(test_engine)
+    finally:
+        close_all_sessions()


### PR DESCRIPTION
Resolves #177 to skip and log authors who have a duplicate ORCID or other duplicate data in fields with a unique constraint. 

This is constructing the session with each row of the CSV, so that each author is loaded one by one, and thus if an IntegrityError is raised, it does not affect authors earlier or later in the CSV. If there's a better way to handles sessions in this situation, would be willing to do differently. 

I had been encountering the following error when testing a situation that would raise the exception (`test_load_
dupe_orcid`). The tests were passing. 

```
Exception during reset or similar
Traceback (most recent call last):
  File "/Users/lwrubel/sul-dlss/rialto-airflow/.venv/lib/python3.12/site-packages/sqlalchemy/pool/base.py", line 763, in _finalize_fairy
    fairy._reset(pool, transaction_was_reset)
  File "/Users/lwrubel/sul-dlss/rialto-airflow/.venv/lib/python3.12/site-packages/sqlalchemy/pool/base.py", line 1038, in _reset
    pool._dialect.do_rollback(self)
  File "/Users/lwrubel/sul-dlss/rialto-airflow/.venv/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 683, in do_rollback
    dbapi_connection.rollback()
psycopg2.OperationalError: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

I added [pessimistic testing of connections](https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic) in test (we can see if we need this in production but I haven't noticed it being needed so far when looking at logs in the DAG).  I also needed to add an explicit close of sessions in `conftest.py` (`session.close_all_sessions()`) based on the discussion at the end of[ this sqlalchemy issue](https://github.com/sqlalchemy/sqlalchemy/issues/5522). The combination of these two changes eliminated the postgres OperationalErrors.

