### PR TITLE
Join Funders table

### DIFF
--- a/rialto_airflow/distiller.py
+++ b/rialto_airflow/distiller.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from functools import cache
 from dataclasses import dataclass
 from typing import Callable, Optional
 
@@ -119,7 +120,7 @@ def first(pub: Row, rules: list[Rule]) -> Optional[str | int]:
 
 
 def _jsonpath_match(rule: JsonPathRule, data) -> Optional[str | int]:
-    jpath = jsonpath_ng.parse(rule.matcher)
+    jpath = _json_path(rule.matcher)
     results = jpath.find(data)
 
     if len(results) > 0:
@@ -168,3 +169,8 @@ def _func_match(rule: FuncRule, data: dict) -> Optional[str | int]:
         result = rule.matcher(data)
 
     return result
+
+
+@cache
+def _json_path(path):
+    return jsonpath_ng.parse(path)

--- a/rialto_airflow/publish/publication_utils.py
+++ b/rialto_airflow/publish/publication_utils.py
@@ -26,11 +26,12 @@ def _openalex_journal(openalex_json):
     try:
         primary_location = openalex_json["primary_location"]
         if (
-            primary_location.get("source")
+            primary_location is not None
+            and primary_location.get("source")
             and primary_location["source"]["type"] == "journal"
         ):
             return primary_location["source"]["display_name"]
-    except KeyError:
+    except (KeyError, TypeError):
         logging.warning("[title] OpenAlex JSON does not contain primary location")
         return None
 
@@ -45,7 +46,7 @@ def _wos_journal(wos_json):
         for title in wos_json["static_data"]["summary"]["titles"]["title"]:
             if title.get("type") and title["type"] == "source":
                 return title["content"]
-    except KeyError:
+    except (KeyError, TypeError):
         logging.warning("[title] WOS JSON does not contain journal title")
         return None
 
@@ -86,7 +87,7 @@ def _dim_mesh(dim_json):
 
     try:
         return "|".join(list(map(lambda x: x, dim_json["mesh_terms"])))
-    except KeyError:
+    except (KeyError, TypeError):
         logging.warning("[mesh] Dimensions JSON does not contain mesh terms")
         return None
 
@@ -99,7 +100,7 @@ def _openalex_mesh(openalex_json):
         return "|".join(
             list(map(lambda x: x["descriptor_name"], openalex_json["mesh"]))
         )
-    except KeyError:
+    except (KeyError, TypeError):
         logging.warning("[mesh] OpenAlex JSON does not contain mesh terms")
         return None
 
@@ -125,7 +126,7 @@ def _openalex_pages(openalex_json):
 
     try:
         return f"{openalex_json['biblio']['first_page']}-{openalex_json['biblio']['last_page']}"
-    except KeyError:
+    except (KeyError, TypeError):
         logging.warning("[pages] OpenAlex JSON does not contain pages")
         return None
 
@@ -138,7 +139,7 @@ def _wos_pages(wos_json):
 
     try:
         return f"{wos_json['static_data']['summary']['pub_info']['page']['begin']}-{wos_json['static_data']['summary']['pub_info']['page']['end']}"
-    except KeyError:
+    except (KeyError, TypeError):
         logging.warning("[pages] WOS JSON does not contain page begin/end")
         return None
 
@@ -174,9 +175,10 @@ def _wos_pmid(wos_json):
         for identifier in wos_json["dynamic_data"]["cluster_related"]["identifiers"][
             "identifier"
         ]:
-            if identifier["type"] == "pmid":
+            # sometimes wos represents an identifier as a string instead of dict
+            if isinstance(identifier, dict) and identifier["type"] == "pmid":
                 return identifier["value"]
-    except KeyError:
+    except (KeyError, TypeError):
         logging.warning("[pmid] WOS JSON does not contain pmid")
         return None
 

--- a/test/publish/test_publication.py
+++ b/test/publish/test_publication.py
@@ -178,7 +178,7 @@ def test_write_contributions_by_school(test_session, snapshot, dataset, caplog):
     assert len(df) == 3
 
     # sort it so we know what is in each row
