### PR TITLE
filter out bad doi values before sending to openalex

### DIFF
--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -178,7 +178,7 @@ def _clean_dois_for_query(dois: list[str]) -> list[str]:
             continue
         elif doi.startswith("doi:"):
             continue
-        elif " pmcid:" in doi:
+        elif "pmcid:" in doi:
             continue
         else:
             new_dois.append(doi)

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -292,5 +292,12 @@ def test_colon():
 
 def test_clean_dois_for_query():
     assert openalex._clean_dois_for_query(
-        ["doi:123", "abc/123,45", "aaa/111", "123/abc pmcid:123", "abc/123"]
+        [
+            "doi:123",
+            "abc/123,45",
+            "aaa/111",
+            "123/abc pmcid:123",
+            "abc/123",
+            "10.1093/noajnl/vdad070.013pmcid:pmc10402389",
+        ]
     ) == ["aaa/111", "abc/123"]


### PR DESCRIPTION
Fixes #459 

The problematic DOI turned out to be this: "10.1093/noajnl/vdad070.013pmcid:pmc10402389"

The "pmcid:XXXX" is just attached to the DOI.  We had been looking for cases where it was separated by a space, but apparently it isn't in this case.  This tightens the filtering method to remove these cases as well as the ones with spaces.  This seems like a pretty unusual pattern to find in a DOI (e.g. colons are not common anyway) so is hopefully safe to filter out like this.