### PR TITLE
Handle sulpub visibility None

### DIFF
--- a/rialto_airflow/publish/data_quality.py
+++ b/rialto_airflow/publish/data_quality.py
@@ -91,13 +91,9 @@ def write_sulpub(snapshot: Snapshot) -> Path:
                 {
                     "doi": extract_doi(pub),
                     "year": pub.get("year"),
-                    "cap_profile_id": "|".join(
-                        [str(a["cap_profile_id"]) for a in pub["authorship"]]
-                    ),
-                    "status": "|".join([a["status"] for a in pub["authorship"]]),
-                    "visibility": "|".join(
-                        [a["visibility"] for a in pub["authorship"]]
-                    ),
+                    "cap_profile_id": _extract_authorship(pub, "cap_profile_id"),
+                    "status": _extract_authorship(pub, "status"),
+                    "visibility": _extract_authorship(pub, "visibility"),
                 }
             )
 
@@ -269,3 +265,20 @@ def _openalex_apc_paid(row: Row):
             JsonPathRule("openalex_json", "apc_paid.value_usd"),
         ],
     )
+
+
+def _extract_authorship(pub: dict, name: str) -> str:
+    """
+    Some status and visibility values are set to null in the JSON. Also some are
+    in all caps. This ensures that the string "none" is returned instead of
+    None, and also that the values are lowercased.
+    """
+    values = []
+
+    for author in pub["authorship"]:
+        if author.get(name) is not None:
+            values.append(str(author.get(name)).lower())
+        else:
+            values.append("none")
+
+    return "|".join(values)


### PR DESCRIPTION
It appears that visibility on some sulpub authorship-authors is not set
(None). This results in the publish data-quality step failing:

```
[2025-05-09, 11:52:26 UTC] {taskinstance.py:3311} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 767, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 733, in _execute_callable
    return ExecutionCallableRunner(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/operator_helpers.py", line 252, in run
    return self.func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/baseoperator.py", line 422, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/decorators/base.py", line 266, in execute
    return_value = super().execute(context)
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/baseoperator.py", line 422, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/operators/python.py", line 238, in execute
    return_value = self.execute_callable()
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/operators/python.py", line 256, in execute_callable
    return runner.run(*self.op_args, **self.op_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/operator_helpers.py", line 252, in run
    return self.func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/rialto_airflow/dags/harvest.py", line 183, in publish_data_quality
    data_quality.write_sulpub(snapshot)
  File "/opt/airflow/rialto_airflow/publish/data_quality.py", line 98, in write_sulpub
    "visibility": "|".join(
                  ^^^^^^^^^
TypeError: sequence item 0: expected str instance, NoneType found
```

This commit uses the string 'none' instead. Note: in researching this I
noticed that there are a small number where all caps are used (PUBLIC,
PRIVATE) so they are lowercased.
