### PR TITLE
Collect data from Crossref

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -10,6 +10,7 @@ from airflow.models import Variable
 from rialto_airflow import funders
 from rialto_airflow.harvest import (
     authors,
+    crossref,
     dimensions,
     openalex,
     sul_pub,
@@ -149,11 +150,19 @@ def harvest():
         """
         pubmed.fill_in(snapshot)
 
+    @task()
+    def fill_in_crossref(snapshot):
+        """
+        Fill in Crossref data for DOIs from other publication sources.
+        """
+        crossref.fill_in(snapshot)
+
     @task_group()
     def fill_in(snapshot):
         fill_in_openalex(snapshot)
         fill_in_dimensions(snapshot)
         fill_in_wos(snapshot)
+        fill_in_crossref(snapshot)
         # fill_in_pubmed(snapshot)
         # Note: this was disabled on June 9, 2025 because it is running
         # very slowly.  We think we need to figure out how to better

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -126,6 +126,7 @@ class Publication(Base):  # type: ignore
     sulpub_json = Column(JSONB(none_as_null=True))
     wos_json = Column(JSONB(none_as_null=True))
     pubmed_json = Column(JSONB(none_as_null=True))
+    crossref_json = Column(JSONB(none_as_null=True))
     created_at = Column(DateTime, server_default=utcnow())
     updated_at = Column(DateTime, onupdate=utcnow())
     authors: RelationshipProperty = relationship(

--- a/rialto_airflow/harvest/crossref.py
+++ b/rialto_airflow/harvest/crossref.py
@@ -1,0 +1,109 @@
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Dict
+
+import requests
+from sqlalchemy import select, update
+
+from rialto_airflow.database import Publication, get_session
+from rialto_airflow.snapshot import Snapshot
+from rialto_airflow.utils import normalize_doi
+
+RIALTO_EMAIL = os.environ.get(
+    "AIRFLOW_VAR_OPENALEX_EMAIL"
+)  # use the same email address
+
+
+def fill_in(snapshot: Snapshot) -> Path:
+    """Harvest Crossref data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "crossref.jsonl"
+    count = 0
+    with jsonl_file.open("a") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            stmt = (
+                select(Publication.doi)  # type: ignore
+                .where(Publication.doi.is_not(None))  # type: ignore
+                .execution_options(yield_per=25)
+            )
+
+            for rows in select_session.execute(stmt).partitions():
+                # since the query uses yield_per=25 we will be looking up 25 DOIs at a time
+                dois = [normalize_doi(row.doi) for row in rows]
+
+                # The public API has a rate limit https://api.crossref.org/swagger-ui/
+                # This should hopefully let us go quickly enough and stay within the limit
+                # We could consider implementing support for the x-rate-limit-limit header.
+                time.sleep(1.0)
+
+                logging.info(f"looking up DOIs {dois}")
+                for crossref_pub in get_dois(dois):
+                    doi = normalize_doi(crossref_pub.get("DOI"))
+                    if doi is None:
+                        logging.warning("unable to determine what DOI to update")
+                        continue
+
+                    with get_session(snapshot.database_name).begin() as update_session:
+                        update_stmt = (
+                            update(Publication)  # type: ignore
+                            .where(Publication.doi == doi)
+                            .values(crossref_json=crossref_pub)
+                        )
+                        update_session.execute(update_stmt)
+
+                    count += 1
+                    jsonl_output.write(json.dumps(crossref_pub) + "\n")
+
+    logging.info(f"filled in {count} publications")
+
+    return jsonl_file
+
+
+def get_dois(dois: list[str]) -> list[dict]:
+    prefixed_dois = []
+    for doi in dois:
+        doi = doi.replace(",", "")  # commas are used to join DOIs in the filter
+
+        # DOIs need to have a prefix in the API works filter call, but we don't store them that way
+        if not doi.startswith("doi:"):
+            doi = f"doi:{doi}"
+
+        # According to Crossref API error messages the DOI must be of the form:
+        # doi:10.prefix/suffix where prefix is 4 or more digits and suffix is a string
+        if m := re.match(r"^doi:10\.(.+)/.+$", doi):
+            if len(m.group(1)) >= 4:
+                prefixed_dois.append(doi)
+            else:
+                logging.warning(f"Ignoring {doi} with invalid prefix code {m.group(1)}")
+        else:
+            logging.warning(f"Ignoring invalid DOI format {doi}")
+
+    if len(prefixed_dois) == 0:
+        logging.warning(f"No valid DOIs to look up in {dois}")
+        return []
+
+    params: Dict[str, str | int | None] = {
+        "filter": ",".join(prefixed_dois),
+        "rows": len(prefixed_dois),
+        "mailto": RIALTO_EMAIL,
+    }
+
+    resp = requests.get(  # type: ignore
+        "https://api.crossref.org/works/",
+        params=params,
+        headers={
+            "User-Agent": "Stanford RIALTO: https://github.com/sul-dlss/rialto-airflow"
+        },
+    )
+
+    # be noisy if we don't get a 200 OK
+    resp.raise_for_status()
+
+    results = resp.json()
+    if "message" in results and "items" in results.get("message", {}):
+        return results["message"]["items"]
+    else:
+        return []

--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -189,7 +189,7 @@ def fill_in(snapshot: Snapshot):
             )
 
             for rows in select_session.execute(stmt).partitions():
