### PR TITLE
add pubmed fill_in task and tests

### DIFF
--- a/rialto_airflow/.codecov.yml
+++ b/rialto_airflow/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1
+    patch:
+      default:
+        target: 80%

--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -158,11 +158,19 @@ def harvest():
         """
         wos.fill_in(snapshot)
 
+    @task()
+    def fill_in_pubmed(snapshot):
+        """
+        Fill in Pubmed data for DOIs from other publication sources.
+        """
+        pubmed.fill_in(snapshot)
+
     @task_group()
     def fill_in(snapshot):
         fill_in_openalex(snapshot)
         fill_in_dimensions(snapshot)
         fill_in_wos(snapshot)
+        fill_in_pubmed(snapshot)
 
     @task()
     def distill_publications(snapshot):

--- a/rialto_airflow/harvest/pubmed.py
+++ b/rialto_airflow/harvest/pubmed.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 from pathlib import Path
+import time
 
 import requests
 import xmltodict
@@ -153,9 +154,17 @@ def pmids_from_dois(dois: list[str]) -> list[str]:
     Returns PMIDs associated with given list of DOIs.
     """
 
-    query = " OR ".join([f'"{s}"' for s in dois])
+    # Note that we need to do these one by one, since Pubmed doesn't support searching for multiple DOIs
+    pmids = []
+    for doi in dois:
+        # look up the PMID given a DOI
+        pmid_results = _pubmed_search_api(f"{doi}")
+        # assuming we get one result, this is probably the PMID we want
+        if len(pmid_results) == 1:
+            pmids.append(pmid_results[0])
+        time.sleep(0.5)  # add a small delay to avoid hitting the API too hard
 
-    return _pubmed_search_api(f"{query}")
+    return pmids
 
 
 def publications_from_pmids(pmids: list[str]) -> list[str]:

--- a/rialto_airflow/harvest/pubmed.py
+++ b/rialto_airflow/harvest/pubmed.py
@@ -158,7 +158,7 @@ def pmids_from_dois(dois: list[str]) -> list[str]:
     pmids = []
     for doi in dois:
         # look up the PMID given a DOI
-        pmid_results = _pubmed_search_api(f"{doi}")
+        pmid_results = _pubmed_search_api(doi)
         # assuming we get one result, this is probably the PMID we want
         if len(pmid_results) == 1:
             pmids.append(pmid_results[0])

--- a/test/harvest/test_pubmed.py
+++ b/test/harvest/test_pubmed.py
@@ -55,13 +55,6 @@ def mock_jsonl(path):
         {
             "MedlineCitation": {
                 "Article": {
-                    "ELocationID": [
-                        {
-                            "@EIdType": "doi",
-                            "@ValidYN": "Y",
-                            "#text": "10.1182/bloodadvances.2022008893",
-                        }
-                    ],
                     "ArticleTitle": "Example Title",
                 },
             },
@@ -69,9 +62,7 @@ def mock_jsonl(path):
                 "ArticleIdList": {
                     "ArticleId": [
                         {"@IdType": "pubmed", "#text": "36857419"},
-                        {"@IdType": "pmc", "#text": "PMC10275701"},
                         {"@IdType": "doi", "#text": "10.1182/bloodadvances.2022008893"},
-                        {"@IdType": "pii", "#text": "494746"},
                     ]
                 },
             },
@@ -79,13 +70,6 @@ def mock_jsonl(path):
         {
             "MedlineCitation": {
                 "Article": {
-                    "ELocationID": [
-                        {
-                            "@EIdType": "doi",
-                            "@ValidYN": "Y",
-                            "#text": "10.1021/ac1028984",
-                        }
-                    ],
                     "ArticleTitle": "Another Article Title",
                 },
             },
@@ -93,7 +77,6 @@ def mock_jsonl(path):
                 "ArticleIdList": {
                     "ArticleId": [
                         {"@IdType": "pubmed", "#text": "21302935"},
-                        {"@IdType": "pmc", "#text": "PMC21302935"},
                         {"@IdType": "doi", "#text": "10.1021/ac1028984"},
                     ]
                 },
@@ -441,18 +424,7 @@ def test_get_doi():
     }
     assert pubmed.get_doi(pubmed_json_single_id) == "10.1182/bloodadvances.2022008893"
 
