### PR TITLE
Need another Funders join

### DIFF
--- a/rialto_airflow/publish/publication.py
+++ b/rialto_airflow/publish/publication.py
@@ -64,6 +64,7 @@ def write_publications(snapshot) -> Path:
                     func.jsonb_agg_strict(Funder.federal).label("federal"),
                 )
                 .join(Author, Publication.authors)  # type: ignore
+                .join(Funder, Publication.funders, isouter=True)  # type: ignore
                 .group_by(Publication.id)
                 .execution_options(yield_per=10_000)
             )


### PR DESCRIPTION
This one results in a cartesian product too. I did notice a warning about this in the logs this time:

```
[2025-06-03, 14:29:16 UTC] {warnings.py:112} WARNING - /opt/airflow/rialto_airflow/publish/publication.py:71: SAWarning: SELECT statement has a cartesian product between FROM element(s) "funder" and FROM element "author".  Apply join condition(s) between each element to resolve.
```
