### PR TITLE
Publish Open Access CSV

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -9,6 +9,7 @@ from honeybadger import honeybadger  # type: ignore
 
 from rialto_airflow import funders
 from rialto_airflow.harvest import authors, dimensions, openalex, sul_pub, wos, distill
+from rialto_airflow.publish import openaccess
 from rialto_airflow.database import create_database, create_schema
 from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.utils import rialto_authors_file
@@ -156,6 +157,11 @@ def harvest():
 
         return count
 
+    @task()
+    def publish_openaccess(snapshot):
+        openaccess.write_publications(snapshot)
+        openaccess.write_contributions(snapshot)
+
     snapshot = setup()
 
     snapshot = load_authors(snapshot)
@@ -176,9 +182,13 @@ def harvest():
         snapshot, openalex_jsonl, dimensions_jsonl, wos_jsonl
     )
 
-    distill_publications(snapshot, openalex_fill_in, dimensions_fill_in)
+    distilled_pubs = distill_publications(
+        snapshot, openalex_fill_in, dimensions_fill_in
+    )
 
-    link_funders(snapshot, openalex_fill_in, dimensions_fill_in)
+    linked_pubs = link_funders(snapshot, openalex_fill_in, dimensions_fill_in)
+
+    (distilled_pubs, linked_pubs) >> publish_openaccess(snapshot)
 
 
 harvest()

