### PR TITLE
Add distill DAG task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ package-mode = false
 
 dependencies = [
     "dimcli",
+    "jsonpath-ng>=1.7.0",
     "more-itertools",
     "psycopg2-binary>=2.9.10",
     "pyalex",
@@ -36,7 +37,7 @@ omit = ["test/*"]
 check_untyped_defs = true # Type-checks the interior of functions without type annotations.
 
 [[tool.mypy.overrides]]
-module = ["dimcli", "pyalex", "requests_oauthlib", "sqlalchemy_utils"]
+module = ["dimcli", "pyalex", "requests_oauthlib", "sqlalchemy_utils", "jsonpath_ng"]
 ignore_missing_imports = true
 
 [dependency-groups]

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -85,6 +85,7 @@ class Publication(Base):  # type: ignore
     doi = Column(String, unique=True)
     title = Column(String)
     pub_year = Column(Integer)
+    open_access = Column(String)
     dim_json = Column(JSONB)
     openalex_json = Column(JSONB)
     sulpub_json = Column(JSONB)

--- a/rialto_airflow/harvest/distill.py
+++ b/rialto_airflow/harvest/distill.py
@@ -1,0 +1,173 @@
+import logging
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import jsonpath_ng
+from sqlalchemy import select, update
+
+from rialto_airflow.database import Publication, get_session
+from rialto_airflow.snapshot import Snapshot
+
+
+@dataclass
+class JsonPathRule:
+    col: str  # the JSONB column name to apply the rule to
+    matcher: str  # a JSON Path to evaluate against the JSON
+
+
+@dataclass
+class FuncRule:
+    col: str  # the JSONB column name to pass to a function
+    matcher: Callable  # a function to pass the JSON to
+
+
+Rules = list[JsonPathRule | FuncRule]
+
+
+def distill(snapshot: Snapshot) -> None:
+    """
+    Walk through all publications in the database and set the title, pub_year,
+    open_access columns using the harvested metadata.
+    """
+    with get_session(snapshot.database_name).begin() as select_session:
+        # iterate through publictions 100 at a time
+        stmt = select(Publication).execution_options(yield_per=100)  # type: ignore
+
+        for pos, row in enumerate(select_session.execute(stmt)):
+            if pos % 100 == 0:
+                logging.info(f"processed {pos} publications")
+
+            pub = row[0]
+
+            # populate new publication columns
+            cols = {
+                "title": _title(pub),
+                "pub_year": _pub_year(pub),
+                "open_access": _open_access(pub),
+                # These are TBD:
+                # "apc":                _apc(pub),
+                # "funders":            _funders(pub),
+                # "federally_funded":   _federally_funded(pub)
+            }
+
+            # persist the new columns to the database
+            with get_session(snapshot.database_name).begin() as update_session:
+                update_stmt = (
+                    update(Publication)  # type: ignore
+                    .where(Publication.id == pub.id)
+                    .values(cols)
+                )
+                update_session.execute(update_stmt)
+
+
+def _title(pub):
+    """
+    Get the title from sulpub, dimensions, openalex, then wos.
+    """
+    return _first(
+        pub,
+        rules=[
+            JsonPathRule("sulpub_json", "title"),
+            JsonPathRule("dim_json", "title"),
+            JsonPathRule("openalex_json", "title"),
+            FuncRule("wos_json", _wos_title),
+        ],
+    )
+
+
+def _pub_year(pub):
+    """
+    Get the pub_year from sulpub, dimensions, openalex and then wos.
+    """
+    return _first_int(
+        pub,
+        rules=[
+            JsonPathRule("sulpub_json", "year"),
+            JsonPathRule("dim_json", "year"),
+            JsonPathRule("openalex_json", "publication_year"),
+            JsonPathRule("wos_json", "static_data.summary.pub_info.pubyear"),
+        ],
+    )
+
+
+def _open_access(pub):
+    """
+    Get the _open_access value from openalex and then dimensions.
+    """
+    return _first(
+        pub,
+        rules=[
+            JsonPathRule("openalex_json", "open_access.oa_status"),
+            FuncRule("dim_json", _open_access_dim),
+        ],
+    )
+
+
+def _first(pub, rules: Rules) -> Optional[str]:
+    """
+    Return the first rule match for the publication as a str.
+    """
+    for rule in rules:
+        # get the appropriate bit of json to analyze
+        data = getattr(pub, rule.col)
+
+        # if the rule is a string it's a jsonpath
+        if isinstance(rule.matcher, str):
+            jpath = jsonpath_ng.parse(rule.matcher)
+            results = jpath.find(data)
+            if len(results) > 0:
+                return results[0].value
+
+        # if the rule is a function pass it the json
+        elif callable(rule.matcher):
+            result = rule.matcher(data)
+            if result is not None:
+                return result
+
+    return None
+
+
+def _first_int(pub, rules: Rules) -> Optional[int]:
+    """
+    Return the first rule match for the publication as an int.
+    """
+    result = _first(pub, rules)
+    if result:
+        return int(result)
+    else:
+        return None
+
+
+# These are custom functions to work with specific JSON data structures that
+# aren't workable using JSON Path alone.
+
+
+def _wos_title(wos_json):
+    jsonp = jsonpath_ng.parse("static_data.summary.titles[*].title[*]")
+    for title in jsonp.find(wos_json):
+        if isinstance(title.value, dict) and title.value.get("type") == "item":
+            return title.value.get("content")
+
+    return None
+
+
+def _open_access_dim(dim_json):
+    """
+    Get the open access value, but ignore "oa_all"
+    """
+    jsonp = jsonpath_ng.parse("open_access[*]")
+    for oa in jsonp.find(dim_json):
+        if oa.value and oa.value != "oa_all":
+            return oa.value
+
+    return None
+
+
+# TODO: We need to distill other values but this will involve additional work to
+# get appropriate data:
+#
+# - apc
+# - funders
+# - federally funded
+#
+# See: https://docs.google.com/document/d/1WojtunkzNtidF2JW4ZLcSClbxajMkH36eUdRIl9tk0E/edit?tab=t.0#heading=h.8lc1fr3onylw

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,12 +5,13 @@ from sqlalchemy.orm.session import close_all_sessions
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from rialto_airflow.database import (
+    Author,
+    Publication,
     create_schema,
     engine_setup,
-    Publication,
-    Author,
     pub_author_association,
 )
+from rialto_airflow.snapshot import Snapshot
 
 
 @pytest.fixture
@@ -115,3 +116,8 @@ def mock_association(test_session, mock_publication, mock_authors):
                 author_id=1,
             )
         )
