### PR TITLE
normalize dois fix

### DIFF
--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -28,7 +28,7 @@ def normalize_doi(doi):
 
     doi = doi.strip().lower()
     doi = doi.replace("https://doi.org/", "").replace("https://dx.doi.org/", "")
-    doi = re.sub("^doi: ", "", doi)
+    doi = re.sub(r"^doi:\s?", "", doi)
 
     return doi
 

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -4,7 +4,6 @@ import logging
 import pytest
 
 import pyalex
-from pyalex import Works
 from rialto_airflow.harvest import openalex
 from rialto_airflow.database import Publication
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -42,7 +42,9 @@ def test_normalize_doi():
         utils.normalize_doi("10.1103/PhysRevLett.96.07390")
         == "10.1103/physrevlett.96.07390"
     )
+    assert utils.normalize_doi(" 10.1234/5678 ") == "10.1234/5678"
     assert utils.normalize_doi(" doi: 10.1234/5678 ") == "10.1234/5678"
+    assert utils.normalize_doi("doi:10.1234/5678") == "10.1234/5678"
     assert utils.normalize_doi(None) is None
 
 


### PR DESCRIPTION
We should strip the `doi:` prefix from dois, even if there is no space after the prefix.

Fixes #281