### PR TITLE
create normalize_orcid function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ done
 ```
 
 5. The harvest DAG requires a CSV file of authors from rialto-orgs to be available. This is not yet automatically available, so to set up locally, download the file at
-https://sul-rialto-stage.stanford.edu/authors?action=index&commit=Search&controller=authors&format=csv&orcid_filter=&q=. Put the `authors.csv` file in the `data/` directory. 
+https://sul-rialto-stage.stanford.edu/authors?action=index&commit=Search&controller=authors&format=csv&orcid_filter=&q=. Put the `authors.csv` file in the `data/` directory.
 
-6. Bring up containers. 
+6. Bring up containers.
 ```
 docker compose up -d
 ```
 
-7. The Airflow application will be available at `localhost:8080` and can be accessed with the default Airflow username and password. 
+7. The Airflow application will be available at `localhost:8080` and can be accessed with the default Airflow username and password.
 
 ## Development
 
@@ -107,8 +107,10 @@ DOCKER_DEFAULT_PLATFORM="linux/amd64" docker build . -t suldlss/rialto-airflow:l
 docker push suldlss/rialto-airflow
 ```
 
-Deployment to https://sul-rialto-airflow-dev.stanford.edu/ is handled like other SDR services using Capistrano. You'll need to have Ruby installed and then:
+Deployment to https://sul-rialto-airflow-XXXX.stanford.edu/ is handled like other SDR services using Capistrano. You'll need to have Ruby installed and then:
 
 ```
-bundle exec cap dev deploy
+bundle exec cap stage deploy # stage
+bundle exec cap prod deploy  # prod
+# Note: there is no QA
 ```

--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -10,7 +10,7 @@ import pandas as pd
 import requests
 from more_itertools import batched
 
-from rialto_airflow.utils import invert_dict
+from rialto_airflow.utils import invert_dict, normalize_doi, normalize_orcid
 
 
 def dois_from_orcid(orcid):
@@ -27,7 +27,7 @@ def dois_from_orcid(orcid):
         logging.warning("Truncated results for ORCID %s", orcid)
     for pub in result["publications"]:
         if pub.get("doi"):
-            doi_id = pub["doi"].replace("https://doi.org/", "")
+            doi_id = normalize_doi(pub["doi"])
             yield doi_id
 
 
@@ -41,7 +41,7 @@ def doi_orcids_pickle(authors_csv, pickle_file, limit=None) -> None:
     orcid_dois = {}
 
     for orcid_url in orcids[:limit]:
-        orcid = orcid_url.replace("https://orcid.org/", "")
+        orcid = normalize_orcid(orcid_url)
         dois = list(dois_from_orcid(orcid))
         orcid_dois.update({orcid: dois})
 

--- a/rialto_airflow/harvest/doi_sunet.py
+++ b/rialto_airflow/harvest/doi_sunet.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 # TODO: use polars instead?
 import pandas as pd
 
-from rialto_airflow.utils import normalize_doi
+from rialto_airflow.utils import normalize_doi, normalize_orcid
 
 
 def create_doi_sunet_pickle(
@@ -120,4 +120,4 @@ def orcid_id(orcid):
     if pd.isna(orcid):
         return None
     else:
-        return orcid.replace("https://orcid.org/", "")
+        return normalize_orcid(orcid)

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -7,7 +7,7 @@ import time
 from more_itertools import batched
 from pyalex import Authors, Works, config, api
 
-from rialto_airflow.utils import invert_dict, normalize_doi
+from rialto_airflow.utils import invert_dict, normalize_doi, normalize_orcid
 
 config.email = os.environ.get("AIRFLOW_VAR_OPENALEX_EMAIL")
 config.max_retries = 5
@@ -23,7 +23,7 @@ def doi_orcids_pickle(authors_csv, pickle_file, limit=None):
         orcid_dois = {}
         count = 0
         for row in csv.DictReader(csv_input):
-            orcid = row["orcidid"].replace("https://orcid.org/", "")
+            orcid = normalize_orcid(row["orcidid"])
             if orcid:
                 count += 1
                 orcid_dois[orcid] = list(dois_from_orcid(orcid))

--- a/rialto_airflow/mais.py
+++ b/rialto_airflow/mais.py
@@ -3,6 +3,7 @@ import logging
 from collections import defaultdict
 from datetime import date
 from typing import Any, Dict, List, Optional, Union
+from rialto_airflow.utils import normalize_orcid
 
 import requests
 from requests_oauthlib import OAuth2Session
@@ -113,7 +114,7 @@ def fetch_orcid_users(
 
 def fetch_orcid_user(access_token: str, base_url: str, user_id: str) -> ORCIDRecord:
     """Fetches a single ORCID user record by ORCID iD or SUNet ID from the MAIS ORCID API."""
-    cleaned_id = user_id.replace("https://orcid.org/", "")
+    cleaned_id = normalize_orcid(user_id)
     return get_response(access_token, f"{base_url}/mais/orcid/v1/users/{cleaned_id}")
 
 

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -49,3 +49,12 @@ def normalize_doi(doi):
     doi = re.sub("^doi: ", "", doi)
 
     return doi
+
+
+def normalize_orcid(orcid):
+    orcid = orcid.strip().lower()
+    orcid = orcid.replace("https://orcid.org/", "").replace(
+        "https://sandbox.orcid.org/", ""
+    )
+
+    return orcid

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -62,3 +62,19 @@ def test_normalize_doi():
         == "10.1103/physrevlett.96.07390"
     )
     assert utils.normalize_doi(" doi: 10.1234/5678 ") == "10.1234/5678"
+
+
+def test_normalize_orcid():
+    assert (
+        utils.normalize_orcid("https://orcid.org/0000-0002-7262-6251")
+        == "0000-0002-7262-6251"
+    )
+    assert (
+        utils.normalize_orcid("https://sandbox.orcid.org/0000-0002-7262-6251")
+        == "0000-0002-7262-6251"
+    )
+    assert utils.normalize_orcid("0000-0002-7262-6251") == "0000-0002-7262-6251"
+    assert (
+        utils.normalize_orcid(" HTTPS://ORCID.org/0000-0002-7262-6251 ")
+        == "0000-0002-7262-6251"
+    )


### PR DESCRIPTION
Fixes #151 - create and use a normalize_orcid function

Also, update README to reflect updated environment name and use the existing normalize_doi function in a spot where it wasn't being used