### PR TITLE
Dimensions fill in task

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -109,6 +109,15 @@ def harvest():
 
         return snapshot
 
+    @task()
+    def fill_in_dimensions(snapshot, openalex_jsonl, dimensions_jsonl, wos_jsonl):
+        """
+        Fill in Dimensions data for DOIs from other publication sources.
+        """
+        dimensions.fill_in(snapshot, dimensions_jsonl)
+
+        return snapshot
+
     snapshot = setup()
 
     snapshot = load_authors(snapshot)
@@ -121,9 +130,11 @@ def harvest():
 
     wos_jsonl = wos_harvest(snapshot)
 
-    openalex_additions = fill_in_openalex(
+    fill_in_openalex(
         snapshot, sul_pub_jsonl, openalex_jsonl, dimensions_jsonl, wos_jsonl
-    )  # noqa: F841
+    )
+
+    fill_in_dimensions(snapshot, openalex_jsonl, dimensions_jsonl, wos_jsonl)
 
 
 harvest()

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -119,13 +119,12 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
             )
             # TODO: consider getting data for more than one DOI at a time
             for row in select_session.execute(stmt):
-                logging.info(f"filling in data for {row.doi}")
                 try:
                     openalex_pub = Works()[f"https://doi.org/{row.doi}"]
                     # TODO: get a key so we don't have to sleep!
                     time.sleep(1)
                 except requests.exceptions.HTTPError as e:
-                    logging.error(f"error looking up {row.doi}: {e}")
+                    logging.info(f"No data found for {row.doi}: {e}")
                     continue
 
                 with get_session(snapshot.database_name).begin() as update_session:

--- a/test/harvest/test_dimensions.py
+++ b/test/harvest/test_dimensions.py
@@ -250,7 +250,15 @@ def mock_dimensions_not_found(monkeypatch):
     monkeypatch.setattr(dimensions, "publications_from_dois", f)
 
 
-def test_fill_in_no_doi(tmp_path, test_session, mock_publication, mock_no_dim_publication, mock_dimensions_not_found, caplog, monkeypatch):
+def test_fill_in_no_doi(
+    tmp_path,
+    test_session,
+    mock_publication,
+    mock_no_dim_publication,
+    mock_dimensions_not_found,
+    caplog,
+    monkeypatch,
+):
     caplog.set_level(logging.INFO)
     snapshot = Snapshot(path=tmp_path, database_name="rialto_test")
     # set up a pre-existing jsonl file

--- a/test/harvest/test_dimensions.py
+++ b/test/harvest/test_dimensions.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import pytest
@@ -45,7 +46,7 @@ def test_orcid_publications():
 @pytest.fixture
 def mock_dimensions(monkeypatch):
     """
-    Mock our function for fetching publications by orcid from OpenAlex.
+    Mock our function for fetching publications by orcid from Dimensions.
     """
 
     def f(*args, **kwargs):
@@ -156,3 +157,106 @@ def test_log_message(tmp_path, mock_authors, mock_many_dimensions, caplog):
     snapshot = Snapshot(tmp_path, "rialto_test")
     dimensions.harvest(snapshot, limit=50)
     assert "Reached limit of 50 publications stopping" in caplog.text
+
+
+def mock_jsonl(path):
+    """
+    Mock the existing jsonl file for Dimensions
+    """
+    records = [
+        {
+            "doi": "10.1515/9781503624150",
+            "title": "An example title",
+            "publication_year": 1891,
+        },
+        {
+            "doi": "10.1515/9781503624151",
+            "title": "Another example title",
+            "publication_year": 1892,
+        },
+    ]
+    with open(path, "w") as f:
+        for record in records:
+            f.write(f"{json.dumps(record)}\n")
+
+
+@pytest.fixture
+def mock_no_dim_publication(test_session):
+    with test_session.begin() as session:
+        pub = Publication(
+            doi="10.1515/9781503624153",
+            sulpub_json={"sulpub": "data"},
+            wos_json={"wos": "data"},
+        )
+        session.add(pub)
+        return pub
+
+
+@pytest.fixture
+def mock_dimensions_doi(monkeypatch):
+    """
+    Mock our function for fetching publications by DOI from Dimensions.
+    """
+
+    def f(*args, **kwargs):
+        yield {
+            "doi": "10.1515/9781503624153",
+            "title": "An example title",
+            "type": "article",
+            "publication_year": 1891,
+        }
+
+    monkeypatch.setattr(dimensions, "publications_from_dois", f)
+
+
+def test_fill_in(
+    tmp_path, test_session, mock_no_dim_publication, mock_dimensions_doi, caplog
+):
+    caplog.set_level(logging.INFO)
+    snapshot = Snapshot(path=tmp_path, database_name="rialto_test")
+    # set up a pre-existing jsonl file
+    jsonl_file = snapshot.path / "dimensions.jsonl"
+    mock_jsonl(jsonl_file)
+
+    dimensions.fill_in(snapshot, jsonl_file)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.dim_json == {
+            "doi": "10.1515/9781503624153",
+            "title": "An example title",
+            "type": "article",
+            "publication_year": 1891,
+        }
+
+    # adds 1 publication to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "dimensions.jsonl") == 3
+    assert "filled in 1 publications" in caplog.text
+
+
+def test_fill_in_no_doi(tmp_path, test_session, mock_publication, caplog, monkeypatch):
+    monkeypatch.setattr(dimensions, "publications_from_dois", [])
+    caplog.set_level(logging.INFO)
+    snapshot = Snapshot(path=tmp_path, database_name="rialto_test")
+    # set up a pre-existing jsonl file
+    jsonl_file = snapshot.path / "dimensions.jsonl"
+    mock_jsonl(jsonl_file)
+
+    dimensions.fill_in(snapshot, jsonl_file)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.dimensions_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "dimensions.jsonl") == 2
+    assert "filled in 0 publications" in caplog.text
+    assert "No data found for 10.1515/9781503624153" in caplog.text

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -245,6 +245,6 @@ def test_fill_in_no_doi(
     assert num_jsonl_objects(snapshot.path / "openalex.jsonl") == 2
     assert "filled in 0 publications" in caplog.text
     assert (
-        "error looking up 10.1515/9781503624153: 404 Client Error: NOT FOUND for url: https://api.openalex.org/works/https%3A%2F%2Fdoi.org%2F10.1515%2F9781503624153"
+        "No data found for 10.1515/9781503624153: 404 Client Error: NOT FOUND for url: https://api.openalex.org/works/https%3A%2F%2Fdoi.org%2F10.1515%2F9781503624153"
         in caplog.text
     )


### PR DESCRIPTION
Resolves #200 to fill in Dimensions json where available by DOI. 

This is currently looking up DOIs one by one. With some work it could be adjusted to work with batches of DOIs (and then updating batches of records in the database). 