### PR TITLE
Fix WoS DOI extraction

### DIFF
--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -183,7 +183,12 @@ def check_status(resp):
 
 
 def get_doi(pub) -> Optional[str]:
-    ids = pub.get("cluster_related", {}).get("identifiers", {}).get("identifier", [])
+    ids = (
+        pub.get("dynamic_data", {})
+        .get("cluster_related", {})
+        .get("identifiers", {})
+        .get("identifier", [])
+    )
     for id in ids:
         if id["type"] == "doi":
             return normalize_doi(id["value"])

--- a/test/harvest/test_wos.py
+++ b/test/harvest/test_wos.py
@@ -33,15 +33,17 @@ def mock_wos(monkeypatch):
                     }
                 }
             },
-            "cluster_related": {
-                "identifiers": {
-                    "identifier": [
-                        {"type": "issn", "value": "2211-9124"},
-                        {
-                            "type": "doi",
-                            "value": "https://doi.org/10.1515/9781503624153",
-                        },
-                    ]
+            "dynamic_data": {
+                "cluster_related": {
+                    "identifiers": {
+                        "identifier": [
+                            {"type": "issn", "value": "2211-9124"},
+                            {
+                                "type": "doi",
+                                "value": "https://doi.org/10.1515/9781503624153",
+                            },
+                        ]
+                    }
                 }
             },
         }


### PR DESCRIPTION
(apologies for the after hours PR, I just wanted to get to this before being out of the office next week)

After doing a 100k harvest I noticed there were no WoS DOIs for publications that had WoS metadata:

```sql
select doi, wos_json -> 'dynamic_data' -> 'cluster_related' -> 'identifiers'
from publication
where wos_json is not null;
```

This commit adjusts where the DOI is getting pulled from so we get it from the `dynamic_data` portion of the metadata.
