### PR TITLE
allow google more time to show the files uploaded before checking

### DIFF
--- a/test/test_google.py
+++ b/test/test_google.py
@@ -128,7 +128,7 @@ def test_replace_file_in_google_drive():
     google.upload_file_to_google_drive("test/data/authors.csv", google_drive_id())
 
     # give it some time to upload to google before checking it exists
-    time.sleep(2)
+    time.sleep(4)
 
     # Get the file ID of the uploaded file and ensure it exists
     file_id = google.get_file_id(google_drive_id(), "authors.csv")
@@ -169,7 +169,7 @@ def test_upload_file_to_google_drive():
     google.upload_file_to_google_drive("test/data/authors.csv", google_drive_id())
 
     # give it some time to upload to google before checking it exists
-    time.sleep(2)
+    time.sleep(4)
 
     # Confirm the file now exists in the shared google drive
     assert google_file_exists(google_drive_id(), "authors.csv") is True


### PR DESCRIPTION
*sigh* tests are still a bit flaky because we rely on google having indicated the file is available ... if this continues to be a problem, we may need to get more creative, but this is making it less flaky for me on localhost