### PR TITLE
Assign APC based on openaccess values

### DIFF
--- a/rialto_airflow/harvest/distill.py
+++ b/rialto_airflow/harvest/distill.py
@@ -119,10 +119,21 @@ def _apc(pub, context):
         ],
     )
     # non-OA publications should not have an APC charge recorded
-    if isinstance(first_match_apc, int) and context["open_access"] == "closed":
+    oa = (context.get("open_access") or "").lower()
+    is_int = isinstance(first_match_apc, int)
+
+    if is_int and oa == "closed":
         return 0
-    else:
+    elif is_int:
         return first_match_apc
+    elif oa == "diamond":
+        return 0
+    elif oa == "gold":
+        return 2450
+    elif oa == "hybrid":
+        return 3600
+    else:
+        return None
 
 
 #

--- a/test/harvest/test_distill.py
+++ b/test/harvest/test_distill.py
@@ -471,6 +471,69 @@ def test_apc_closed_oa(test_session, snapshot):
     assert _pub(session).apc == 0
 
 
+def test_diamond_apc(test_session, snapshot):
+    """
+    diamond openaccess publications with no apc are assigned $0
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                dim_json={
+                    "year": 2021,
+                    "open_access": ["diamond"],
+                    "issn": None,
+                },
+            ),
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).apc == 0
+
+
+def test_hybrid_apc(test_session, snapshot):
+    """
+    hybrid openaccess publications with no apc are assigned $3600
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                dim_json={
+                    "year": 2021,
+                    "open_access": ["hybrid"],
+                    "issn": None,
+                },
+            ),
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).apc == 3600
+
+
+def test_gold_apc(test_session, snapshot):
+    """
+    gold openaccess publications with no apc are assigned $2450
+    """
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                dim_json={
+                    "year": 2021,
+                    "open_access": ["gold"],
+                    "issn": None,
+                },
+            ),
+        )
+
+    distill(snapshot)
+
+    assert _pub(session).apc == 2450
+
+
 def test_missing_dim_issn(test_session, snapshot):
     """
     Use APC 2024 dataset to get APC cost when openalex apc_paid isn't there.


### PR DESCRIPTION
When APC can't be determined using our dataset, assign default values if there is an openaccess match:

* diamond: $0
* gold: $2,450
* hybrid: $3,600

Closes #330
