### PR TITLE
Set APCs for closed pubs to 0

### DIFF
--- a/rialto_airflow/harvest/distill.py
+++ b/rialto_airflow/harvest/distill.py
@@ -35,7 +35,7 @@ def distill(snapshot: Snapshot) -> int:
                 "open_access": _open_access(pub),
             }
 
-            # pub_year in cols is needed to determine the apc
+            # pub_year and open_access in cols is needed to determine the apc
             cols["apc"] = _apc(pub, cols)
 
             # update the publication with the new columns
@@ -102,11 +102,11 @@ def _open_access(pub):
 
 def _apc(pub, context):
     """
-    Get the APC cost from one place in the openalex data , an external dataset, or another place in
+    Get the APC cost from one place in the openalex data, an external dataset, or another place in
     OpenAlex data.
     """
     # https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/CR1MMV
-    return _first(
+    first_match_apc = _first(
         pub,
         rules=[
             JsonPathRule(
@@ -118,6 +118,11 @@ def _apc(pub, context):
             ),
         ],
     )
+    # non-OA publications should not have an APC charge recorded
+    if isinstance(first_match_apc, int) and context["open_access"] == "closed":
+        return 0
+    else:
+        return first_match_apc
 
 
 #

--- a/test/harvest/test_distill.py
+++ b/test/harvest/test_distill.py
@@ -447,6 +447,30 @@ def test_apc_dataset(test_session, snapshot):
     assert _pub(session).apc == 400
 
 
+def test_apc_closed_oa(test_session, snapshot):
+    """
+    pubs with a closed open access status should not have an APC
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                dim_json={
+                    "year": 2021,
+                    "open_access": ["closed"],
+                    "issn": None,
+                },
+                openalex_json={
+                    "apc_paid": {"value_usd": 123},
+                },
+            ),
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).apc == 0
+
+
 def test_missing_dim_issn(test_session, snapshot):
     """
     Use APC 2024 dataset to get APC cost when openalex apc_paid isn't there.


### PR DESCRIPTION
Resolves the first requirement of #330, to set APCs for "closed" publications to 0, since a closed article should not have an estimated APC. 