### PR TITLE
Ignore "researchers" Dimensions metadata

### DIFF
--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -75,12 +75,12 @@ def harvest(snapshot: Snapshot, limit: None | int = None) -> Path:
 
 
 def orcid_publications(orcid: str) -> Generator[dict, None, None]:
+    logging.info("looking up publications for orcid {orcid}")
     dois = dois_from_orcid(orcid)
     yield from publications_from_dois(dois)
 
 
 def dois_from_orcid(orcid):
-    logging.info(f"looking up dois for orcid {orcid}")
     q = """
         search publications where researchers.orcid_id = "{}"
         return publications [doi]
@@ -122,7 +122,13 @@ def publication_fields():
     Get a list of all possible fields for publications.
     """
     result = dsl().query("describe schema")
-    return list(result.data["sources"]["publications"]["fields"].keys())
+    fields = list(result.data["sources"]["publications"]["fields"].keys())
+
+    # for some reason "researchers" causes 408 errors when harvesting, maybe we
+    # can add it back when this is resolved?
+    fields.remove("researchers")
+
+    return fields
 
 
 def normalize_publication(pub) -> dict:


### PR DESCRIPTION
After some experimentation I was able to determine that including the "researchers" property in Dimensions queries can cause the occasional HTTP 408 errors. Removing it seems to allow the harvest to succeed.

For example this code reliably causes a HTTP 408 error from the API, at least at the time of this writing:

```python
import os
import dimcli

dimcli.login(
    key=os.environ.get("DIMENSIONS_API_KEY"),
    endpoint="https://app.dimensions.ai/api/dsl/v2",
)

dsl = dimcli.Dsl()

q = '''
search publications where doi in ["10.3847/1538-4357/ad9749","10.1103/physrevd.111.042005","10.3847/1538-4357/ad8de0","10.1364/fio.2024.jtu4a.2","10.3847/1538-4357/ad65ce","10.1364/cleo_si.2024.sm1d.3","10.1103/physrevd.110.042001","10.3847/1538-4357/ad3e83","10.3847/2041-8213/ad5beb"]
return publications [researchers]
limit 1000
'''

result = dsl.query(q)
```

Looking at a few Dimensions records it didn't appear that `researchers` provided any additional information to what is already available for `authors`.

This commit removes "researchers" from the list of properties we query for, and adjusts the tests. It also adds a test to track whether the API error starts working.

If this bug report on the dimcli repository gets addressed we can consider adding "researchers" back into the list of metadata properties that we collect:

https://github.com/digital-science/dimcli/issues/90

Fixes #254
