### PR TITLE
Purge old data

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ docker compose up -d
 
 ### Console
 
-$ uv run dotenv run python
+```
+uv run dotenv run python
+```
 
 ### Set-up
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -107,6 +107,7 @@ x-airflow-common:
     AIRFLOW_VAR_RIALTO_POSTGRES: "postgresql+psycopg2://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOSTNAME}"
     AIRFLOW_VAR_HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY}
     AIRFLOW_VAR_HONEYBADGER_ENV: ${HONEYBADGER_ENV}
+    AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 30
   volumes:
     - /opt/app/rialto/rialto-airflow/current/rialto_airflow:/opt/airflow/rialto_airflow
     - /rialto-data:/opt/airflow/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -100,7 +100,7 @@ x-airflow-common:
     AIRFLOW_VAR_RIALTO_POSTGRES: "postgresql+psycopg2://airflow:airflow@postgres"
     AIRFLOW_VAR_HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY}
     AIRFLOW_VAR_HONEYBADGER_ENV: ${HONEYBADGER_ENV}
-    AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 30
+    AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 10
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/rialto_airflow:/opt/airflow/rialto_airflow
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs

--- a/compose.yaml
+++ b/compose.yaml
@@ -100,6 +100,7 @@ x-airflow-common:
     AIRFLOW_VAR_RIALTO_POSTGRES: "postgresql+psycopg2://airflow:airflow@postgres"
     AIRFLOW_VAR_HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY}
     AIRFLOW_VAR_HONEYBADGER_ENV: ${HONEYBADGER_ENV}
+    AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 30
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/rialto_airflow:/opt/airflow/rialto_airflow
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs

--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -13,7 +13,7 @@ def cleanup_author_files(cleanup_interval_days: int, data_dir: str):
         Path(data_dir).glob("authors_active.csv.*")
     )
     for file in files:
-        file_time = datetime.strptime(file.name.split(".")[-1], "%Y%m%d")
+        file_time = datetime.strptime(file.name.split(".")[-1], "%Y-%m-%d")
         age = current_time - file_time
         if age.days > cleanup_interval_days:
             logging.info(f"Removing author file: {file} (age: {age.days} days)")

--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -1,0 +1,44 @@
+import datetime
+import os
+import shutil
+import logging
+
+from pathlib import Path
+from rialto_airflow.database import drop_database, database_exists
+
+
+current_time = datetime.datetime.now()
+
+
+def cleanup_author_files(cleanup_interval_days, data_dir):
+    files = list(Path(data_dir).glob("authors.csv.*")) + list(
+        Path(data_dir).glob("authors_active.csv.*")
+    )
+    for file in files:
+        creation_time = os.path.getmtime(str(file.resolve()))
+        file_time = datetime.datetime.fromtimestamp(creation_time)
+        age = current_time - file_time
+        if age.days > int(cleanup_interval_days):
+            logging.info(f"Removing author file: {file} (age: {age.days} days)")
+            file.unlink()
+
+
+def cleanup_snapshots(cleanup_interval_days, data_dir):
+    base_snapshot_folder = Path(data_dir) / "snapshots"
+    snapshots = os.listdir(base_snapshot_folder)
+    for snapshot in snapshots:
+        folder_path = os.path.join(base_snapshot_folder, snapshot)
+        if os.path.isdir(folder_path):
+            creation_time = os.path.getmtime(folder_path)
+            folder_time = datetime.datetime.fromtimestamp(creation_time)
+            age = current_time - folder_time
+            if age.days > int(cleanup_interval_days):
+                logging.info(
+                    f"Removing snapshot folder: {folder_path} (age: {age.days} days)"
+                )
+                shutil.rmtree(folder_path)  # delete folder and all contents
+
+                database_name = f"rialto_{snapshot}"
+                logging.info(f"Searching for database named {database_name}")
+                if database_exists(database_name):
+                    drop_database(database_name)

--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -1,44 +1,40 @@
-import datetime
-import os
-import shutil
 import logging
-
+import shutil
 from pathlib import Path
-from rialto_airflow.database import drop_database, database_exists
+from datetime import datetime
+
+from rialto_airflow.database import database_exists, drop_database
 
 
-current_time = datetime.datetime.now()
+def cleanup_author_files(cleanup_interval_days: int, data_dir: str):
+    current_time = datetime.now()
 
