### PR TITLE
Allow User.cap_profile_id to be None

### DIFF
--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -102,7 +102,7 @@ class Author(Base):  # type: ignore
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     sunet = Column(String, unique=True)
-    cap_profile_id = Column(String, unique=True, nullable=False)
+    cap_profile_id = Column(String, unique=True)
     orcid = Column(String, unique=True)
     first_name = Column(String, nullable=False)
     last_name = Column(String, nullable=False)

--- a/rialto_airflow/harvest/authors.py
+++ b/rialto_airflow/harvest/authors.py
@@ -29,7 +29,7 @@ def load_authors_table(snapshot) -> None:
                 with Session.begin() as session:  # type: ignore
                     author = Author(
                         sunet=row["sunetid"],
-                        cap_profile_id=row["cap_profile_id"],
+                        cap_profile_id=row["cap_profile_id"] or None,
                         orcid=row["orcidid"] or None,
                         first_name=row["first_name"],
                         last_name=row["last_name"],


### PR DESCRIPTION
... and don't force it to be an empty string when reading from the CSV, which then causes a unique constraint violation.

Fixes #192
