### PR TITLE
Normalize spaces in DOIs and prevent lookup

### DIFF
--- a/rialto_airflow/harvest/crossref.py
+++ b/rialto_airflow/harvest/crossref.py
@@ -67,7 +67,8 @@ def get_dois(dois: Iterable[str], tries=5) -> Iterable[dict]:
 
             # According to Crossref API error messages the DOI must be of the form:
             # doi:10.prefix/suffix where prefix is 4 or more digits and suffix is a string
-            if m := re.match(r"^doi:10\.(\d+)/.+$", doi):
+            # the string must not contain whitespace
+            if m := re.match(r"^doi:10\.(\d+)/\S+$", doi):
                 if len(m.group(1)) >= 4:
                     prefixed_dois.append(doi)
                 else:

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -26,8 +26,13 @@ def normalize_doi(doi):
     if doi is None:
         return None
 
-    doi = doi.strip().lower()
-    doi = doi.replace("https://doi.org/", "").replace("https://dx.doi.org/", "")
+    doi = (
+        doi.lower()
+        .replace(" ", "")
+        .replace("https://doi.org/", "")
+        .replace("https://dx.doi.org/", "")
+    )
+
     doi = re.sub(r"^doi:\s?", "", doi)
 
     return doi

--- a/test/harvest/test_crossref.py
+++ b/test/harvest/test_crossref.py
@@ -73,6 +73,16 @@ def test_doi_missing_suffix(caplog):
     assert "Ignoring invalid DOI format doi:10.2345" in caplog.text
 
 
+def test_doi_with_space(caplog):
+    """
+    The API requires that DOIs not include spaces.
+    """
+    assert len(list(crossref.get_dois(["10.1234/ abcdef"]))) == 0, (
+        "doi can't include space"
+    )
+    assert "Ignoring invalid DOI format doi:10.1234/ abcdef" in caplog.text
+
+
 def test_http_500(caplog, requests_mock):
     """
     Crossref API sometimes throws random 500 errors, which work when retried. We

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -45,6 +45,7 @@ def test_normalize_doi():
     assert utils.normalize_doi(" 10.1234/5678 ") == "10.1234/5678"
     assert utils.normalize_doi(" doi: 10.1234/5678 ") == "10.1234/5678"
     assert utils.normalize_doi("doi:10.1234/5678") == "10.1234/5678"
+    assert utils.normalize_doi("doi:10.1234/ 56 78") == "10.1234/5678"
     assert utils.normalize_doi(None) is None
 
 


### PR DESCRIPTION
We had a situation where the DOI "doi:10.1016/ j.xkme.2022.100435" was being looked up. Our normalize_doi() function was stripping leading and trailing whitespace but not whitespace inside the string. This change adds the stripping of whitespace, and also ensures that we don't try to look them up in the Crossref API which throws a HTTP 400 error that stops the workflow.
