### PR TITLE
see if we can get docker to build on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -49,7 +49,7 @@ set :docker_compose_file, 'compose.prod.yaml'
 set :docker_compose_migrate_use_hooks, false
 set :docker_compose_seed_use_hooks, false
 set :docker_compose_rabbitmq_use_hooks, false
-set :docker_compose_build_use_hooks, false
+set :docker_compose_build_use_hooks, true
 set :docker_compose_restart_use_hooks, true
 set :docker_compose_copy_assets_use_hooks, false
 set :honeybadger_use_hooks, false


### PR DESCRIPTION
Maybe deals with #402 ? 

 1. Looked at https://github.com/sul-dlss/dlss-capistrano-docker
 2. Tried changing this setting
 3. Deployed the app and saw it building the docker container before bringing it up
 4. Tried adding a new dependency and importing it in harvest dag and deploying
 5. All worked, so maybe ok?