-
-def cleanup_author_files(cleanup_interval_days, data_dir):
     files = list(Path(data_dir).glob("authors.csv.*")) + list(
         Path(data_dir).glob("authors_active.csv.*")
     )
     for file in files:
-        creation_time = os.path.getmtime(str(file.resolve()))
-        file_time = datetime.datetime.fromtimestamp(creation_time)
+        file_time = datetime.strptime(file.name.split(".")[-1], "%Y%m%d")
         age = current_time - file_time
-        if age.days > int(cleanup_interval_days):
+        if age.days > cleanup_interval_days:
             logging.info(f"Removing author file: {file} (age: {age.days} days)")
             file.unlink()
 
 
-def cleanup_snapshots(cleanup_interval_days, data_dir):
+def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
+    current_time = datetime.now()
+
     base_snapshot_folder = Path(data_dir) / "snapshots"
-    snapshots = os.listdir(base_snapshot_folder)
-    for snapshot in snapshots:
-        folder_path = os.path.join(base_snapshot_folder, snapshot)
-        if os.path.isdir(folder_path):
-            creation_time = os.path.getmtime(folder_path)
-            folder_time = datetime.datetime.fromtimestamp(creation_time)
+    for folder_path in base_snapshot_folder.iterdir():
+        if folder_path.is_dir():
+            folder_time = datetime.strptime(folder_path.name, "%Y%m%d%H%M%S")
             age = current_time - folder_time
-            if age.days > int(cleanup_interval_days):
+            if age.days > cleanup_interval_days:
                 logging.info(
                     f"Removing snapshot folder: {folder_path} (age: {age.days} days)"
                 )
                 shutil.rmtree(folder_path)  # delete folder and all contents
 
-                database_name = f"rialto_{snapshot}"
+                database_name = f"rialto_{folder_path.name}"
                 logging.info(f"Searching for database named {database_name}")
                 if database_exists(database_name):
                     drop_database(database_name)

--- a/rialto_airflow/dags/cleanup.py
+++ b/rialto_airflow/dags/cleanup.py
@@ -1,0 +1,80 @@
+import datetime
+import os
+import shutil
+import logging
+
+from airflow.decorators import dag, task
+from airflow.models import Variable
+from pathlib import Path
+
+data_dir = Variable.get("data_dir")
+cleanup_interval_days = Variable.get("cleanup_interval_days", default_var=30)
+current_time = datetime.datetime.now()
+
+
+@dag(
+    schedule="@weekly",
+    max_active_runs=1,
+    start_date=datetime.datetime(2024, 1, 1),
+    catchup=False,
+)
+def cleanup():
+    @task
+    def cleanup_author_files():
+        """
+        Remove author files older than the specified number of days from the data directory.
+        """
+        logging.info(
+            f"Cleanup any author files older than {cleanup_interval_days} days"
+        )
+        files = list(Path(data_dir).glob("authors.csv.*")) + list(
+            Path(data_dir).glob("authors_active.csv.*")
+        )
+        for file in files:
+            creation_time = os.path.getmtime(str(file.resolve()))
+            file_time = datetime.datetime.fromtimestamp(creation_time)
+            age = current_time - file_time
+            if age.days > int(cleanup_interval_days):
+                logging.info(f"Removing author file: {file} (age: {age.days} days)")
+                file.unlink()
+        return True
+
+    @task
+    def cleanup_snapshots():
+        """
+        Remove snapshot folders older than the specified number of days from the data directory.
+        """
+        logging.info(
+            f"Cleanup any snapshot folders older than {cleanup_interval_days} days"
+        )
+        base_snapshot_folder = Path(data_dir) / "snapshots"
+        snapshots = os.listdir(base_snapshot_folder)
+        for snapshot in snapshots:
+            folder_path = os.path.join(base_snapshot_folder, snapshot)
+            if os.path.isdir(folder_path):
+                creation_time = os.path.getmtime(folder_path)
+                folder_time = datetime.datetime.fromtimestamp(creation_time)
+                age = current_time - folder_time
+                if age.days > int(cleanup_interval_days):
+                    logging.info(
+                        f"Removing snapshot folder: {folder_path} (age: {age.days} days)"
+                    )
+                    shutil.rmtree(folder_path)
+        return True
+
+    @task
+    def cleanup_databases():
+        """
+        Remove snapshot databases older than the specified number of days.
+        """
+        logging.info(f"Cleanup any databases older than {cleanup_interval_days} days")
+        return True
+
+    cleanup_author_files()
+
+    cleanup_snapshots()
+
+    cleanup_databases()
+
+
+cleanup()

