### PR TITLE
remove README cruft

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ for i in `vault kv list -format yaml puppet/application/rialto-airflow/stage | s
 done
 ```
 
-Additionally, you may want a value for `AIRFLOW_VAR_MAIS_BASE_URL`. This is available from the rialto-orgs configuration (either in the [base config](https://github.com/sul-dlss/rialto-orgs/blob/main/config/settings.yml), or overridden via shared_configs).
-
 5. The harvest DAG requires a CSV file of authors from rialto-orgs to be available. This is not yet automatically available, so to set up locally, download the file at
 https://sul-rialto-stage.stanford.edu/authors?action=index&commit=Search&controller=authors&format=csv&orcid_filter=&q=. Put the `authors.csv` file in the `data/` directory.
 


### PR DESCRIPTION
info about setting AIRFLOW_VAR_MAIS_BASE_URL is no longer needed after https://github.com/sul-dlss/rialto-airflow/pull/209