### PR TITLE
Remove sunet and role column headers

### DIFF
--- a/rialto_airflow/publish/publication.py
+++ b/rialto_airflow/publish/publication.py
@@ -111,8 +111,6 @@ def write_contributions_by_school(snapshot) -> Path:
         "federally_funded",
         "open_access",
         "primary_school",
-        "role",
-        "sunet",
         "pub_year",
         "types",
     ]


### PR DESCRIPTION
We can't report on author sunet and role when we are aggregating by school. Well we could report on it, but I think we'd need to put a delimited list in the cell, since it could contain multiple authors and roles.
