### PR TITLE
Handle invalid integer values

### DIFF
--- a/test/harvest/test_distill.py
+++ b/test/harvest/test_distill.py
@@ -405,5 +405,44 @@ def test_missing_dim_issn(test_session, snapshot):
     assert _pub(session).apc is None
 
 
+def test_non_int_year(test_session, snapshot, caplog):
+    """
+    Test that non-integer years don't cause a problem.
+    """
+    with test_session.begin() as session:
+        session.bulk_save_objects(
+            [
+                Publication(
+                    doi="10.1515/9781503624153",
+                    sulpub_json={"year": "nope"},
+                ),
+            ]
+        )
+
+    distill(snapshot)
+    assert _pub(session).pub_year is None
+
+
+def test_non_int_year_fallback(test_session, snapshot, caplog):
+    """
+    Test that sulpub non-integer year doesn't prevent a year coming from
+    dimensions.
+    """
+    with test_session.begin() as session:
+        session.bulk_save_objects(
+            [
+                Publication(
+                    doi="10.1515/9781503624153",
+                    sulpub_json={"year": "nope"},
+                    dim_json={"year": 2022},
+                ),
+            ]
+        )
+
+    distill(snapshot)
+    assert _pub(session).pub_year == 2022
+    assert 'got "nope" instead of int' in caplog.text
+
+
 def _pub(session, doi="10.1515/9781503624153"):
     return session.query(Publication).where(Publication.doi == doi).first()


### PR DESCRIPTION
The publication year values can sometimes be strings instead of integers. This commit adds an `is_int` property to JsonPathRule which will cause it to cast the matched value to an integer if found, and return None if it isn't an integer. All possible rules will be tried before returning None. So if a sulpub value is a non-integer the dimensions value will be tried next.

The unexpected values are logged. But we may need to add more context to track them down if there turn out to be a lot of them.

Fixes #279
