### PR TITLE
docker deploy use latest images

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -13,8 +13,6 @@ require 'capistrano/maintenance'
 
 require 'dlss/docker/capistrano'
 require 'capistrano/bundler'
-require 'dlss/capistrano'
-require 'capistrano/honeybadger'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,5 @@ group :deployment do
   gem 'capistrano'
   gem 'capistrano-bundler'
   gem 'capistrano-maintenance', '~> 1.2', require: false
-  gem 'dlss-capistrano', require: false
   gem 'dlss-capistrano-docker', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,13 +25,6 @@ GEM
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
     concurrent-ruby (1.3.5)
-    dlss-capistrano (5.3.0)
-      bcrypt_pbkdf
-      capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.3.0)
-      capistrano-one_time_key (>= 0.2.0)
-      capistrano-shared_configs
-      ed25519
     dlss-capistrano-docker (1.2.0)
       bcrypt_pbkdf
       capistrano (~> 3.0)
@@ -70,7 +63,6 @@ DEPENDENCIES
   capistrano
   capistrano-bundler
   capistrano-maintenance (~> 1.2)
-  dlss-capistrano
   dlss-capistrano-docker
   honeybadger
   rake

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -138,6 +138,7 @@ services:
 
   airflow-webserver:
     <<: *airflow-common
+    image: current-airflow-webserver
     command: webserver
     ports:
       - "3000:8080"
@@ -155,6 +156,7 @@ services:
 
   airflow-scheduler:
     <<: *airflow-common
+    image: current-airflow-scheduler
     command: scheduler
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8974/health"]
@@ -170,6 +172,7 @@ services:
 
   airflow-worker:
     <<: *airflow-common
+    image: current-airflow-worker
     command: celery worker
     healthcheck:
       # yamllint disable rule:line-length
@@ -193,6 +196,7 @@ services:
 
   airflow-triggerer:
     <<: *airflow-common
+    image: current-airflow-triggerer
     command: triggerer
     healthcheck:
       test: ["CMD-SHELL", 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
@@ -208,6 +212,7 @@ services:
 
   airflow-init:
     <<: *airflow-common
+    image: current-airflow-init
     entrypoint: /bin/bash
     environment:
       <<: *airflow-common-env

--- a/compose.yaml
+++ b/compose.yaml
@@ -152,6 +152,7 @@ services:
 
   airflow-webserver:
     <<: *airflow-common
+    image: current-airflow-webserver
     command: webserver
     ports:
       - "8080:8080"
@@ -169,6 +170,7 @@ services:
 
   airflow-scheduler:
     <<: *airflow-common
+    image: current-airflow-scheduler
     command: scheduler
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8974/health"]
@@ -184,6 +186,7 @@ services:
 
   airflow-worker:
     <<: *airflow-common
+    image: current-airflow-worker
     command: celery worker
     healthcheck:
       # yamllint disable rule:line-length
@@ -207,6 +210,7 @@ services:
 
   airflow-triggerer:
     <<: *airflow-common
+    image: current-airflow-triggerer
     command: triggerer
     healthcheck:
       test: ["CMD-SHELL", 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
@@ -222,6 +226,7 @@ services:
 
   airflow-init:
     <<: *airflow-common
+    image: current-airflow-init
     entrypoint: /bin/bash
     # yamllint disable rule:line-length
     command:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -52,4 +52,5 @@ set :docker_compose_rabbitmq_use_hooks, false
 set :docker_compose_build_use_hooks, true
 set :docker_compose_restart_use_hooks, true
 set :docker_compose_copy_assets_use_hooks, false
+set :docker_prune_use_hooks, true
 set :honeybadger_use_hooks, false


### PR DESCRIPTION
Attempts to fix #424 - get the correct docker container running as was built during the cap deploy.

This change ensures we name the images specifically instead of letting them get auto-named via the directory.  This lets them start up using the latest images.

Tested on stage, and seems to work based on checking the image names and when they were built after a deploy.

See the ticket comments in #424 for history