### PR TITLE
More informative error message in load authors log

### DIFF
--- a/rialto_airflow/harvest/authors.py
+++ b/rialto_airflow/harvest/authors.py
@@ -54,7 +54,7 @@ def load_authors_table(snapshot) -> None:
     logging.info(f"Loaded {session.query(Author).count()} authors")
     if errors:
         # show all errors at the end of the log
-        logging.warning(f"Errors: {errors}")
+        logging.warning(f"Errors with {len(errors)} authors: {errors}")
 
 
 def check_headers(authors_file: str) -> None:

--- a/test/harvest/test_authors.py
+++ b/test/harvest/test_authors.py
@@ -146,4 +146,4 @@ def test_load_dupe_orcid(test_session, tmp_path, caplog, authors_csv, snapshot):
     )
     for record in caplog.records:
         assert "Skipping author: ('lelands'" in caplog.text
-        assert "Errors:" in caplog.text
+        assert "Errors with 1 author" in caplog.text


### PR DESCRIPTION
Adds the number of authors with errors, which is helpful when there are over a hundred. 