### PR TITLE
schedule harvest to run weekly

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -58,7 +58,8 @@ def task_failure_notify(context):
 
 
 @dag(
-    schedule=None,
+    schedule="@weekly",
+    max_active_runs=1,
     start_date=datetime.datetime(2024, 1, 1),
     catchup=False,
     default_args={"on_failure_callback": task_failure_notify},

--- a/rialto_airflow/dags/publish_orcid.py
+++ b/rialto_airflow/dags/publish_orcid.py
@@ -23,6 +23,7 @@ gcp_conn_id = Variable.get("google_connection")
 
 @dag(
     schedule="@weekly",
+    max_active_runs=1,
     start_date=datetime.datetime(2024, 1, 1),
     catchup=False,
 )


### PR DESCRIPTION
1. Schedule harvest dag to run weekly.
2. Do not allow more than one concurrent DAG to be running for either orcid or harvest (so that if the previous run is still happening, a new one will not start).

Fixes #2 

see https://www.astronomer.io/docs/learn/rerunning-dags/