### PR TITLE
Tiny authors csv refactor plus coverage tweak

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ pythonpath = ["."]
 markers = "mais_tests: Tests requiring MAIS access"
 addopts = "-v --cov --cov-report=html --cov-report=term"
 
+[tool.coverage.run]
+omit = ["test/*"]
+
 [tool.mypy]
 check_untyped_defs = true # Type-checks the interior of functions without type annotations.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 description = "Airflow app for harvesting data for open access analysis and research intelligence."
 
-authors = [ {name = "Laura Wrubel", email = "lwrubel@stanford.edu"}, {name = "Ed Summers", email = "edsu@stanford.edu"}, {name = "Jacob Hill", email = "jacob.hill@stanford.edu"}]
+authors = [ {name = "Laura Wrubel", email = "lwrubel@stanford.edu"}, {name = "Ed Summers", email = "edsu@stanford.edu"}, {name = "Jacob Hill", email = "jacob.hill@stanford.edu"}, {name = "Johnathan Martin", email = "john.martin@stanford.edu"}]
 
 # Aligned with what is defined in Dockerfile and CI
 requires-python = "== 3.12.*" 

--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -42,9 +42,7 @@ def harvest():
         Set up the snapshot directory and database.
         """
         snapshot = Snapshot(data_dir)
-        shutil.copyfile(
-            Path(rialto_authors_file(data_dir)), snapshot.path / "authors.csv"
-        )
+        shutil.copyfile(Path(rialto_authors_file(data_dir)), snapshot.authors_csv)
         create_database(snapshot.database_name)
         create_schema(snapshot.database_name)
 
@@ -63,9 +61,8 @@ def harvest():
         """
         Fetch the data by ORCID from Dimensions.
         """
-        authors_csv = snapshot.path / "authors.csv"
         pickle_file = snapshot.path / "dimensions-doi-orcid.pickle"
-        dimensions.doi_orcids_pickle(authors_csv, pickle_file, limit=dev_limit)
+        dimensions.doi_orcids_pickle(snapshot.authors_csv, pickle_file, limit=dev_limit)
         return str(pickle_file)
 
     @task()
@@ -73,9 +70,8 @@ def harvest():
         """
         Fetch the data by ORCID from OpenAlex.
         """
-        authors_csv = snapshot.path / "authors.csv"
         pickle_file = snapshot.path / "openalex-doi-orcid.pickle"
-        openalex.doi_orcids_pickle(authors_csv, pickle_file, limit=dev_limit)
+        openalex.doi_orcids_pickle(snapshot.authors_csv, pickle_file, limit=dev_limit)
         return str(pickle_file)
 
     @task()
@@ -95,9 +91,10 @@ def harvest():
         Extract a mapping of DOI -> [SUNET] from the dimensions doi-orcid dict,
         openalex doi-orcid dict, SUL-Pub publications, and authors data.
         """
-        authors_csv = snapshot.path / "authors.csv"
         pickle_file = snapshot.path / "doi-sunet.pickle"
-        create_doi_sunet_pickle(dimensions, openalex, sul_pub, authors_csv, pickle_file)
+        create_doi_sunet_pickle(
+            dimensions, openalex, sul_pub, snapshot.authors_csv, pickle_file
+        )
 
         return str(pickle_file)
 
@@ -135,9 +132,8 @@ def harvest():
         """
         Get contributions from publications.
         """
-        authors_csv = snapshot.path / "authors.csv"
         contribs_path = snapshot.path / "contributions.parquet"
-        create_contribs(pubs, doi_sunet_pickle, authors_csv, contribs_path)
+        create_contribs(pubs, doi_sunet_pickle, snapshot.authors_csv, contribs_path)
 
         return str(contribs_path)
 

--- a/rialto_airflow/snapshot.py
+++ b/rialto_airflow/snapshot.py
@@ -13,6 +13,7 @@ class Snapshot:
     path: Path
     time: str
     database_name: str
+    authors_csv: Path
 
     def __init__(self, path, database_name=None):
         now = datetime.datetime.now()
@@ -22,3 +23,4 @@ class Snapshot:
         self.path.mkdir(parents=True)
 
         self.database_name = database_name or f"rialto_{self.time}"
+        self.authors_csv = self.path / "authors.csv"

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -1,6 +1,7 @@
 import io
 import pickle
 
+from pathlib import Path
 from rialto_airflow.snapshot import Snapshot
 
 
@@ -11,6 +12,8 @@ def test_snapshot(tmpdir):
     s = Snapshot(tmpdir)
     assert s.time
     assert s.path.is_dir()
+    assert s.path.is_relative_to(Path(tmpdir))
+    assert s.authors_csv.is_relative_to(Path(tmpdir))
     assert s.database_name == f"rialto_{s.time}"
 
 


### PR DESCRIPTION
* centralize authors csv path construction into field on `Snapshot` class
  * i felt like this made things a bit more readable and centralized some path construction that we'd probably want to change across all current uses if it did change, but this was like 10 minutes of work, so i'm happy to just drop this commit if others don't think it's an improvement.
* test config touchup: test code itself shouldn't be counted in coverage stats
  * this unfortunately drops the overall coverage for the codebase, leading one codecov check to fail on this PR.  making the stats more honest seemed like an improvement by itself, even if we do want to consider upping coverage in light of the new stats, so i wasn't inclined to find some uncovered spot to test solely for the sake of this PR's checks.
* add myself to the contributors list 😄 