### PR TITLE
Batch lookup DOIs during fill-in

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -87,7 +87,9 @@ def harvest():
         """
         Fetch the data by ORCID from Dimensions.
         """
-        return dimensions.harvest(snapshot, limit=harvest_limit)
+        jsonl_file = dimensions.harvest(snapshot, limit=harvest_limit)
+
+        return jsonl_file
 
     @task()
     def openalex_harvest(snapshot):


### PR DESCRIPTION
This commit adjusts the fill-in DOI lookups for Dimensions and OpenAlex to look up the DOIs in batch rather than one by one. We are looking up 50 DOIs at a time for Dimensions and 100 at a time for OpenAlex.

I did adjust some of the other tests to use the `snapshot` fixtures, and in a few case move monkeypatching into the pytest function since it made it easier for me to read without the indirection of a mock.
