### PR TITLE
simplify how we call mais api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,10 @@ jobs:
           AIRFLOW_TEST_GOOGLE_DRIVE_ID: ${{ secrets.AIRFLOW_TEST_GOOGLE_DRIVE_ID }}
           AIRFLOW_TEST_GOOGLE_SHEET_ID: ${{ secrets.AIRFLOW_TEST_GOOGLE_SHEET_ID }}
           AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: "google-cloud-platform://?keyfile_dict=${{ secrets.AIRFLOW_VAR_GOOGLE_SERVICE_ACCOUNT_JSON }}&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive%2Chttps%3A%2F%2Fwww.googleapis.com%2Fauth%2Fspreadsheets&project=sul-rialto&num_retries=5"
+          AIRFLOW_VAR_MAIS_TOKEN_URL: ${{ secrets.AIRFLOW_VAR_MAIS_TOKEN_URL }}
+          AIRFLOW_VAR_MAIS_BASE_URL: ${{ secrets.AIRFLOW_VAR_MAIS_BASE_URL }}
+          AIRFLOW_VAR_MAIS_CLIENT_ID: ${{ secrets.AIRFLOW_VAR_MAIS_CLIENT_ID }}
+          AIRFLOW_VAR_MAIS_SECRET: ${{ secrets.AIRFLOW_VAR_MAIS_SECRET }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
-markers = "mais_tests: Tests requiring MAIS access"
 addopts = "-v --cov --cov-report=html --cov-report=term --log-level INFO --log-file test.log"
 
 

--- a/rialto_airflow/dags/publish_orcid.py
+++ b/rialto_airflow/dags/publish_orcid.py
@@ -5,7 +5,6 @@ from airflow.decorators import dag, task
 from airflow.models import Variable
 
 from rialto_airflow.mais import (
-    get_token,
     current_orcid_users,
     get_orcid_stats,
 )
@@ -53,8 +52,9 @@ def publish_orcid():
         orcid_integration_sheet_id = google.get_file_id(
             google.orcid_dashboard_folder_id(), "orcid-integration-stats"
         )
-        access_token = get_token(mais_client_id, mais_client_secret, mais_token_url)
-        current_users = current_orcid_users(access_token, mais_base_url)
+        current_users = current_orcid_users(
+            mais_client_id, mais_client_secret, mais_token_url, mais_base_url
+        )
         orcid_stats = get_orcid_stats(current_users)
         logging.info(f"Adding orcid stats row to {orcid_integration_sheet_id}")
         google.append_rows_to_google_sheet(

--- a/rialto_airflow/mais.py
+++ b/rialto_airflow/mais.py
@@ -111,16 +111,11 @@ def fetch_orcid_users(
         if limit and len(orcid_users) >= limit:
             break
 
-        self_link = data.get("links", {}).get("self")
-        last_link = data.get("links", {}).get("last")
-        # if we have reached the last page, the self and last links will be the same
-        if self_link == last_link:
+        next_link = data.get("links", {}).get("next")
+        if not next_link:
             break
 
-        next_link = data.get("links", {}).get("next")
-        logger.info(f"Self: {self_link}, Last: {last_link}, Next: {next_link}")
-
-        url = f"{base_url}/orcid/v1{next_link}"  # Construct url using next link value
+        url = f"{base_url}/orcid/v1{next_link}"  # Construct url using next link value, and then loop again
 
     return orcid_users[:limit] if limit else orcid_users
 

--- a/rialto_airflow/mais.py
+++ b/rialto_airflow/mais.py
@@ -60,6 +60,11 @@ def get_response(access_token: str, url: str) -> dict[str, Any]:
     return response.json()
 
 
+def page_size() -> int:
+    """Returns the page size for the API request."""
+    return 100  # This is the max value from the API.
+
+
 def fetch_orcid_users(
     mais_client_id: str,
     mais_client_secret: str,
@@ -70,8 +75,7 @@ def fetch_orcid_users(
     """Fetches ORCID user records from the MAIS ORCID API, handling pagination."""
 
     orcid_users: list[ORCIDRecord] = []
-    per_page = 100  # This max value from the API.
-    url = f"{base_url}/orcid/v1/users?scope=ANY&page_number=1&page_size={per_page}"  # first page url
+    url = f"{base_url}/orcid/v1/users?scope=ANY&page_number=1&page_size={page_size()}"  # first page url
     access_token = get_token(mais_client_id, mais_client_secret, mais_token_url)
 
     while True:  # paging

--- a/rialto_airflow/mais.py
+++ b/rialto_airflow/mais.py
@@ -61,13 +61,19 @@ def get_response(access_token: str, url: str) -> dict[str, Any]:
 
 
 def fetch_orcid_users(
-    access_token: str, base_url: str, path: str, limit: Optional[int] = None
+    mais_client_id: str,
+    mais_client_secret: str,
+    mais_token_url: str,
+    base_url: str,
+    path: str,
+    limit: Optional[int] = None,
 ) -> list[ORCIDRecord]:
     """Fetches ORCID user records from the MAIS ORCID API, handling pagination."""
 
     orcid_users: list[ORCIDRecord] = []
     per_page = 100  # This max value from the API.
     url = f"{base_url}/orcid/v1{path}&page_number=1&page_size={per_page}"  # first page url
+    access_token = get_token(mais_client_id, mais_client_secret, mais_token_url)
 
     while True:
         logger.info(f"Fetching {url}")
@@ -99,13 +105,17 @@ def fetch_orcid_user(access_token: str, base_url: str, user_id: str) -> ORCIDRec
     return get_response(access_token, f"{base_url}/orcid/v1/users/{cleaned_id}")
 
 
-def current_orcid_users(access_token: str, base_url: str) -> list[ORCIDRecord]:
+def current_orcid_users(
+    mais_client_id: str, mais_client_secret: str, mais_token_url: str, base_url: str
+) -> list[ORCIDRecord]:
     """Retrieves the current ORCID records from the MAIS ORCID API."""
 
     if base_url is None:
         raise ValueError("AIRFLOW_VAR_MAIS_BASE_URL is a required value")
 
-    all_users = fetch_orcid_users(access_token, base_url, "/users?scope=ANY")
+    all_users = fetch_orcid_users(
+        mais_client_id, mais_client_secret, mais_token_url, base_url, "/users?scope=ANY"
+    )
 
     # Create a dictionary to store the most recent record for each ORCID iD
     current_users_by_orcid: dict[str, ORCIDRecord] = {}

--- a/test/test_mais.py
+++ b/test/test_mais.py
@@ -1,3 +1,4 @@
+import dotenv
 import os
 import pytest
 import requests
@@ -8,6 +9,8 @@ from rialto_airflow import mais
 
 ORCIDRecord = dict[str, Any]
 ORCIDStats = list[Union[str, int, float]]
+
+dotenv.load_dotenv()
 
 
 @pytest.fixture(scope="module")

--- a/test/test_mais.py
+++ b/test/test_mais.py
@@ -62,10 +62,9 @@ def test_get_token_failure(token_url, client_id, client_secret):
 def test_get_response_success(access_token, base_url, client_id, client_secret):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
-    test_url = f"{base_url}/orcid/v1/users"
-    params = {"page": 1, "per_page": 1}
+    test_url = f"{base_url}/orcid/v1/users?scope=ANY&page_number=1&page_size=100"
     try:
-        response_data = mais.get_response(access_token, test_url, params=params)
+        response_data = mais.get_response(access_token, test_url)
         assert isinstance(response_data, dict)
         assert "results" in response_data
         assert isinstance(response_data["results"], list)

--- a/test/test_mais.py
+++ b/test/test_mais.py
@@ -76,25 +76,27 @@ def test_get_response_success(access_token, base_url, client_id, client_secret):
 
 
 @pytest.mark.mais_tests
-def test_fetch_orcid_users_with_limit(access_token, base_url, client_id, client_secret):
+def test_fetch_orcid_users_with_limit(client_id, client_secret, token_url, base_url):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
     path = "/users?scope=ANY"
     limit = 5
-    users = mais.fetch_orcid_users(access_token, base_url, path, limit=limit)
+    users = mais.fetch_orcid_users(
+        client_id, client_secret, token_url, base_url, path, limit=limit
+    )
     assert isinstance(users, list)
     assert len(users) == limit
 
 
 @pytest.mark.mais_tests
-def test_fetch_orcid_users_invalid_path(
-    access_token, base_url, client_id, client_secret
-):
+def test_fetch_orcid_users_invalid_path(client_id, client_secret, token_url, base_url):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
     invalid_path = "/invalid_path"
     with pytest.raises(requests.exceptions.HTTPError):
-        mais.fetch_orcid_users(access_token, base_url, invalid_path)
+        mais.fetch_orcid_users(
+            client_id, client_secret, token_url, base_url, invalid_path
+        )
 
 
 @pytest.mark.mais_tests
@@ -107,10 +109,12 @@ def test_fetch_orcid_user_valid_id(access_token, base_url, client_id, client_sec
 
 
 @pytest.mark.mais_tests
-def test_current_orcid_users(access_token, base_url, client_id, client_secret):
+def test_current_orcid_users(client_id, client_secret, token_url, base_url):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
-    current_users = mais.current_orcid_users(access_token, base_url)
+    current_users = mais.current_orcid_users(
+        client_id, client_secret, token_url, base_url
+    )
     assert isinstance(current_users, list)
     assert len(current_users) > 0
     seen_orcids = set()

--- a/test/test_mais.py
+++ b/test/test_mais.py
@@ -97,9 +97,14 @@ def test_fetch_orcid_user_valid_id(access_token, base_url, client_id, client_sec
 
 
 @pytest.mark.mais_tests
-def test_current_orcid_users(client_id, client_secret, token_url, base_url):
+def test_current_orcid_users(
+    client_id, client_secret, token_url, base_url, monkeypatch
+):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
+    monkeypatch.setattr(
+        mais, "page_size", lambda *args: 5
+    )  # monkey patch a smaller page size so we can hit the paging code in UAT
     current_users = mais.current_orcid_users(
         client_id, client_secret, token_url, base_url
     )

--- a/test/test_mais.py
+++ b/test/test_mais.py
@@ -40,7 +40,6 @@ def access_token(client_id, client_secret, token_url):
     return mais.get_token(client_id, client_secret, token_url)
 
 
-@pytest.mark.mais_tests
 def test_get_token_success(token_url, client_id, client_secret):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
@@ -50,7 +49,6 @@ def test_get_token_success(token_url, client_id, client_secret):
     assert len(token) > 0
 
 
-@pytest.mark.mais_tests
 def test_get_token_failure(token_url, client_id, client_secret):
     # It's true, this test specifically doesn't use a valid client_id or client_secret, but
     # the presence of those values indicates we're able to reach the service in question (which
@@ -61,7 +59,6 @@ def test_get_token_failure(token_url, client_id, client_secret):
         mais.get_token("dummy_invalid_id", "dummy_invalid_secret", token_url)
 
 
-@pytest.mark.mais_tests
 def test_get_response_success(access_token, base_url, client_id, client_secret):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
@@ -75,7 +72,6 @@ def test_get_response_success(access_token, base_url, client_id, client_secret):
         pytest.fail(f"API request failed: {e}")
 
 
-@pytest.mark.mais_tests
 def test_fetch_orcid_users_with_limit(client_id, client_secret, token_url, base_url):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
@@ -87,7 +83,6 @@ def test_fetch_orcid_users_with_limit(client_id, client_secret, token_url, base_
     assert len(users) == limit
 
 
-@pytest.mark.mais_tests
 def test_fetch_orcid_user_valid_id(access_token, base_url, client_id, client_secret):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
@@ -96,7 +91,6 @@ def test_fetch_orcid_user_valid_id(access_token, base_url, client_id, client_sec
     assert isinstance(user_data, dict)
 
 
-@pytest.mark.mais_tests
 def test_current_orcid_users(
     client_id, client_secret, token_url, base_url, monkeypatch
 ):
@@ -118,7 +112,6 @@ def test_current_orcid_users(
         seen_orcids.add(orcid_id)
 
 
-@pytest.mark.mais_tests
 def test_invalid_token_retry(
     client_id, client_secret, token_url, base_url, monkeypatch
 ):


### PR DESCRIPTION
1. The MaIS API uses a GET with simple URL params to make request.  We don't need that params hash.  This aligns it's usage with how we do it in the Ruby mais-orcid-client gem.
2. Move token generation into the method that does pagination, so we can more easily fetch a new token if we get a 401.
3. Add some extra logging of what the links are in the response so we can better see what the MaIS API is returning.
4. Fix an issue that was preventing the MaIS tests from running locally when credentials were available.
5. Retry to get a new token if one expires (three times)

Tested in localhost and via `uv run pytest test/test_mais.py` on my laptop where i have credentials for the MaIS API

Fixes #371