### PR TITLE
Need to guard against None

### DIFF
--- a/rialto_airflow/harvest/distill.py
+++ b/rialto_airflow/harvest/distill.py
@@ -206,7 +206,7 @@ def _first(pub, rules: Rules) -> Optional[str | int]:
                 if rule.is_int:
                     try:
                         return int(value)
-                    except ValueError:
+                    except (ValueError, TypeError):
                         # continue matching if the rule wants an int but we don't have one
                         logging.warn(f'got "{value}" instead of int')
                 else:

--- a/test/harvest/test_distill.py
+++ b/test/harvest/test_distill.py
@@ -415,6 +415,7 @@ def test_non_int_year(test_session, snapshot, caplog):
                 Publication(
                     doi="10.1515/9781503624153",
                     sulpub_json={"year": "nope"},
+                    dim_json={"year": None},
                 ),
             ]
         )


### PR DESCRIPTION
The publication year value could also be None, which throws a TypeError rather than a ValueError.