-    df = df.sort_values(["doi"])
+    df = df.sort_values(["doi", "primary_school"])
 
     # Rows 1 and 2 are the same publication, but different schools
     row = df.iloc[0]
@@ -196,7 +196,7 @@ def test_write_contributions_by_school(test_session, snapshot, dataset, caplog):
     assert bool(row.faculty_authored) is True
     assert bool(row.federally_funded) is True
     assert row.open_access == "gold"
-    assert row.primary_school == "School of Humanities and Sciences"  # school 1
+    assert row.primary_school == "School of Engineering"
     assert row.pub_year == 2023
     assert row.types == "article|preprint"
 
@@ -215,7 +215,7 @@ def test_write_contributions_by_school(test_session, snapshot, dataset, caplog):
     assert bool(row.faculty_authored) is True
     assert bool(row.federally_funded) is True
     assert row.open_access == "gold"
-    assert row.primary_school == "School of Engineering"  # school 2
+    assert row.primary_school == "School of Humanities and Sciences"
     assert row.pub_year == 2023
     assert row.types == "article|preprint"
 
@@ -259,7 +259,7 @@ def test_write_contributions_by_department(test_session, snapshot, dataset, capl
     assert len(df) == 4
 
     # sort it so we know what is in each row
-    df = df.sort_values(["doi"])
+    df = df.sort_values(["doi", "primary_department"])
 
     # Rows 1-3 are the same publication, but different department/school combinations
     row = df.iloc[0]
@@ -278,9 +278,9 @@ def test_write_contributions_by_department(test_session, snapshot, dataset, capl
     assert bool(row.federally_funded) is True
     assert row.open_access == "gold"
     assert (
-        row.primary_school == "School of Humanities and Sciences"
-    )  # two authors with same school AND same department, one row
-    assert row.primary_department == "Social Sciences"
+        row.primary_school == "School of Engineering"
+    )  # other author with same school BUT different department
+    assert row.primary_department == "Electrical Engineering"
     assert row.pub_year == 2023
     assert row.types == "article|preprint"
 
@@ -322,9 +322,9 @@ def test_write_contributions_by_department(test_session, snapshot, dataset, capl
     assert bool(row.federally_funded) is True
     assert row.open_access == "gold"
     assert (
-        row.primary_school == "School of Engineering"
-    )  # other author with same school BUT different department
-    assert row.primary_department == "Electrical Engineering"
+        row.primary_school == "School of Humanities and Sciences"
+    )  # two authors with same school AND same department, one row
+    assert row.primary_department == "Social Sciences"
     assert row.pub_year == 2023
     assert row.types == "article|preprint"
 

--- a/test/publish/test_publication_utils.py
+++ b/test/publish/test_publication_utils.py
@@ -178,6 +178,20 @@ def test_journal_with_pubmed_pmid():
     assert pub_utils._pmid(row) == "36857419"
 
 
+def test_wos_identifier_as_string():
+    """
+    Sometimes WoS uses a string as the identifier instead of a dictionary. We should handle that.
+    """
+    row = TestRow(
+        wos_json={
+            "dynamic_data": {
+                "cluster_related": {"identifiers": {"identifier": ["nope"]}}
+            }
+        }
+    )
+    assert pub_utils._pmid(row) is None
+
+
 def test_journal_without_pubmed_pmid():
     row = TestRow(
         dim_json=test_data.dim_json(),


### PR DESCRIPTION
The school and department queries report on data from the Funders table without joining on it, which results in a cartesian product that fills up the database sort space. This commit adds the join, and adjusts the tests to sort by the school and department as appropriate to ensure that the rows can be reliably tested (they are not dependent on the implicit sort order of the query results).

Fixes #423 🤞

This PR also includes several changes to publication_utils.py to improve the reliability of working with the extracted JSON, as well as a performance improvement to the distiller, which now caches JSON Paths that have been parsed.