-    pubmed_json_no_doi = {
-        "PubmedData": {
-            "ArticleIdList": {
-                "ArticleId": [
-                    {"@IdType": "pubmed", "#text": "36857419"},
-                    {"@IdType": "pmc", "#text": "PMC10275701"},
-                    {"@IdType": "pii", "#text": "494746"},
-                ]
-            },
-        }
-    }
-    assert pubmed.get_doi(pubmed_json_no_doi) is None
+    assert pubmed.get_doi(pubmed_json_no_doi()) is None
 
     pubmed_json_no_ids = {
         "PubmedData": {

--- a/test/harvest/test_pubmed.py
+++ b/test/harvest/test_pubmed.py
@@ -210,7 +210,7 @@ def test_pubmed_search_dois_found_publications():
     # These DOIs should both return PMIDs
     dois = ["10.1118/1.598623", "10.3899/jrheum.220960"]
     pmids = pubmed.pmids_from_dois(dois)
-    assert pmids == ["36243410", "10435530"], "found both publications"
+    assert pmids == ["10435530", "36243410"], "found both publications"
 
 
 def test_pubmed_search_dois_found_one_publication():

--- a/test/harvest/test_pubmed.py
+++ b/test/harvest/test_pubmed.py
@@ -1,5 +1,8 @@
-import dotenv
+import json
+import logging
 import pytest
+
+import dotenv
 
 from rialto_airflow.database import Publication
 from rialto_airflow.harvest import pubmed
@@ -44,11 +47,85 @@ def existing_publication(test_session):
         return pub
 
 
+def mock_jsonl(path):
+    """
+    Mock the existing jsonl file for Pubmed
+    """
+    records = [
+        {
+            "MedlineCitation": {
+                "Article": {
+                    "ELocationID": [
+                        {
+                            "@EIdType": "doi",
+                            "@ValidYN": "Y",
+                            "#text": "10.1182/bloodadvances.2022008893",
+                        }
+                    ],
+                    "ArticleTitle": "Example Title",
+                },
+            },
+            "PubmedData": {
+                "ArticleIdList": {
+                    "ArticleId": [
+                        {"@IdType": "pubmed", "#text": "36857419"},
+                        {"@IdType": "pmc", "#text": "PMC10275701"},
+                        {"@IdType": "doi", "#text": "10.1182/bloodadvances.2022008893"},
+                        {"@IdType": "pii", "#text": "494746"},
+                    ]
+                },
+            },
+        },
+        {
+            "MedlineCitation": {
+                "Article": {
+                    "ELocationID": [
+                        {
+                            "@EIdType": "doi",
+                            "@ValidYN": "Y",
+                            "#text": "10.1021/ac1028984",
+                        }
+                    ],
+                    "ArticleTitle": "Another Article Title",
+                },
+            },
+            "PubmedData": {
+                "ArticleIdList": {
+                    "ArticleId": [
+                        {"@IdType": "pubmed", "#text": "21302935"},
+                        {"@IdType": "pmc", "#text": "PMC21302935"},
+                        {"@IdType": "doi", "#text": "10.1021/ac1028984"},
+                    ]
+                },
+            },
+        },
+    ]
+    with open(path, "w") as f:
+        for record in records:
+            f.write(f"{json.dumps(record)}\n")
+
+
+def jsonl_file(path):
+    return path / "pubmed.jsonl"
+
+
 def pubmed_json():
     """
     A partial Pubmed JSON object with a DOI and some other IDs.
     """
     return {
+        "MedlineCitation": {
+            "Article": {
+                "ELocationID": [
+                    {
+                        "@EIdType": "doi",
+                        "@ValidYN": "Y",
+                        "#text": "10.1021/ac1028984",
+                    }
+                ],
+                "ArticleTitle": "Another Article Title",
+            },
+        },
         "PubmedData": {
             "ArticleIdList": {
                 "ArticleId": [
@@ -58,11 +135,54 @@ def pubmed_json():
                     {"@IdType": "pii", "#text": "494746"},
                 ]
             },
-        }
+        },
     }
 
 
-def test_pubmed_search_found_publications():
+def pubmed_json_no_doi():
+    """
+    A partial Pubmed JSON object without a DOI.
+    """
+    return {
+        "MedlineCitation": {
+            "Article": {
+                "ArticleTitle": "Another Article Title",
+            },
+        },
+        "PubmedData": {
+            "ArticleIdList": {
+                "ArticleId": [
+                    {"@IdType": "pubmed", "#text": "36857419"},
+                    {"@IdType": "pmc", "#text": "PMC10275701"},
+                    {"@IdType": "pii", "#text": "494746"},
+                ]
+            },
+        },
+    }
+
+
+def pubmed_json_fill_in_doi():
+    """
+    A partial Pubmed JSON object with a DOI.
+    """
+    return {
+        "MedlineCitation": {
+            "Article": {
+                "ArticleTitle": "Another Article Title To Be Filled In",
+            },
+        },
+        "PubmedData": {
+            "ArticleIdList": {
+                "ArticleId": [
+                    {"@IdType": "pubmed", "#text": "12345"},
+                    {"@IdType": "doi", "#text": "10.1515/9781503624153"},
+                ]
+            },
+        },
+    }
+
+
+def test_pubmed_search_orcid_found_publications():
     """
     This is a live test of the Pubmed Search API to ensure we can get PMIDs back given an ORCID.
     """
@@ -73,13 +193,43 @@ def test_pubmed_search_found_publications():
     assert "29035265" in pmids, "found an expected publication for this author"
 
 
-def test_pubmed_search_no_publications():
+def test_pubmed_search_orcid_no_publications():
     """
     This is a live test of the Pubmed Search API to ensure no results are returned for an ORCID with no publications.
     """
     # No publications should be found for this ORCID
     orcid = "5555-5555-5555-5555"
     pmids = pubmed.pmids_from_orcid(orcid)
+    assert len(pmids) == 0, "found no publications"
+
+
+def test_pubmed_search_dois_found_publications():
+    """
+    This is a live test of the Pubmed Search API to ensure we can get PMIDs back given two DOIs.
+    """
+    # These DOIs should both return PMIDs
+    dois = ["10.1118/1.598623", "10.3899/jrheum.220960"]
+    pmids = pubmed.pmids_from_dois(dois)
+    assert pmids == ["36243410", "10435530"], "found both publications"
+
+
+def test_pubmed_search_dois_found_one_publication():
+    """
+    This is a live test of the Pubmed Search API to ensure we can get PMIDs back a single DOIs.
+    """
+    # These DOIs should both return PMIDs
+    dois = ["10.1021/ac1028984"]
+    pmids = pubmed.pmids_from_dois(dois)
+    assert pmids == ["21302935"], "found single publication"
+
+
+def test_pubmed_search_dois_no_publications():
+    """
+    This is a live test of the Pubmed Search API to ensure no results are returned for DOIs with no publications.
+    """
+    # No publications should be found for these dois
+    dois = ["bogus-doi-1", "bogus-doi-2"]
+    pmids = pubmed.pmids_from_dois(dois)
     assert len(pmids) == 0, "found no publications"
 
 
@@ -134,7 +284,7 @@ def test_harvest(
     pubmed.harvest(snapshot)
 
     # the mocked Pubmed api returns the same two publications for both authors
-    assert num_jsonl_objects(snapshot.path / "pubmed.jsonl") == 4
+    assert num_jsonl_objects(jsonl_file(snapshot.path)) == 4
 
     # make sure a publication is in the database and linked to the author
     with test_session.begin() as session:
@@ -165,7 +315,7 @@ def test_harvest_when_doi_exists(
     pubmed.harvest(snapshot)
 
     # jsonl file is there and has four lines (two pubs for each author)
-    assert num_jsonl_objects(snapshot.path / "pubmed.jsonl") == 4
+    assert num_jsonl_objects(jsonl_file(snapshot.path)) == 4
 
     # ensure that the existing publication for the DOI was updated
     with test_session.begin() as session:
@@ -179,6 +329,101 @@ def test_harvest_when_doi_exists(
         assert len(pub.authors) == 2, "publication has two authors"
         assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
         assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+
+    # mock pubmed api to return a PMID for the fake DOI
+    monkeypatch.setattr(pubmed, "pmids_from_dois", lambda *args, **kwargs: ["12345"])
+
+    # mock pubmed api to return a record for this PMID
+    monkeypatch.setattr(
+        pubmed,
+        "publications_from_pmids",
+        lambda *args, **kwargs: [pubmed_json_fill_in_doi()],
+    )
+
+    # set up a pre-existing jsonl file
+    mock_jsonl(jsonl_file(snapshot.path))
+
+    pubmed.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.pubmed_json == pubmed_json_fill_in_doi()
+
+    # adds 1 publication to the jsonl file
+    assert num_jsonl_objects(jsonl_file(snapshot.path)) == 3
+    assert "filled in 1 publications" in caplog.text
+
+
+def test_fill_in_no_pubmed(
+    test_session, mock_publication, snapshot, caplog, monkeypatch
+):
+    caplog.set_level(logging.INFO)
+
+    # mock pubmed api to return no records for the doi
+    monkeypatch.setattr(pubmed, "pmids_from_dois", lambda *args, **kwargs: [])
+
+    # set up a pre-existing jsonl file
+    mock_jsonl(jsonl_file(snapshot.path))
+
+    pubmed.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.pubmed_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(jsonl_file(snapshot.path)) == 2
+    assert "filled in 0 publications" in caplog.text
+
+
+def test_fill_in_no_doi(test_session, mock_publication, snapshot, caplog, monkeypatch):
+    """
+    Test that a publication coming back from Pubmed without DOI doesn't
+    cause an exception.
+    """
+
+    # mock pubmed api to return a PMID for the fake DOI
+    monkeypatch.setattr(pubmed, "pmids_from_dois", lambda *args, **kwargs: ["12345"])
+
+    # mock pubmed api to return a record for this PMID, but without a DOI
+    monkeypatch.setattr(
+        pubmed,
+        "publications_from_pmids",
+        lambda *args, **kwargs: [pubmed_json_no_doi()],
+    )
+
+    caplog.set_level(logging.INFO)
+
+    # set up a pre-existing jsonl file
+    mock_jsonl(jsonl_file(snapshot.path))
+    assert num_jsonl_objects(jsonl_file(snapshot.path)) == 2
+
+    pubmed.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.pubmed_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(jsonl_file(snapshot.path)) == 2
+    assert "unable to determine what DOI to update" in caplog.text
+    assert "filled in 0 publications" in caplog.text
 
 
 def test_get_doi():

--- a/test/test_google.py
+++ b/test/test_google.py
@@ -166,7 +166,7 @@ def test_replace_file_in_google_drive():
     google.upload_file_to_google_drive("test/data/authors.csv", google_drive_id())
 
     # give it some time to upload to google before checking it exists
-    time.sleep(4)
+    time.sleep(12)
 
     # Get the file ID of the uploaded file and ensure it exists
     file_id = google.get_file_id(google_drive_id(), "authors.csv")


### PR DESCRIPTION
Fixes #202, add Pubmed fill in task and tests.

Also, add a custom codecov.yml file

~~HOLD: need to verify the pubmed search by DOI works as expected.~~

~~When running on my laptop, the search for 50 DOIs yielded way too many PMIDs, suggesting it didn't work as expected.~~  Searching for DOIs one by one seems to work better.