### PR TITLE
send email notifications on task failures

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -109,7 +109,7 @@ x-airflow-common:
     AIRFLOW_VAR_HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY}
     AIRFLOW_VAR_HONEYBADGER_ENV: ${HONEYBADGER_ENV}
     AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 30
-    AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS: rialto-team@lists.stanford.edu
+    AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS: ${AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS}
   volumes:
     - /opt/app/rialto/rialto-airflow/current/rialto_airflow:/opt/airflow/rialto_airflow
     - /rialto-data:/opt/airflow/data

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -109,6 +109,7 @@ x-airflow-common:
     AIRFLOW_VAR_HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY}
     AIRFLOW_VAR_HONEYBADGER_ENV: ${HONEYBADGER_ENV}
     AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 30
+    AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS: rialto-team@lists.stanford.edu
   volumes:
     - /opt/app/rialto/rialto-airflow/current/rialto_airflow:/opt/airflow/rialto_airflow
     - /rialto-data:/opt/airflow/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -102,7 +102,7 @@ x-airflow-common:
     AIRFLOW_VAR_HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY}
     AIRFLOW_VAR_HONEYBADGER_ENV: ${HONEYBADGER_ENV}
     AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 10
-    AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS: rialto-team@lists.stanford.edu
+    AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS: ''
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/rialto_airflow:/opt/airflow/rialto_airflow
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs

--- a/compose.yaml
+++ b/compose.yaml
@@ -102,6 +102,7 @@ x-airflow-common:
     AIRFLOW_VAR_HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY}
     AIRFLOW_VAR_HONEYBADGER_ENV: ${HONEYBADGER_ENV}
     AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 10
+    AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS: rialto-team@lists.stanford.edu
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/rialto_airflow:/opt/airflow/rialto_airflow
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs

--- a/rialto_airflow/dags/cleanup.py
+++ b/rialto_airflow/dags/cleanup.py
@@ -3,6 +3,7 @@ import logging
 
 from airflow.models import Variable
 from airflow.decorators import dag, task
+from rialto_airflow.honeybadger import default_args
 from rialto_airflow.cleanup import (
     cleanup_author_files,
     cleanup_snapshots,
@@ -17,6 +18,7 @@ cleanup_interval_days = int(Variable.get("cleanup_interval_days"))
     max_active_runs=1,
     start_date=datetime.datetime(2024, 1, 1),
     catchup=False,
+    default_args=default_args(),
 )
 def cleanup():
     @task

--- a/rialto_airflow/dags/publish_orcid.py
+++ b/rialto_airflow/dags/publish_orcid.py
@@ -3,6 +3,7 @@ import logging
 
 from airflow.decorators import dag, task
 from airflow.models import Variable
+from rialto_airflow.honeybadger import default_args
 
 from rialto_airflow.mais import (
     current_orcid_users,
@@ -26,6 +27,7 @@ gcp_conn_id = Variable.get("google_connection")
     max_active_runs=1,
     start_date=datetime.datetime(2024, 1, 1),
     catchup=False,
+    default_args=default_args(),
 )
 def publish_orcid():
     @task

--- a/rialto_airflow/honeybadger.py
+++ b/rialto_airflow/honeybadger.py
@@ -1,0 +1,28 @@
+from honeybadger import honeybadger  # type: ignore
+from airflow.models import Variable
+import logging
+
+honeybadger.configure(
+    api_key=Variable.get("honeybadger_api_key"),
+    environment=Variable.get("honeybadger_env"),
+    force_sync=True,
+)  # type: ignore
+
+
+def task_failure_notify(context):
+    task = context["task"].task_id
+    logging.error(f"Task {task} failed.")
+    honeybadger.notify(
+        error_class="Task failure",
+        error_message=f"Task {task} failed in {context.get('task_instance_key_str')}",
+        context=context,
+    )
+
+
+def default_args():
+    return {
+        "email": [Variable.get("email_address_for_errors")],
+        "on_failure_callback": task_failure_notify,
+        "email_on_failure": True,
+        "email_on_retry": False,
+    }


### PR DESCRIPTION
Send email notification and HB alert on any task failure in any DAG.

Fixes #383 

Needs to be tested.

Goes with https://github.com/sul-dlss/puppet/pull/12427 and https://github.com/sul-dlss/puppet/pull/12429