+
+
+@pytest.fixture
+def snapshot(tmp_path):
+    return Snapshot(path=tmp_path, database_name="rialto_test")

--- a/test/harvest/test_distill.py
+++ b/test/harvest/test_distill.py
@@ -1,0 +1,311 @@
+from rialto_airflow.database import Publication
+from rialto_airflow.harvest.distill import distill
+
+# Set up JSON data that mirrors (in part) what we get from the respective APIs
+
+sulpub_json = {"title": "On the dangers of stochastic parrots (sulpub)", "year": "2020"}
+
+dim_json = {
+    "title": "On the dangers of stochastic parrots (dim)",
+    "year": 2021,
+    "open_access": ["oa_all", "green"],
+}
+
+openalex_json = {
+    "title": "On the dangers of stochastic parrots (openalex)",
+    "publication_year": 2022,
+    "open_access": {"oa_status": "gold"},
+}
+
+wos_json = {
+    "static_data": {
+        "summary": {
+            "pub_info": {"pubyear": 2023},
+            "titles": {
+                "count": 6,
+                "title": [
+                    {
+                        "type": "source",
+                        "content": "FAccT '21: Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency",
+                    },
+                    {"type": "source_abbrev", "content": "FAACT"},
+                    {"type": "abbrev_iso", "content": "FAccT J."},
+                    {
+                        "type": "item",
+                        "content": "On the dangers of stochastic parrots (wos)",
+                    },
+                ],
+            },
+        }
+    }
+}
+
+
+# test the title preferences
+
+
+def test_title_sulpub(test_session, snapshot):
+    """
+    title should come from sulpub before dimensions, openalex and wos_json
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                sulpub_json=sulpub_json,
+                dim_json=dim_json,
+                openalex_json=openalex_json,
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).title == "On the dangers of stochastic parrots (sulpub)"
+
+
+def test_title_dim(test_session, snapshot):
+    """
+    title should come from dimensions before openalex and wos
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                dim_json=dim_json,
+                openalex_json=openalex_json,
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).title == "On the dangers of stochastic parrots (dim)"
+
+
+def test_title_openalex(test_session, snapshot):
+    """
+    title should come from openalex before wos
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                openalex_json=openalex_json,
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).title == "On the dangers of stochastic parrots (openalex)"
+
+
+def test_title_wos(test_session, snapshot):
+    """
+    title should come from wos if all the others are unavaialable
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).title == "On the dangers of stochastic parrots (wos)"
+
+
+def test_title_none(test_session, snapshot):
+    """
+    Ensure that no title doesn't cause a problem.
+    """
+    with test_session.begin() as session:
+        session.add(Publication(doi="10.1515/9781503624153"))
+
+    distill(snapshot)
+
+    assert _pub(session).title is None
+
+
+# test the pub_year preferences
+
+
+def test_pub_year_sulpub(test_session, snapshot):
+    """
+    pub_year should come from sulpub before dimensions, openalex and wos
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                sulpub_json=sulpub_json,
+                dim_json=dim_json,
+                openalex_json=openalex_json,
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).pub_year == 2020
+
+
+def test_pub_year_dim(test_session, snapshot):
+    """
+    pub_year should come from dimensions before openalex and wos
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                dim_json=dim_json,
+                openalex_json=openalex_json,
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).pub_year == 2021
+
+
+def test_pub_year_openalex(test_session, snapshot):
+    """
+    pub_year should come from openalex before wos
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                openalex_json=openalex_json,
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).pub_year == 2022
+
+
+def test_pub_year_wos(test_session, snapshot):
+    """
+    pub_year should come from wos if all others are unavailable
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).pub_year == 2023
+
+
+def test_pub_year_none(test_session, snapshot):
+    """
+    no pub_year shouldn't be a problem
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).pub_year is None
+
+
+# test open-access
+
+
+def test_open_access_openalex(test_session, snapshot):
+    """
+    open_access should come from openalex first
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                openalex_json=openalex_json,
+                dim_json=dim_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).open_access == "gold"
+
+
+def test_open_access_dim(test_session, snapshot):
+    """
+    open_access should come from dimensions if it is unavailable in openalex
+    """
+    with test_session.begin() as session:
+        session.add(Publication(doi="10.1515/9781503624153", dim_json=dim_json))
+
+    distill(snapshot)
+
+    assert _pub(session).open_access == "green"
+
+
+def test_open_access_null(test_session, snapshot):
+    """
+    dimensions is still used when there is an empty in openalex open_access
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                openalex_json={"open_access": []},
+                dim_json=dim_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).open_access == "green"
+
+
+def test_multiple(test_session, snapshot):
+    """
+    dimensions is still used when there is an empty in openalex open_access
+    """
+    with test_session.begin() as session:
+        session.bulk_save_objects(
+            [
+                Publication(
+                    doi="10.1515/9781503624153",
+                    sulpub_json=sulpub_json,
+                    dim_json=dim_json,
+                    openalex_json=openalex_json,
+                    wos_json=wos_json,
+                ),
+                Publication(
+                    doi="10.1515/9781503624153-2",
+                    sulpub_json=sulpub_json,
+                    dim_json=dim_json,
+                    wos_json=wos_json,
+                ),
+            ]
+        )
+
+    distill(snapshot)
+
+    assert _pub(session, "10.1515/9781503624153").open_access == "gold", (
+        "prefer open alex"
+    )
+    assert _pub(session, "10.1515/9781503624153-2").open_access == "green", (
+        "fell back to dimensions"
+    )
+
+
+def _pub(session, doi="10.1515/9781503624153"):
+    return session.query(Publication).where(Publication.doi == doi).first()

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -91,6 +91,7 @@ def test_create_schema(
                 "doi",
                 "title",
                 "pub_year",
+                "open_access",
                 "dim_json",
                 "openalex_json",
                 "sulpub_json",

--- a/uv.lock
+++ b/uv.lock
@@ -1110,6 +1110,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpath-ng"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ply" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105 },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1628,6 +1640,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567 },
+]
+
+[[package]]
 name = "prison"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1990,6 +2011,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "dimcli" },
+    { name = "jsonpath-ng" },
     { name = "more-itertools" },
     { name = "psycopg2-binary" },
     { name = "pyalex" },
@@ -2016,6 +2038,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dimcli" },
+    { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "more-itertools" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pyalex" },


### PR DESCRIPTION
This PR adds a distill step to the DAG which will update the publication table for the title, pub_year and open_access.

We need to distill more metadata including:

- apc
- funders
- federally_funded

Since the `type` value is going to simply mix together the Dimensions and OpenAlex types into a list I propose we collect those as part of the publishing process since they should be easy to query out of the JSONB.

Closes #216
