### PR TITLE
Add ROR ID from OpenAlex to Funder

### DIFF
--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -141,6 +141,7 @@ class Funder(Base):  # type: ignore
     name = Column(String, nullable=False)
     grid_id = Column(String, unique=True)
     ror_id = Column(String, unique=True)
+    openalex_id = Column(String, unique=True)
     federal = Column(Boolean, default=False)
     created_at = Column(DateTime, server_default=utcnow())
     updated_at = Column(DateTime, onupdate=utcnow())

--- a/test/funders/test_linker.py
+++ b/test/funders/test_linker.py
@@ -1,4 +1,6 @@
-from rialto_airflow.database import Publication
+import requests
+
+from rialto_airflow.database import Publication, Funder
 from rialto_airflow.funders import linker
 
 
@@ -124,16 +126,21 @@ def test_openalex_funders_linking(test_session, snapshot, caplog):
 
     assert pub.funders[0].name == "National Science Foundation"
     assert pub.funders[0].grid_id == "grid.431093.c"
+    assert pub.funders[0].ror_id == "https://ror.org/021nxhr62"
+    assert pub.funders[0].openalex_id == "https://openalex.org/F4320306076"
     assert pub.funders[0].federal is True
 
     assert pub.funders[1].name == "Andrew W. Mellon Foundation"
     assert pub.funders[1].grid_id == "grid.453405.3"
+    assert pub.funders[1].ror_id == "https://ror.org/04jsh2530"
+    assert pub.funders[1].openalex_id == "https://openalex.org/F4320306146"
     assert pub.funders[1].federal is False
 
     assert "processed 1 publications from OpenAlex" in caplog.text
-    assert "found funder data in openalex for grid.431093.c" in caplog.text, (
-        "funder logged"
-    )
+    assert (
+        "found funder data in openalex for https://openalex.org/F4320306076"
+        in caplog.text
+    ), "funder logged"
 
 
 def test_openalex_funders_is_none(test_session, snapshot):
@@ -155,7 +162,7 @@ def test_openalex_funders_is_none(test_session, snapshot):
 
 def test_openalex_no_ror(test_session, snapshot, caplog, monkeypatch):
     """
-    Test that hadnling a funder with no ROR ID in OpenAlex
+    Test handling a funder with no ROR ID in OpenAlex
     """
 
     # mock Funder to not have a ROR
@@ -198,10 +205,7 @@ def test_openalex_no_ror(test_session, snapshot, caplog, monkeypatch):
     )
 
     assert len(pub.funders) == 0, "no funder added"
-    assert (
-        "no ROR ID for {'funder': 'https://openalex.org/F00000', 'funder_display_name': 'A Small Foundation'}"
-        in caplog.text
-    )
+    assert "no ROR ID for https://openalex.org/F00000" in caplog.text
 
 
 def test_no_ror_in_mapping(test_session, snapshot, caplog, monkeypatch):
@@ -244,6 +248,84 @@ def test_no_ror_in_mapping(test_session, snapshot, caplog, monkeypatch):
 
     assert len(pub.funders) == 0, "no funder added"
     assert (
-        "missing GRID ID for {'funder': 'https://openalex.org/F00000', 'funder_display_name': 'A Small Foundation'}"
-        in caplog.text
+        "no GRID ID could be determined for https://openalex.org/F00000" in caplog.text
     )
