### PR TITLE
make this warning less chatty

### DIFF
--- a/rialto_airflow/publish/publication_utils.py
+++ b/rialto_airflow/publish/publication_utils.py
@@ -131,13 +131,15 @@ def _openalex_pages(openalex_json):
 
 
 def _wos_pages(wos_json):
-    if not wos_json:
+    if not wos_json or not wos_json.get("static_data", {}).get("summary", {}).get(
+        "pub_info", {}
+    ).get("page", {}):
         return None
 
     try:
         return f"{wos_json['static_data']['summary']['pub_info']['page']['begin']}-{wos_json['static_data']['summary']['pub_info']['page']['end']}"
     except KeyError:
-        logging.warning("[mesh] WOS JSON does not contain pages")
+        logging.warning("[pages] WOS JSON does not contain page begin/end")
         return None
 
 


### PR DESCRIPTION
This will make the logs a bit less noisy when pulling pages from WoS as it will only be triggered when we have some kind of page info in the JSON, just not the begin/end.  We may not even want this log message anymore at all.  I verified (via a temporary log message) that page info IS available from WoS in the begin/end keys quite often, so geting a warrning that it is not there may not be useful