### PR TITLE
[SQUASH-MERGE-PLS] Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,5 +2,3 @@
 
 # Roles are passed to docker-compose as profiles.
 server 'sul-rialto-airflow-prod.stanford.edu', user: 'rialto', roles: %w[app]
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,5 +2,3 @@
 
 # Roles are passed to docker-compose as profiles.
 server 'sul-rialto-airflow-stage.stanford.edu', user: 'rialto', roles: %w[app]
-
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.

Please squash-merge.