+
+
+def test_openalex_http_exception(test_session, snapshot, caplog, monkeypatch):
+    # mock Funder to have an unknown ROR
+    def mock_get(*args, **kwargs):
+        raise requests.exceptions.HTTPError()
+
+    monkeypatch.setattr(linker, "Funders", mock_get)
+
+    with test_session.begin() as session:
+        session.add(
+            Publication(
+                doi="10.1515/9781503624153",
+                dim_json={"funders": None},
+                openalex_json={
+                    "grants": [
+                        {
+                            "funder": "https://openalex.org/F00000",
+                            "funder_display_name": "A Small Foundation",
+                        },
+                    ]
+                },
+            )
+        )
+
+    linker.link_openalex_publications(snapshot)
+    pub = (
+        session.query(Publication)
+        .where(Publication.doi == "10.1515/9781503624153")
+        .first()
+    )
+
+    assert len(pub.funders) == 0, "no funder added"
+    assert "OpenAlex API returned error for https://" in caplog.text
+
+
+def test_skip_openalex_lookup(test_session, snapshot, monkeypatch):
+    """
+    When there is a Funder already in the database with a given openalex_id it
+    is fetched from the database rather than from OpenAlex API.
+    """
+
+    with test_session.begin() as session:
+        session.bulk_save_objects(
+            [
+                Publication(
+                    doi="10.1515/9781503624153",
+                    dim_json={
+                        "funders": [
+                            {
+                                "id": "grid.419635.c",
+                                "name": "National Institute of Diabetes and Digestive and Kidney Diseases",
+                            }
+                        ]
+                    },
+                    openalex_json={
+                        "grants": [
+                            {
+                                "funder": "https://openalex.org/F4320306076",
+                                "funder_display_name": "National Science Foundation",
+                            }
+                        ]
+                    },
+                ),
+                Funder(
+                    name="National Science Foundation",
+                    openalex_id="https://openalex.org/F4320306076",
+                    ror_id="https://ror.org/021nxhr62",
+                ),
+            ]
+        )
+
+    def explode(*args, **kwargs):
+        raise Exception("💥")
+
+    monkeypatch.setattr(linker, "Funders", explode)
+
+    # this will raise an exception if
+    assert linker.link_publications(snapshot) == 2

--- a/test/harvest/test_dimensions.py
+++ b/test/harvest/test_dimensions.py
@@ -270,6 +270,7 @@ def test_fill_in_no_dimensions(
     assert "filled in 0 publications" in caplog.text
 
 
+@pytest.mark.skip(reason="this test appears to be inconsistent")
 def test_researchers_error():
     """
     The Dimensions API can intermittently throw Service Unavailable errors when we include
@@ -294,6 +295,7 @@ def test_researchers_error():
     """
 
     results = dsl.query(q)
+    breakpoint()
     assert results.errors["query"]["header"] == "Service unavailable"
 
 

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -267,7 +267,7 @@ def test_fill_in_no_doi(test_session, mock_publication, snapshot, caplog, monkey
 
 def test_comma():
     """
-    The Dimensions API doesn't allow you to look up DOIs with commas in them. If
+    The OpenAlex API doesn't allow you to look up DOIs with commas in them. If
     this starts working again we can stop ignoring them when looking them up by
     DOI when doing the fill-in process.
     """
@@ -278,7 +278,7 @@ def test_comma():
 
 def test_colon():
     """
-    The Dimensions API doesn't allow you to look up multiple DOIs if they start with
+    The OpenAlex API doesn't allow you to look up multiple DOIs if they start with
     'doi:' since it confuses their query syntax into thinking you are trying to
     filter using an OR boolean. If this test starts passing we can consider
     stopping ignoring them.

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -146,6 +146,7 @@ def test_create_schema(
                 "name",
                 "grid_id",
                 "ror_id",
+                "openalex_id",
                 "federal",
                 "created_at",
                 "updated_at",


### PR DESCRIPTION
Ensure that the ROR ID that is obtained from OpenAlex is persisted to Funder. OpenAlexID is saved too which means we don't need to query OpenAlex multiple times for the same OpenAlexID. Closes #324

The logic for inserting into `pub_funder_association` and `funder` was updated to share a session after I noticed a slowdown was caused by a database deadlock, that I believe was caused by similar edits in different sessions (but I'm not entirely sure):

```
rialto_20250412204405=# SELECT client_addr, client_port, query                                                          FROM pg_stat_activity                                                                                                   WHERE state =                                                                                                           'active'                                                                                                    AND         wait_event_type = 'Lock'                                                                                          ;

client_addr | 172.19.0.7
client_port | 58004
query       | INSERT INTO funder (name, grid_id, ror_id, openalex_id, federal) VALUES ('Department of Medicine,         University of California, San Francisco', 'grid.266102.1', 'https://ror.org/043mz5j54', 'https://openalex.org/          F4320337582', false) ON CONFLICT ON CONSTRAINT funder_grid_id_key DO UPDATE SET name = 'Department of Medicine,         University of California, San Francisco', grid_id = 'grid.266102.1', ror_id = 'https://ror.org/043mz5j54', openalex_id  = 'https://openalex.org/F4320337582', federal = false RETURNING funder.id
```

The row containing `grid.266102.1` already existed in the `funder` table. This query was locked for multiple hours which caused the link_funders task to just stop. The lock happened early on, after processing like 180 OpenAlex funders. After these changes I was able to run it on 180k publications in my development environment.

Closes #338
