### PR TITLE
Keep unapproved sul_pub pubs for the jsonl file

### DIFF
--- a/rialto_airflow/harvest/sul_pub.py
+++ b/rialto_airflow/harvest/sul_pub.py
@@ -25,38 +25,40 @@ def harvest(snapshot, host, key, per_page=1000, limit=None):
             with get_session(snapshot.database_name).begin() as session:
                 doi = extract_doi(sulpub_pub)
 
-                # if when inserting the row we get a constraint violation
-                # on the DOI then we have to do an update
-                pub_id = session.execute(
-                    insert(Publication)
-                    .values(doi=doi, sulpub_json=sulpub_pub)
-                    .on_conflict_do_update(
-                        constraint="publication_doi_key",
-                        set_=dict(sulpub_json=sulpub_pub),
-                    )
-                    .returning(Publication.id)
-                ).scalar_one()
+                # only write approved publications to the database
+                if approved(sulpub_pub):
+                    # if when inserting the row we get a constraint violation
+                    # on the DOI then we have to do an update
+                    pub_id = session.execute(
+                        insert(Publication)
+                        .values(doi=doi, sulpub_json=sulpub_pub)
+                        .on_conflict_do_update(
+                            constraint="publication_doi_key",
+                            set_=dict(sulpub_json=sulpub_pub),
+                        )
+                        .returning(Publication.id)
+                    ).scalar_one()
 
-                # get a list of approved cap_ids for the publication
-                # the cap_profile_id needs to be a string for the database
-                cap_ids = [
-                    str(a["cap_profile_id"])
-                    for a in sulpub_pub["authorship"]
-                    if a["status"] == "approved"
-                ]
+                    # get a list of approved cap_ids for the publication
+                    # the cap_profile_id needs to be a string for the database
+                    cap_ids = [
+                        str(a["cap_profile_id"])
+                        for a in sulpub_pub["authorship"]
+                        if a["status"] == "approved"
+                    ]
 
-                # if the row is already there we could get a constraint
-                # violation, but we can safely ignore that
-                session.execute(
-                    insert(pub_author_association)
-                    .from_select(
-                        ["publication_id", "author_id"],
-                        select(pub_id, Author.id).where(
-                            Author.cap_profile_id.in_(cap_ids)
-                        ),
+                    # if the row is already there we could get a constraint
+                    # violation, but we can safely ignore that
+                    session.execute(
+                        insert(pub_author_association)
+                        .from_select(
+                            ["publication_id", "author_id"],
+                            select(pub_id, Author.id).where(
+                                Author.cap_profile_id.in_(cap_ids)
+                            ),
+                        )
+                        .on_conflict_do_nothing()
                     )
-                    .on_conflict_do_nothing()
-                )
 
                 jsonl_output.write(json.dumps(sulpub_pub) + "\n")
 
@@ -93,9 +95,6 @@ def publications(host, key, per_page=1000, limit=None):
             more = False
 
         for record in records:
-            if not approved(record):
-                continue
-
             record_count += 1
             if limit is not None and record_count > limit:
                 logging.info(f"stopping with limit={limit}")


### PR DESCRIPTION
Resolves #195 to write all sul_pub publications to the jsonl files, even if not approved by any author. Only approved pubs are added to the database. 