### PR TITLE
honeybadger deploy notifications

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -12,6 +12,7 @@ require 'stringio'
 require 'capistrano/maintenance'
 
 require 'dlss/docker/capistrano'
+require 'capistrano/honeybadger'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'capistrano'
 gem 'capistrano-maintenance', '~> 1.2', require: false
 gem 'dlss-capistrano-docker', require: false
 gem 'rake'
+gem 'honeybadger'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'capistrano'
+gem 'capistrano-bundler'
 gem 'capistrano-maintenance', '~> 1.2', require: false
 gem 'dlss-capistrano-docker', require: false
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,13 +33,18 @@ GEM
       capistrano-shared_configs
       ed25519
     ed25519 (1.3.0)
+    honeybadger (5.27.1)
+      logger
+      ostruct
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    logger (1.6.6)
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.2.3)
+    ostruct (0.6.1)
     rake (13.2.1)
     sshkit (1.23.0)
       base64
@@ -56,6 +61,7 @@ DEPENDENCIES
   capistrano
   capistrano-maintenance (~> 1.2)
   dlss-capistrano-docker
+  honeybadger
   rake
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
     capistrano-one_time_key (0.2.0)
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
+    capistrano-shell (0.2.0)
+      capistrano (~> 3.1)
     concurrent-ruby (1.3.3)
     dlss-capistrano-docker (1.1.1)
       bcrypt_pbkdf
@@ -59,7 +61,9 @@ PLATFORMS
 
 DEPENDENCIES
   capistrano
+  capistrano-bundler
   capistrano-maintenance (~> 1.2)
+  capistrano-shell
   dlss-capistrano-docker
   honeybadger
   rake

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'honeybadger'
 
 set :application, 'rialto-airflow'
 set :repo_url, 'https://github.com/sul-dlss-labs/rialto-airflow.git'
@@ -39,6 +40,11 @@ set :log_level, :info
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
 
+# Honeybadger configuration uses alternative env variables for airflow availability
+Honeybadger.configure do |config|
+  config.api_key = ENV['AIRFLOW_VAR_HONEYBADGER_API_KEY']
+  config.env = ENV['AIRFLOW_VAR_HONEYBADGER_ENV']
+end
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
 
@@ -52,4 +58,4 @@ set :docker_compose_rabbitmq_use_hooks, false
 set :docker_compose_build_use_hooks, false
 set :docker_compose_restart_use_hooks, true
 set :docker_compose_copy_assets_use_hooks, false
-set :honeybadger_use_hooks, false
+# set :honeybadger_use_hooks, false

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'honeybadger'
 
 set :application, 'rialto-airflow'
 set :repo_url, 'https://github.com/sul-dlss-labs/rialto-airflow.git'
@@ -40,11 +39,6 @@ set :log_level, :info
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
 
-# Honeybadger configuration uses alternative env variables for airflow availability
-Honeybadger.configure do |config|
-  config.api_key = ENV['AIRFLOW_VAR_HONEYBADGER_API_KEY']
-  config.env = ENV['AIRFLOW_VAR_HONEYBADGER_ENV']
-end
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,4 +58,4 @@ set :docker_compose_rabbitmq_use_hooks, false
 set :docker_compose_build_use_hooks, false
 set :docker_compose_restart_use_hooks, true
 set :docker_compose_copy_assets_use_hooks, false
-# set :honeybadger_use_hooks, false
+set :honeybadger_use_hooks, false


### PR DESCRIPTION
Fixes #285 

Notify HB on deployment.  HB API key and stage already set by puppet

This worked, but required me installing the honeybadger gem directly on the server, since i can't get bundle exec to execute.