### PR TITLE
Use task groups

### DIFF
--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -175,8 +175,9 @@ def query_with_retry(q, retry=5):
                 time.sleep(try_count * 10)
 
 
-def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
+def fill_in(snapshot: Snapshot):
     """Harvest Dimensions data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "dimensions.jsonl"
     count = 0
     with jsonl_file.open("a") as jsonl_output:
         with get_session(snapshot.database_name).begin() as select_session:
@@ -211,4 +212,4 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
 
     logging.info(f"filled in {count} publications")
 
-    return snapshot.path
+    return jsonl_file

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -105,8 +105,9 @@ def orcid_publications(orcid: str) -> Generator[dict, None, None]:
         yield from page
 
 
-def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
+def fill_in(snapshot) -> Path:
     """Harvest OpenAlex data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "openalex.jsonl"
     count = 0
     with jsonl_file.open("a") as jsonl_output:
         with get_session(snapshot.database_name).begin() as select_session:
@@ -150,7 +151,7 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path) -> Path:
 
     logging.info(f"filled in {count} publications")
 
-    return snapshot.path
+    return jsonl_file
 
 
 def _clean_dois_for_query(dois: list[str]) -> list[str]:

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -79,8 +79,9 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
     return jsonl_file
 
 
-def fill_in(snapshot: Snapshot, jsonl_file: Path):
+def fill_in(snapshot: Snapshot):
     """Harvest WebOfScience data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "wos.jsonl"
     count = 0
     with jsonl_file.open("a") as jsonl_output:
         with get_session(snapshot.database_name).begin() as select_session:
@@ -114,7 +115,7 @@ def fill_in(snapshot: Snapshot, jsonl_file: Path):
 
     logging.info(f"filled in {count} publications")
 
-    return snapshot.path
+    return jsonl_file
 
 
 def orcid_publications(orcid) -> Generator[dict, None, None]:

--- a/test/harvest/test_dimensions.py
+++ b/test/harvest/test_dimensions.py
@@ -215,7 +215,7 @@ def test_fill_in(
     jsonl_file = snapshot.path / "dimensions.jsonl"
     mock_jsonl(jsonl_file)
 
-    dimensions.fill_in(snapshot, jsonl_file)
+    dimensions.fill_in(snapshot)
 
     with test_session.begin() as session:
         pub = (
@@ -255,7 +255,7 @@ def test_fill_in_no_dimensions(
     mock_jsonl(jsonl_file)
     assert num_jsonl_objects(snapshot.path / "dimensions.jsonl") == 2
 
-    dimensions.fill_in(snapshot, jsonl_file)
+    dimensions.fill_in(snapshot)
     with test_session.begin() as session:
         pub = (
             session.query(Publication)
@@ -323,7 +323,7 @@ def test_fill_in_no_doi(
     mock_jsonl(jsonl_file)
     assert num_jsonl_objects(snapshot.path / "dimensions.jsonl") == 2
 
-    dimensions.fill_in(snapshot, jsonl_file)
+    dimensions.fill_in(snapshot)
 
     with test_session.begin() as session:
         pub = (

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -189,7 +189,7 @@ def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
     jsonl_file = snapshot.path / "openalex.jsonl"
     mock_jsonl(jsonl_file)
 
-    openalex.fill_in(snapshot, jsonl_file)
+    openalex.fill_in(snapshot)
 
     with test_session.begin() as session:
         pub = (
@@ -220,7 +220,7 @@ def test_fill_in_no_openalex(
     jsonl_file = snapshot.path / "openalex.jsonl"
     mock_jsonl(jsonl_file)
 
-    openalex.fill_in(snapshot, jsonl_file)
+    openalex.fill_in(snapshot)
 
     with test_session.begin() as session:
         pub = (
@@ -249,7 +249,7 @@ def test_fill_in_no_doi(test_session, mock_publication, snapshot, caplog, monkey
     jsonl_file = snapshot.path / "openalex.jsonl"
     mock_jsonl(jsonl_file)
 
-    openalex.fill_in(snapshot, jsonl_file)
+    openalex.fill_in(snapshot)
 
     with test_session.begin() as session:
         pub = (

--- a/test/harvest/test_wos.py
+++ b/test/harvest/test_wos.py
@@ -377,7 +377,7 @@ def test_fill_in(snapshot, test_session, mock_no_wos_publication, mock_wos_doi, 
     jsonl_file = snapshot.path / "wos.jsonl"
     mock_jsonl(jsonl_file)
 
-    wos.fill_in(snapshot, jsonl_file)
+    wos.fill_in(snapshot)
 
     with test_session.begin() as session:
         pub = (
@@ -415,7 +415,7 @@ def test_fill_in_no_wos(
     mock_jsonl(jsonl_file)
     assert num_jsonl_objects(snapshot.path / "wos.jsonl") == 2
 
-    wos.fill_in(snapshot, jsonl_file)
+    wos.fill_in(snapshot)
     with test_session.begin() as session:
         pub = (
             session.query(Publication)


### PR DESCRIPTION
Group the Airflow tasks into task groups to make the workflow graph display a bit easier to understand. This also simplifies how the workflow dependencies are expressed in code, which seems like a big improvement.

Currently the workflow graph looks like:

![Screenshot 2025-05-10 at 7 37 31 AM](https://github.com/user-attachments/assets/8faabc1f-00f0-4142-a4b2-e245e6e90cf9)

WIth task groups it looks like the below screenshot. All the task steps are dependent on the initial setup task which creates the snapshot directory and database; so the graph apparently can't be expressed as a simple linear line.

![Screenshot 2025-05-10 at 7 27 01 AM](https://github.com/user-attachments/assets/13d282e8-6482-4353-b57c-2a1e79241473)

You can expand different task groups (the blue boxes) to see the tasks they contain:

![Screenshot 2025-05-10 at 7 27 12 AM](https://github.com/user-attachments/assets/4581791c-c78b-4857-9146-a8e8530c8b34)

![Screenshot 2025-05-10 at 7 27 18 AM](https://github.com/user-attachments/assets/f13ab69f-7e10-40ef-8e9c-400a5f58dc8a)


Closes #213