--- a/rialto_airflow/dags/cleanup.py
+++ b/rialto_airflow/dags/cleanup.py
@@ -9,7 +9,7 @@ from rialto_airflow.cleanup import (
 )
 
 data_dir = Variable.get("data_dir")
-cleanup_interval_days = Variable.get("cleanup_interval_days")
+cleanup_interval_days = int(Variable.get("cleanup_interval_days"))
 
 
 @dag(

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -51,8 +51,34 @@ def create_database(database_name: str) -> str:
     with engine.connect() as connection:
         connection.execution_options(isolation_level="AUTOCOMMIT")
         connection.execute(text(f"create database {database_name}"))
-    logging.info(f"created database {database_name}")
+    logging.info(f"Created database {database_name}")
     return database_name
+
+
+def drop_database(database_name: str):
+    """Drop a DAG-specific database for publications and author/orgs data"""
+
+    # set up the connection using the default postgres database
+    engine = engine_setup("postgres")
+    with engine.connect() as connection:
+        connection.execution_options(isolation_level="AUTOCOMMIT")
+        connection.execute(text(f"drop database {database_name}"))
+    logging.info(f"Dropped database {database_name}")
+
+
+def database_exists(database_name: str) -> bool:
+    """Checks if a database with the given name exists"""
+
+    engine = engine_setup("postgres")
+    with engine.connect() as connection:
+        result = connection.execute(
+            text(
+                "SELECT datname FROM pg_database WHERE datname = :db_name AND datistemplate = false"
+            ),
+            {"db_name": database_name},
+        )
+        # If the query returns any rows, the database exists
+        return result.fetchone() is not None
 
 
 class utcnow(expression.FunctionElement):

--- a/test/test_cleanup.py
+++ b/test/test_cleanup.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timedelta
+
+from rialto_airflow.cleanup import cleanup_snapshots, cleanup_author_files
+from rialto_airflow.database import create_database, database_exists
+
+
+def test_cleanup_snapshots(tmp_path, monkeypatch):
+    # since we aren't using the test_session from conftest we have to set the
+    # environment variable for what database to talk to
+    monkeypatch.setenv(
+        "AIRFLOW_VAR_RIALTO_POSTGRES",
+        "postgresql+psycopg2://airflow:airflow@localhost:5432",
+    )
+
+    # set up some timestamps
+    now = datetime.now()
+    time_format = "%Y%m%d%H%M%S"
+    t0 = now.strftime(time_format)
+    t1 = (now - timedelta(days=1)).strftime(time_format)
+    t2 = (now - timedelta(days=40)).strftime(time_format)
+
+    # set up some snapshot directories
+    p0 = tmp_path / "snapshots" / t0
+    p1 = tmp_path / "snapshots" / t1
+    p2 = tmp_path / "snapshots" / t2
+
+    # create the directories
+    p0.mkdir(parents=True)
+    p1.mkdir(parents=True)
+    p2.mkdir(parents=True)
+
+    # write a file to each directory
+    (p0 / "pubs.csv").open("w").write("a,b")
+    (p1 / "pubs.csv").open("w").write("a,b")
+    (p2 / "pubs.csv").open("w").write("a,b")
+
+    # create the databases
+    create_database(f"rialto_{t0}")
+    create_database(f"rialto_{t1}")
+    create_database(f"rialto_{t2}")
+
+    # cleanup snapshots that are older than 30 days
+    cleanup_snapshots(30, tmp_path)
+
+    # ensure that the snapshots are still there except for the 40 day old one
+
+    assert database_exists(f"rialto_{t0}"), "database is still there"
+    assert p0.is_dir(), "snapshot dir is still there"
+    assert len(list(p0.iterdir())) == 1, "snapshot file is still there"
+
+    assert database_exists(f"rialto_{t1}"), "database is still there"
+    assert p1.is_dir(), "snapshot dir is still there"
+    assert len(list(p1.iterdir())) == 1, "snapshot file is still there"
+
+    assert not database_exists(f"rialto_{t2}"), "database is gone"
+    assert not p2.is_dir(), "snapshot directory is gone"
+
+
+def test_cleanup_author_files(tmp_path):
+    # set up some timestamps
+    now = datetime.now()
+    time_format = "%Y%m%d"
+    t1 = (now - timedelta(days=1)).strftime(time_format)
+    t2 = (now - timedelta(days=40)).strftime(time_format)
+
+    # set up some author paths
+    p0 = tmp_path / "authors.csv"
+    p1 = tmp_path / f"authors.csv.{t1}"
+    p2 = tmp_path / f"authors.csv.{t2}"
+
+    # write some data to the files
+    p0.open("w").write("test")
+    p1.open("w").write("test")
+    p2.open("w").write("test")
+
+    # do the cleanup!
+    cleanup_author_files(30, tmp_path)
+
+    # the 40 day old file should be gone but the others are still there
+    assert p0.is_file()
+    assert p1.is_file()
+    assert not p2.is_file()

--- a/test/test_cleanup.py
+++ b/test/test_cleanup.py
@@ -59,24 +59,35 @@ def test_cleanup_snapshots(tmp_path, monkeypatch):
 def test_cleanup_author_files(tmp_path):
     # set up some timestamps
     now = datetime.now()
-    time_format = "%Y%m%d"
+    time_format = "%Y-%m-%d"
     t1 = (now - timedelta(days=1)).strftime(time_format)
     t2 = (now - timedelta(days=40)).strftime(time_format)
 
     # set up some author paths
-    p0 = tmp_path / "authors.csv"
-    p1 = tmp_path / f"authors.csv.{t1}"
-    p2 = tmp_path / f"authors.csv.{t2}"
+    p0 = tmp_path / "authors.csv"  # the current one
+    p1 = tmp_path / f"authors.csv.{t1}"  # the recent one
+    p2 = tmp_path / f"authors.csv.{t2}"  # the far past
+
+    # set up some author paths
+    p3 = tmp_path / "authors_active.csv"  # the current one
+    p4 = tmp_path / f"authors_active.csv.{t1}"  # the recent one
+    p5 = tmp_path / f"authors_active.csv.{t2}"  # the far past
 
     # write some data to the files
     p0.open("w").write("test")
     p1.open("w").write("test")
     p2.open("w").write("test")
+    p3.open("w").write("test")
+    p4.open("w").write("test")
+    p5.open("w").write("test")
 
     # do the cleanup!
     cleanup_author_files(30, tmp_path)
 
-    # the 40 day old file should be gone but the others are still there
+    # the 40 day old files should be gone but the others are still there
     assert p0.is_file()
     assert p1.is_file()
     assert not p2.is_file()
+    assert p3.is_file()
+    assert p4.is_file()
+    assert not p5.is_file()

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -61,6 +61,31 @@ def test_create_database(
         teardown_database(snapshot.database_name)
 
 
+def test_drop_database(
+    snapshot,
+    mock_rialto_postgres,
+    monkeypatch,
+    teardown_database,
+):
+    try:
+        database.create_database(snapshot.database_name)
+
+        with null_pool_engine(snapshot.database_name).connect() as conn:
+            # Verify that the database exists and a connection was able to be made
+            assert conn
+
+        assert (database.database_exists(snapshot.database_name)) is True
+
+        database.drop_database(snapshot.database_name)
+
+        assert (database.database_exists(snapshot.database_name)) is False
+
+    finally:
+        # even if exception raised, tear down the database
+        if database.database_exists(snapshot.database_name):
+            teardown_database(snapshot.database_name)
+
+
 def test_create_schema(
     snapshot,
     mock_rialto_postgres,

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -50,6 +50,9 @@ def test_create_database(
     monkeypatch,
     teardown_database,
 ):
+    if database.database_exists(snapshot.database_name):
+        database.drop_database(snapshot.database_name)
+
     try:
         database.create_database(snapshot.database_name)
 


### PR DESCRIPTION
A first strategy to avoid filling up the disk (see #318).  

Configure a set number of days and when this DAG is run it will remove any author files and snapshot folders older than this number of days.  Downside is: history is lost.

To do:
- [x] tests
- [x] do remove database task