### PR TITLE
Fill in OpenAlex pubs

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -84,6 +84,17 @@ def harvest():
         )
 
         return jsonl_file
+    
+
+    @task()
+    def fill_in_openalex(snapshot, openalex_jsonl):
+        """
+        Fill in OpenAlex data for DOIs from other publication sources.
+        """
+        openalex.fill_in(snapshot, openalex_jsonl)
+
+        return snapshot
+
 
     @task()
     def create_doi_sunet(dimensions, openalex, sul_pub, snapshot):
@@ -149,6 +160,9 @@ def harvest():
     dimensions_dois = dimensions_harvest_dois(snapshot)
 
     openalex_jsonl = openalex_harvest(snapshot)
+
+    # TODO: add dimensions_jsonl as a dependency when task is added to DAG
+    openalex_additions = fill_in_openalex(snapshot, openalex_jsonl)
 
     doi_sunet = create_doi_sunet(
         dimensions_dois,

--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -84,7 +84,6 @@ def harvest():
         )
 
         return jsonl_file
-    
 
     @task()
     def fill_in_openalex(snapshot, openalex_jsonl):
@@ -94,7 +93,6 @@ def harvest():
         openalex.fill_in(snapshot, openalex_jsonl)
 
         return snapshot
-
 
     @task()
     def create_doi_sunet(dimensions, openalex, sul_pub, snapshot):

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -117,6 +117,7 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
                 .where(Publication.openalex_json.is_(None))
                 .execution_options(yield_per=100)
             )
+            # TODO: consider getting data for more than one DOI at a time
             for row in select_session.execute(stmt):
                 logging.info(f"filling in data for {row.doi}")
                 try:

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -112,8 +112,8 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
     with jsonl_file.open("a") as jsonl_output:
         with get_session(snapshot.database_name).begin() as select_session:
             stmt = (
-                select(Publication.doi)
-                .where(Publication.doi.is_not(None))
+                select(Publication.doi)  # type: ignore
+                .where(Publication.doi.is_not(None))  # type: ignore
                 .where(Publication.openalex_json.is_(None))
                 .execution_options(yield_per=100)
             )
@@ -129,7 +129,7 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
 
                 with get_session(snapshot.database_name).begin() as update_session:
                     update_stmt = (
-                        update(Publication)
+                        update(Publication)  # type: ignore
                         .where(Publication.doi == row.doi)
                         .values(openalex_json=openalex_pub)
                     )

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -4,8 +4,10 @@ import os
 import time
 from pathlib import Path
 
+import requests
 from pyalex import Authors, Works, config
 from typing import Generator
+from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert
 
 from rialto_airflow.database import (
@@ -93,7 +95,7 @@ def orcid_publications(orcid: str) -> Generator[dict, None, None]:
     if len(authors) == 0:
         return
     elif len(authors) > 1:
-        logging.warn(f"found more than one openalex author id for {orcid}")
+        logging.warning(f"found more than one openalex author id for {orcid}")
     author_id = authors[0]["id"]
 
     # get all the works for the openalex author id
@@ -102,3 +104,33 @@ def orcid_publications(orcid: str) -> Generator[dict, None, None]:
         time.sleep(1)
 
         yield from page
+
+
+def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
+    """Harvest OpenAlex data for DOIs from other publication sources."""
+    count = 0
+    with jsonl_file.open("a") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            stmt = select(Publication.doi).where(Publication.doi.is_not(None)).where(Publication.openalex_json.is_(None)).execution_options(yield_per=100)
+            for row in select_session.execute(stmt):
+                logging.info(f"filling in data for {row.doi}")
+                # look up in openalex
+                try:
+                    openalex_pub = Works()[f"https://doi.org/{row.doi}"]
+                    # TODO: get a key so we don't have to sleep!
+                    time.sleep(1)
+                except requests.exceptions.HTTPError as e:
+                    logging.error(f"error looking up {row.doi}: {e}")
+                    continue
+
+                with get_session(snapshot.database_name).begin() as update_session:
+                    update_stmt = update(Publication).where(Publication.doi == row.doi).values(openalex_json=openalex_pub).returning(Publication.id)
+                    update_session.execute(update_stmt)
+
+                count += 1
+                jsonl_output.write(json.dumps(openalex_pub) + "\n")
+                
+    logging.info(f"filled in {count} publications")
+
+    return snapshot
+

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -140,4 +140,4 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
 
     logging.info(f"filled in {count} publications")
 
-    return snapshot
+    return snapshot.path


### PR DESCRIPTION
Resolves #194 to fill in OpenAlex json for DOIs that lack it after the by-ORCID harvest. 

A run with a dev limit of 10000 showed that publications from openalex were filled in. 