### PR TITLE
Don't query OpenAlex for DOIs containing pmcid:

### DIFF
--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -278,8 +278,8 @@ def test_comma():
 
 def test_colon():
     """
-    The OpenAlex API doesn't allow you to look up multiple DOIs if they start with
-    'doi:' since it confuses their query syntax into thinking you are trying to
+    The OpenAlex API doesn't allow you to look up multiple DOIs if they contain
+    a name prefix like 'doi:' since it confuses their query syntax into thinking you are trying to
     filter using an OR boolean. If this test starts passing we can consider
     stopping ignoring them.
     """
@@ -288,3 +288,9 @@ def test_colon():
     ):
         dois = "abc123|doi:abc123"
         pyalex.Works().filter(doi=dois).get()
+
+
+def test_clean_dois_for_query():
+    assert openalex._clean_dois_for_query(
+        ["doi:123", "abc/123,45", "aaa/111", "123/abc pmcid:123", "abc/123"]
+    ) == ["aaa/111", "abc/123"]


### PR DESCRIPTION
When querying OpenAlex for multiple DOIs, where one of the DOIs contains the substring `pmcid:` we encounter an OpenAlex error:

```
pyalex.api.QueryError: It looks like you're trying to do an OR query between filters and it's not supported.
You can do this: institutions.country_code:fr|en, but not this: institutions.country_code:gb|host_venue.issn:0957-1558.
```

We need to ignore DOIs like this during the fill_in_openalex task. We received a DOI like this from sulpub prod:

sulpub_id: 895752
doi: 10.1093/noajnl/vdad070.013 pmcid: pmc10402389
