### PR TITLE
decrease page size to 100 for open alex DOI lookups

### DIFF
--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -98,7 +98,7 @@ def orcid_publications(orcid: str) -> Generator[dict, None, None]:
     author_id = authors[0]["id"]
 
     # get all the works for the openalex author id
-    for page in Works().filter(author={"id": author_id}).paginate(per_page=200):
+    for page in Works().filter(author={"id": author_id}).paginate(per_page=100):
         # TODO: get a key so we don't have to sleep!
         time.sleep(1)
 


### PR DESCRIPTION
Deal with this
```
pyalex.api.QueryError: Maximum number of values exceeded for doi. Decrease values to 100 or below, or consider downloading the full dataset at https://docs.openalex.org/download-snapshot
```