--- a/rialto_airflow/publish/openaccess.py
+++ b/rialto_airflow/publish/openaccess.py
@@ -1,0 +1,173 @@
+import logging
+from csv import DictWriter
+from pathlib import Path
+
+from sqlalchemy import select, func
+
+from rialto_airflow.database import get_session, Publication, Author, Funder
+
+
+def write_publications(snapshot) -> Path:
+    """
+    Write a CSV of publications including their funding information.
+    """
+    col_names = [
+        "doi",
+        "pub_year",
+        "apc",
+        "open_access",
+        "types",
+        "funders",
+        "federally_funded",
+    ]
+
+    csv_path = snapshot.path / "publications.csv"
+    logging.info(f"started writing publications {csv_path}")
+
+    with csv_path.open("w") as output:
+        csv_output = DictWriter(output, fieldnames=col_names)
+        csv_output.writeheader()
+
+        with get_session(snapshot.database_name).begin() as session:
+            # This query joins the publication and funder tables
+            # Since we want one row per publication, and a publication can
+            # have multiple funders, the funder names, and the booleans
+            # associated with whether they are federal, are grouped together in
+            # a list using the jsonb_agg_strict function (the strict version
+            # drops null values). In order to use these aggregate functions we
+            # need to group by the Publication.id.
+
+            stmt = (
+                select(  # type: ignore
+                    Publication.doi,  # type: ignore
+                    Publication.pub_year,  # type: ignore
+                    Publication.apc,  # type: ignore
+                    Publication.open_access,
+                    Publication.dim_json["type"].label("dim_type"),
+                    Publication.openalex_json["type"].label("openalex_type"),
+                    func.jsonb_agg_strict(Funder.name).label("funders"),
+                    func.jsonb_agg_strict(Funder.federal).label("federal"),
+                )
+                .join(Funder, Publication.funders, isouter=True)  # type: ignore
+                .where(Publication.pub_year >= 2018)
+                .group_by(Publication.id)
+                .execution_options(yield_per=100)
+            )
+
+            for row in session.execute(stmt):
+                csv_output.writerow(
+                    {
+                        "doi": row.doi,
+                        "pub_year": row.pub_year,
+                        "apc": row.apc,
+                        "open_access": row.open_access,
+                        "types": "|".join(_get_types(row)) or None,
+                        "funders": "|".join(row.funders) or None,
+                        "federally_funded": any(row.federal),
+                    }
+                )
+
+        logging.info(f"finished writing publications {csv_path}")
+
+    return csv_path
+
+
+def write_contributions(snapshot) -> Path:
+    """
+    Write a CSV of contributions where each row represents a publication from a particular Author.
+    """
+
+    col_names = [
+        "sunet",
+        "role",
+        "academic_council",
+        "primary_school",
+        "primary_department",
+        "all_schools",
+        "all_departments",
+        "doi",
+        "pub_year",
+        "apc",
+        "open_access",
+        "types",
+        "funders",
+        "federally_funded",
+    ]
+
+    csv_path = snapshot.path / "contributions.csv"
+
+    logging.info(f"starting to write contributions {csv_path}")
+
+    with csv_path.open("w") as output:
+        csv_output = DictWriter(output, fieldnames=col_names)
+        csv_output.writeheader()
+
+        with get_session(snapshot.database_name).begin() as session:
+            # This query joins the publication, contribution and funder tables.
+            # We want one row per "contribution" or unique Stanford author
+            # per-publication, however a publication can
+            # have multiple funders. In order to prevent there being one row per
+            # funder-publication-author combinateion, the funder names, and the booleans
+            # associated with whether they are federal, are grouped together in
+            # a list using the jsonb_agg_strict function (the strict version
+            # drops null values). Using this aggregate function then requires
+            # that we group by the publication.id and author.id.
+
+            stmt = (
+                select(  # type: ignore
+                    Author.sunet,  # type: ignore
+                    Author.primary_role,
+                    Author.academic_council,  # type: ignore
+                    Author.primary_school,
+                    Author.primary_dept,
+                    Author.schools,
+                    Author.departments,  # type: ignore
+                    Publication.doi,  # type: ignore
+                    Publication.pub_year,  # type: ignore
+                    Publication.apc,  # type: ignore
+                    Publication.open_access,  # type: ignore
+                    Publication.dim_json["type"].label("dim_type"),
+                    Publication.openalex_json["type"].label("openalex_type"),
+                    func.jsonb_agg_strict(Funder.name).label("funders"),
+                    func.jsonb_agg_strict(Funder.federal).label("federal"),
+                )
+                .join(Author, Publication.authors)  # type: ignore
+                .join(Funder, Publication.funders, isouter=True)  # type: ignore
+                .where(Publication.pub_year >= 2018)
+                .group_by(Author.id, Publication.id)
+                .execution_options(yield_per=100)
+            )
+
+            for row in session.execute(stmt):
+                csv_output.writerow(
+                    {
+                        "sunet": row.sunet,
+                        "role": row.primary_role,
+                        "academic_council": row.academic_council,
+                        "primary_school": row.primary_school,
+                        "primary_department": row.primary_dept,
+                        "all_schools": "|".join(row.schools),
+                        "all_departments": "|".join(row.departments),
+                        "doi": row.doi,
+                        "pub_year": row.pub_year,
+                        "apc": row.apc,
+                        "open_access": row.open_access,
+                        "types": "|".join(_get_types(row)),
+                        "funders": "|".join(row.funders),
+                        "federally_funded": any(row.federal),
+                    }
+                )
+
+        logging.info(f"finished writing contributions {csv_path}")
+
+    return csv_path
+
+
+def _get_types(row):
+    types = []
+    if row.dim_type:
+        types.append(row.dim_type)
+    if row.openalex_type:
+        types.append(row.openalex_type)
+
+    return types

