### PR TITLE
ignore years that are in the future

### DIFF
--- a/rialto_airflow/apc/__init__.py
+++ b/rialto_airflow/apc/__init__.py
@@ -20,7 +20,7 @@ def get_apc(issn: str, year: int) -> Optional[int]:
     ]
     if len(matches) >= 1:
         if len(matches) > 1:
-            logging.warn(f"more than one APC match for {issn} and {year}")
+            logging.warning(f"more than one APC match for {issn} and {year}")
         return int(matches.iloc[0].APC_USD)
     else:
         return None

--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -203,7 +203,7 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
                 for dimensions_pub in publications_from_dois(dois, batch_size=50):
                     doi = dimensions_pub.get("doi")
                     if doi is None:
-                        logging.warn("unable to determine what DOI to update")
+                        logging.warning("unable to determine what DOI to update")
                         continue
 
                     with get_session(snapshot.database_name).begin() as update_session:

--- a/rialto_airflow/harvest/distill.py
+++ b/rialto_airflow/harvest/distill.py
@@ -210,9 +210,12 @@ def _first(pub, rules: Rules) -> Optional[str | int]:
                         if year_val <= datetime.datetime.now().year:
                             return year_val
                         else:
-                            logging.warn(f"got a year {year_val} that is in the future")
+                            logging.warning(
+                                f"got a year {year_val} that is in the future"
+                            )
                     except (ValueError, TypeError):
-                        logging.warn(f'got "{value}" instead of int')
+                        # continue matching if the rule wants an int but we don't have one
+                        logging.warning(f'got "{value}" instead of int')
                 else:
                     return value
 

--- a/rialto_airflow/harvest/distill.py
+++ b/rialto_airflow/harvest/distill.py
@@ -8,6 +8,7 @@ from sqlalchemy import select, update
 from rialto_airflow.database import Publication, get_session
 from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.apc import get_apc
+import datetime
 
 
 def distill(snapshot: Snapshot) -> int:
@@ -76,11 +77,11 @@ def _pub_year(pub):
     return _first(
         pub,
         rules=[
-            JsonPathRule("sulpub_json", "year", is_int=True),
-            JsonPathRule("dim_json", "year", is_int=True),
-            JsonPathRule("openalex_json", "publication_year", is_int=True),
+            JsonPathRule("sulpub_json", "year", is_valid_year=True),
+            JsonPathRule("dim_json", "year", is_valid_year=True),
+            JsonPathRule("openalex_json", "publication_year", is_valid_year=True),
             JsonPathRule(
-                "wos_json", "static_data.summary.pub_info.pubyear", is_int=True
+                "wos_json", "static_data.summary.pub_info.pubyear", is_valid_year=True
             ),
         ],
     )
@@ -174,7 +175,7 @@ def _apc_oa_dataset(dim_json, context):
 class JsonPathRule:
     col: str  # the JSONB column name to apply the rule to
     matcher: str  # a JSON Path to evaluate against the JSON
-    is_int: bool = False
+    is_valid_year: bool = False
 
 
 @dataclass
@@ -203,11 +204,14 @@ def _first(pub, rules: Rules) -> Optional[str | int]:
             results = jpath.find(data)
             if len(results) > 0:
                 value = results[0].value
-                if rule.is_int:
+                if rule.is_valid_year:
                     try:
-                        return int(value)
+                        year_val = int(value)
+                        if year_val <= datetime.datetime.now().year:
+                            return year_val
+                        else:
+                            logging.warn(f"got a year {year_val} that is in the future")
                     except (ValueError, TypeError):
-                        # continue matching if the rule wants an int but we don't have one
                         logging.warn(f'got "{value}" instead of int')
                 else:
                     return value

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -144,7 +144,7 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
                 for openalex_pub in Works().filter(doi=dois_joined).get():
                     doi = normalize_doi(openalex_pub.get("doi"))
                     if doi is None:
-                        logging.warn("unable to determine what DOI to update")
+                        logging.warning("unable to determine what DOI to update")
                         continue
 
                     with get_session(snapshot.database_name).begin() as update_session:

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -213,7 +213,7 @@ def get_doi(pub) -> Optional[str]:
             # a str instead of a dict, albeit an empty string in that case. Normalize empty string to None.
             return identifiers_field or None
     except AttributeError as e:
-        logging.warn(f"error {e} trying to parse identifiers from {pub}")
+        logging.warning(f"error {e} trying to parse identifiers from {pub}")
         return None
 
     return None

--- a/test/harvest/test_distill.py
+++ b/test/harvest/test_distill.py
@@ -5,6 +5,11 @@ from rialto_airflow.harvest.distill import distill
 
 sulpub_json = {"title": "On the dangers of stochastic parrots (sulpub)", "year": "2020"}
 
+sulpub_json_future_year = {
+    "title": "On the dangers of stochastic parrots (sulpub)",
+    "year": "2105",
+}
+
 dim_json = {
     "title": "On the dangers of stochastic parrots (dim)",
     "year": 2021,
@@ -151,6 +156,28 @@ def test_pub_year_sulpub(test_session, snapshot):
     distill(snapshot)
 
     assert _pub(session).pub_year == 2020
+
+
+def test_pub_year_sulpub_future(test_session, snapshot):
+    """
+    pub_year should not come from sulpub since it is in the future (get from another source)
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                sulpub_json=sulpub_json_future_year,
+                dim_json=dim_json,
+                openalex_json=openalex_json,
+                wos_json=wos_json,
+            )
+        )
+
+    distill(snapshot)
+
+    assert (
+        _pub(session).pub_year == 2021
+    )  # comes from dimensions, not the 2105 from sul-pub!
 
 
 def test_pub_year_dim(test_session, snapshot):


### PR DESCRIPTION
Fixes #305 by altering the rule for "is_int" (currently only used by years anyway) so that it instead verifies both the fact the year is an int and earlier than the current year.

If we need to validate ints for other fields, we can add that rule separately back in.

Also, fix deprecation warnings.