### PR TITLE
issue SR request for WoS APIs calls to limit data returned

### DIFF
--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -100,6 +100,7 @@ def orcid_publications(orcid) -> Generator[dict, None, None]:
         "usrQuery": f"AI=({orcid})",
         "count": batch_size,
         "firstRecord": 1,
+        "optionView": "SR",  # SR = Short Records, which gives us the most basic info about the publication, skipping authors, to keep
     }
 
     http = requests.Session()


### PR DESCRIPTION
To deal with #207 

Just added the WoS SR param without investigating too deeply what fields are missing and if we use them.  I then ran a full harvest of 100 records on my laptop, whocj ran successfully, so it's likely we were never using the fields that aren't returned anyway.

Ran harvest of 100 on localhost = successfully completed
Ran harvest of 1000 on stage = successfully completed