-                dois = [row["doi"] for row in rows]
+                dois = [row.doi for row in rows]
 
                 # note: we could potentially adjust batch_size upwards if we
                 # want to look up more DOIs at a time

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -120,7 +120,7 @@ def fill_in(snapshot) -> Path:
 
             for rows in select_session.execute(stmt).partitions():
                 # since the query uses yield_per=50 we will be looking up 50 DOIs at a time
-                dois = [normalize_doi(row["doi"]) for row in rows]
+                dois = [normalize_doi(row.doi) for row in rows]
 
                 # drop dois that are problematic for the openalex api
                 dois_filtered = _clean_dois_for_query(dois)

--- a/rialto_airflow/harvest/pubmed.py
+++ b/rialto_airflow/harvest/pubmed.py
@@ -108,7 +108,7 @@ def fill_in(snapshot: Snapshot):
 
             for rows in select_session.execute(stmt).partitions():
                 # use a batch size of 50 DOIs at a time
-                dois = [normalize_doi(row["doi"]) for row in rows]
+                dois = [normalize_doi(row.doi) for row in rows]
 
                 logging.info(f"looking up DOIs {dois}")
 

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -94,7 +94,7 @@ def fill_in(snapshot: Snapshot):
 
             for rows in select_session.execute(stmt).partitions():
                 # since the query uses yield_per=50 we will be looking up 50 DOIs at a time
-                dois = [row["doi"] for row in rows]
+                dois = [row.doi for row in rows]
 
                 logging.info(f"looking up DOIs {dois}")
                 for wos_pub in publications_from_dois(dois):

--- a/test/harvest/test_crossref.py
+++ b/test/harvest/test_crossref.py
@@ -1,0 +1,99 @@
+import logging
+
+import dotenv
+import pandas
+
+from rialto_airflow.database import Publication
+from rialto_airflow.harvest import crossref
+from test.utils import num_jsonl_objects
+
+dotenv.load_dotenv()
+
+
+def test_get_dois():
+    """
+    Test our Crossref API lookups by DOI. Note, we store the DOIs without the
+    'doi:' prefix, however the get_dois() function will add them as needed since
+    the API requires them.
+    """
+    # get 25 DOIs
+    df = pandas.read_csv("test/data/dois.csv")
+    dois = list(df.doi[0:25])
+
+    # look them up
+    results = crossref.get_dois(dois)
+
+    # see if they look good
+    assert len(results) == len(dois)
+    for result in results:
+        assert "DOI" in result
+
+
+def test_get_dois_missing():
+    """
+    Test that things work when looking up bogus DOIs.
+    """
+    df = pandas.read_csv("test/data/dois.csv")
+    dois = [f"{doi}-naw" for doi in df.doi[0:25]]
+
+    results = crossref.get_dois(dois)
+    assert len(results) == 0
+
+
+def test_invalid_doi_prefix(caplog):
+    """
+    Test lookup with invalid DOI format. According to the API docs a DOI must
+    match doi:10.prefix/suffix where prefix is of length 4 or more.
+    """
+    results = crossref.get_dois(["10.123/abcdef"])
+    assert len(results) == 0, ".123 prefix is too short"
+    assert "Ignoring doi:10.123/abcdef with invalid prefix code 123" in caplog.text
+    assert "No valid DOIs to look up" in caplog.text
+
+
+def test_doi_missing_10(caplog):
+    """
+    DOI must start with "10."
+    """
+    assert len(crossref.get_dois(["1234/abcdef"])) == 0, "missing 10."
+    assert "Ignoring invalid DOI format doi:1234/abcdef" in caplog.text
+
+
+def test_doi_missing_suffix(caplog):
+    """
+    DOIs must have a "/" followed by a string.
+    """
+    assert len(crossref.get_dois(["10.2345"])) == 0, "missing /suffix"
+    assert "Ignoring invalid DOI format doi:10.2345" in caplog.text
+
+
+def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+
+    # setup Works to return a list of one record
+    records = [
+        {
+            "DOI": "10.1515/9781503624153",
+            "title": "A sample title",
+            "publication_year": 1891,
+        }
+    ]
+    monkeypatch.setattr(crossref, "get_dois", lambda _: records)
+
+    crossref.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.crossref_json == {
+            "DOI": "10.1515/9781503624153",
+            "title": "A sample title",
+            "publication_year": 1891,
+        }
+
+    # adds 1 publication to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "crossref.jsonl") == 1
+    assert "filled in 1 publications" in caplog.text

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -121,6 +121,7 @@ def test_create_schema(
                 "pub_year",
                 "open_access",
                 "apc",
+                "crossref_json",
                 "dim_json",
                 "openalex_json",
                 "sulpub_json",


### PR DESCRIPTION
This PR adds fetching metadata from the [Crossref API](https://api.crossref.org/swagger-ui/index.html#/limits) by DOI to the "fill in" task in the harvest DAG. Collecting the Crossref metadata was useful for exploratory work to support our participation in COMET #451 and I thought we might as well add it since the metadata does seem to have some value?

We can look up 40 DOIs with each API request, and there is a sleep of one second in between requests. Maybe the sleep is not needed since [they say](https://api.crossref.org/swagger-ui/index.html#limits) that they allow up to 50 requests per second, but I thought we'd just play it safe.

I ran this in production last weekend to work out whatever kinks there might be with DOI formatting and the API responses. For about 500K DOIs it took about 1.5 days to run to completion. I analyzed the log and the responses take 8 seconds on average to come back (std dev 6.15).

While we are doing full, non-incremental harvesting we may want to dial them back to running biweekly or monthly instead of every week?