### PR TITLE
Use multiple sessions when linking funders

### DIFF
--- a/rialto_airflow/funders/linker.py
+++ b/rialto_airflow/funders/linker.py
@@ -2,10 +2,16 @@ import logging
 from typing import Optional
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm.session import Session
 
 
-from rialto_airflow.database import get_session, Publication, Funder
+from rialto_airflow.database import (
+    get_session,
+    Publication,
+    Funder,
+    pub_funder_association,
+)
 from rialto_airflow.funders.dataset import is_federal, is_federal_grid_id
 
 
@@ -27,17 +33,23 @@ def link_publications(snapshot) -> int:
 
             funders = pub.dim_json.get("funders", [])
             if funders is None:
-                logging.warning("got null funders property")
                 continue
 
-            for funder in pub.dim_json.get("funders", []):
-                if funder_model := _find_or_create_funder(session, funder):
-                    pub.funders.append(funder_model)
+            with get_session(snapshot.database_name).begin() as update_session:
+                for funder in pub.dim_json.get("funders", []):
+                    if funder_id := _find_or_create_funder(snapshot, funder):
+                        update_session.execute(
+                            insert(pub_funder_association)
+                            .values(publication_id=pub.id, funder_id=funder_id)
+                            .on_conflict_do_nothing()
+                        )
 
     return count
 
 
-def _find_or_create_funder(session: Session, funder: dict) -> Optional[Funder]:
+def _find_or_create_funder(snapshot, funder: dict) -> Optional[int]:
+    # TODO: handle adding ROR ID? When we do we'll want to also handle unique
+    # constraint errors on insert like we are with grid_id.
     grid_id = funder.get("id")
     name = funder.get("name")
 
@@ -45,12 +57,16 @@ def _find_or_create_funder(session: Session, funder: dict) -> Optional[Funder]:
         logging.info(f"missing GRID ID in {funder}")
         return None
 
-    funder_obj = session.query(Funder).where(Funder.grid_id == grid_id).first()  # type: ignore
-    if funder_obj:
-        return funder_obj
+    federal = is_federal_grid_id(grid_id) or is_federal(name)
 
-    return Funder(
-        name=name,
-        grid_id=grid_id,
-        federal=(is_federal_grid_id(grid_id) or is_federal(name)),
-    )
+    with get_session(snapshot.database_name).begin() as session:
+        funder_id = session.execute(
+            insert(Funder)
+            .values(name=name, grid_id=grid_id, federal=federal)
+            .on_conflict_do_update(
+                constraint="funder_grid_id_key", set_=dict(name=name, federal=federal)
+            )
+            .returning(Funder.id)
+        ).scalar_one()
+
+        return funder_id

--- a/test/funders/test_linker.py
+++ b/test/funders/test_linker.py
@@ -51,7 +51,7 @@ def test_funders_linking(test_session, snapshot, caplog):
     assert "missing GRID ID in {'name': 'Organization A'}" in caplog.text
 
 
-def test_funders_is_none(test_session, snapshot, caplog):
+def test_funders_is_none(test_session, snapshot):
     with test_session.begin() as session:
         session.add(
             Publication(doi="10.1515/9781503624153", dim_json={"funders": None})
@@ -66,4 +66,3 @@ def test_funders_is_none(test_session, snapshot, caplog):
     )
 
     assert len(pub.funders) == 0
-    assert "got null funders" in caplog.text


### PR DESCRIPTION
In order to stop the select session from building up too many changes in memory we need to use multiple sessions:

1. selecting from publication
2. inserting into funder
3. inserting into pub_funder_association

Running in production indicates that the long running session no longer leaks memory.

Fixes #280