--- a/test/publish/test_openaccess.py
+++ b/test/publish/test_openaccess.py
@@ -1,0 +1,146 @@
+import pandas
+import pytest
+
+from rialto_airflow.publish import openaccess
+from rialto_airflow.database import Publication, Author, Funder
+
+
+@pytest.fixture
+def dataset(test_session):
+    with test_session.begin() as session:
+        pub = Publication(
+            doi="10.000/000001",
+            title="My Life",
+            apc=123,
+            open_access="gold",
+            pub_year=2023,
+            dim_json={"type": "article"},
+            openalex_json={"type": "preprint"},
+        )
+
+        pub.authors.append(
+            Author(
+                first_name="Jane",
+                last_name="Stanford",
+                sunet="janes",
+                cap_profile_id="1234",
+                orcid="0298098343",
+                primary_school="School of Humanities and Sciences",
+                primary_dept="Social Sciences",
+                primary_role="faculty",
+                schools=[
+                    "Vice Provost for Undergraduate Education",
+                    "School of Humanities and Sciences",
+                ],
+                departments=["Inter-Departmental Programs", "Social Sciences"],
+                academic_council=True,
+            )
+        )
+
+        pub.authors.append(
+            Author(
+                first_name="Leland",
+                last_name="Stanford",
+                sunet="lelands",
+                cap_profile_id="12345",
+                orcid="02980983434",
+                primary_school="School of Humanities and Sciences",
+                primary_dept="Social Sciences",
+                primary_role="staff",
+                schools=[
+                    "School of Humanities and Sciences",
+                ],
+                departments=["Social Sciences"],
+                academic_council=False,
+            )
+        )
+
+        pub.funders.append(
+            Funder(name="National Institutes of Health", grid_id="12345", federal=True)
+        )
+
+        pub.funders.append(
+            Funder(name="Andrew Mellon Foundation", grid_id="123456", federal=False)
+        )
+
+        session.add(pub)
+
+
+def test_dataset(test_session, dataset):
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication).where(Publication.doi == "10.000/000001").first()
+        )
+        assert pub
+        assert len(pub.authors) == 2
+        assert len(pub.funders) == 2
+
+
+def test_write_publications(test_session, snapshot, dataset, caplog):
+    # generate the publications csv file
+    csv_path = openaccess.write_publications(snapshot)
+
+    # read it in and make sure it looks right
+    df = pandas.read_csv(csv_path)
+    assert len(df) == 1
+
+    row = df.iloc[0]
+    assert row.doi == "10.000/000001"
+    assert row.pub_year == 2023
+    assert row.apc == 123
+    assert row.open_access == "gold"
+    assert row.types == "article|preprint"
+    assert row.funders == "National Institutes of Health|Andrew Mellon Foundation"
+    assert bool(row.federally_funded) is True  # pandas makes federal a numpy.bool_
+
+    assert "started writing publications" in caplog.text
+    assert "finished writing publications" in caplog.text
+
+
+def test_write_contributions(test_session, snapshot, dataset, caplog):
+    # generate the publications csv file
+    csv_path = openaccess.write_contributions(snapshot)
+
+    # read it in and make sure it looks right
+    df = pandas.read_csv(csv_path)
+    assert len(df) == 2
+
+    # firt row of contributions.csv should look like this
+    row = df.iloc[0]
+    assert row.sunet == "janes"
+    assert row.role == "faculty"
+    assert bool(row.academic_council) is True
+    assert row.primary_school == "School of Humanities and Sciences"
+    assert row.primary_department == "Social Sciences"
+    assert (
+        row.all_schools
+        == "Vice Provost for Undergraduate Education|School of Humanities and Sciences"
+    )
+    assert row.all_departments == "Inter-Departmental Programs|Social Sciences"
+    assert row.doi == "10.000/000001"
+    assert row.pub_year == 2023
+    assert row.apc == 123
+    assert row.open_access == "gold"
+    assert row.types == "article|preprint"
+    assert row.funders == "National Institutes of Health|Andrew Mellon Foundation"
+    assert bool(row.federally_funded) is True  # pandas makes federal a numpy.bool_
+
+    # second row of contributions.csv should look like this
+    row = df.iloc[1]
+    assert row.sunet == "lelands"
+    assert row.role == "staff"
+    assert bool(row.academic_council) is False
+    assert row.primary_school == "School of Humanities and Sciences"
+    assert row.primary_department == "Social Sciences"
+    assert row.all_schools == "School of Humanities and Sciences"
+    assert row.all_departments == "Social Sciences"
+    assert row.doi == "10.000/000001"
+    assert row.pub_year == 2023
+    assert row.apc == 123
+    assert row.open_access == "gold"
+    assert row.types == "article|preprint"
+    assert row.funders == "National Institutes of Health|Andrew Mellon Foundation"
+    assert bool(row.federally_funded) is True  # pandas makes federal a numpy.bool_
+
+    assert "starting to write contributions" in caplog.text
+    assert "finished writing contributions" in caplog.text


### PR DESCRIPTION
This PR adds a `publish_openaccess` DAG task which writes the `contributions.csv` and `publications.csv` files following the `distill_publications` and `link_funders` tasks. The CSV files are written to the snapshot path.

Publishing to Google Drive will be done separately, but it should be possible to add to the `publish_openaccess` task.

Sample CSV files are attached here: [oa.zip](https://github.com/user-attachments/files/19289215/oa.zip)

Closes #215

PS. all the `type: ignore` statements for mypy / sqlalechemy were a bit unsatisfying, but I don't think they can be avoided until we are on the latest sqlalchemy and Airflow 3?