### PR TITLE
WOS.get_doi: handle unexpected id structure

### DIFF
--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -184,23 +184,27 @@ def check_status(resp):
 
 def get_doi(pub) -> Optional[str]:
     try:
-        ids = (
+        identifiers_field = (
             pub.get("dynamic_data", {})
             .get("cluster_related", {})
             .get("identifiers", {})
-            .get("identifier", [])
         )
+
+        if isinstance(identifiers_field, dict):
+            # The "identifier" field (from "identifiers" above) is usually a list. But sometimes
+            # there is just one string value instead. (as an examle, see record for WOS:000299597104419)
+            ids = identifiers_field.get("identifier", [])
+            ids = [ids] if isinstance(ids, dict) else ids
+
+            for id in ids:
+                if id["type"] == "doi":
+                    return normalize_doi(id["value"])
+        elif isinstance(identifiers_field, str):
+            # We have seen at least one publication, WOS:000089165000013, where the "identifiers" field is
+            # a str instead of a dict, albeit an empty string in that case. Normalize empty string to None.
+            return identifiers_field or None
     except AttributeError as e:
         logging.warn(f"error {e} trying to parse identifiers from {pub}")
         return None
-
-    # sometimes there is just one id instead of a list of ids
-    # as an examle see record for WOS:000299597104419
-    if isinstance(ids, dict):
-        ids = [ids]
-
-    for id in ids:
-        if id["type"] == "doi":
-            return normalize_doi(id["value"])
 
     return None

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -183,12 +183,16 @@ def check_status(resp):
 
 
 def get_doi(pub) -> Optional[str]:
-    ids = (
-        pub.get("dynamic_data", {})
-        .get("cluster_related", {})
-        .get("identifiers", {})
-        .get("identifier", [])
-    )
+    try:
+        ids = (
+            pub.get("dynamic_data", {})
+            .get("cluster_related", {})
+            .get("identifiers", {})
+            .get("identifier", [])
+        )
+    except AttributeError as e:
+        logging.warn(f"error {e} trying to parse identifiers from {pub}")
+        return None
 
     # sometimes there is just one id instead of a list of ids
     # as an examle see record for WOS:000299597104419

--- a/test/harvest/test_wos.py
+++ b/test/harvest/test_wos.py
@@ -215,7 +215,7 @@ def test_bad_wos_json(test_session, tmp_path, caplog, mock_authors, requests_moc
     assert "uhoh, instead of JSON we got: ffff" in caplog.text
 
 
-def test_get_doi():
+def test_get_doi(caplog):
     wos_json_id_list = {
         "dynamic_data": {
             "cluster_related": {
@@ -250,3 +250,13 @@ def test_get_doi():
 
     wos_json_no_id: dict = {"dynamic_data": {"cluster_related": {"identifiers": {}}}}
     assert wos.get_doi(wos_json_no_id) is None
+
+    wos_json_identifiers_empty_string: dict = {
+        "UID": "WOS:000089165000013",
+        "dynamic_data": {"cluster_related": {"identifiers": ""}},
+    }
+    assert wos.get_doi(wos_json_identifiers_empty_string) is None
+    assert (
+        "error 'str' object has no attribute 'get' trying to parse identifiers from {'UID': 'WOS:000089165000013'"
+        in caplog.text
+    )

--- a/test/harvest/test_wos.py
+++ b/test/harvest/test_wos.py
@@ -256,7 +256,21 @@ def test_get_doi(caplog):
         "dynamic_data": {"cluster_related": {"identifiers": ""}},
     }
     assert wos.get_doi(wos_json_identifiers_empty_string) is None
+    assert "WOS:000089165000013" not in caplog.text
+
+    wos_json_identifiers_nonempty_string: dict = {
+        "UID": "WOS:000089165000014",
+        "dynamic_data": {"cluster_related": {"identifiers": "abc123"}},
+    }
+    assert wos.get_doi(wos_json_identifiers_nonempty_string) == "abc123"
+    assert "WOS:000089165000014" not in caplog.text
+
+    wos_json_no_cluster_related_empty_string: dict = {
+        "UID": "WOS:000012345000067",
+        "dynamic_data": {"cluster_related": ""},
+    }
+    assert wos.get_doi(wos_json_no_cluster_related_empty_string) is None
     assert (
-        "error 'str' object has no attribute 'get' trying to parse identifiers from {'UID': 'WOS:000089165000013'"
+        "error 'str' object has no attribute 'get' trying to parse identifiers from {'UID': 'WOS:000012345000067'"
         in caplog.text
     )


### PR DESCRIPTION
`rialto_airflow.harvest.wos.get_doi`

* handle situation where `pub["dynamic_data"]["cluster_related"]["identifiers"]` is present and a string
e.g.
```
  "dynamic_data": {
    "cluster_related": {
      "identifiers": "abc123"
    }
  }
```
* gracefully handle totally unexpected structures when digging into the JSON we got back to get the DOI

closes #240