### PR TITLE
[initial reporting database implementation] store publications.csv data as a table in a stably named DB

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -18,7 +18,7 @@ from rialto_airflow.harvest import (
     pubmed,
     distill,
 )
-from rialto_airflow.database import create_database, create_schema
+from rialto_airflow.database import create_database, create_schema, HarvestSchemaBase
 from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.utils import rialto_authors_file
 from rialto_airflow.honeybadger import default_args
@@ -66,7 +66,7 @@ def harvest():
         snapshot = Snapshot.create(data_dir)
         shutil.copyfile(Path(rialto_authors_file(data_dir)), snapshot.authors_csv)
         create_database(snapshot.database_name)
-        create_schema(snapshot.database_name)
+        create_schema(snapshot.database_name, HarvestSchemaBase)
 
         return snapshot
 

--- a/rialto_airflow/dags/publish_publications.py
+++ b/rialto_airflow/dags/publish_publications.py
@@ -6,6 +6,11 @@ from airflow.decorators import dag, task
 from airflow.models import Variable
 
 import rialto_airflow.google as google
+from rialto_airflow.database import (
+    RIALTO_REPORTS_DB_NAME,
+    create_database,
+    database_exists,
+)
 from rialto_airflow.honeybadger import default_args
 from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.publish import publication
@@ -35,6 +40,11 @@ def publish_publications():
 
     @task
     def publish(snapshot):
+        if not database_exists(RIALTO_REPORTS_DB_NAME):
+            create_database(RIALTO_REPORTS_DB_NAME)
+
+        publication.init_reports_data_schema()
+
         # these probably could be run in parallel (separate tasks)?
         publication.write_contributions_by_department(snapshot)
         publication.write_contributions_by_school(snapshot)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm.session import close_all_sessions
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from rialto_airflow.database import (
+    HarvestSchemaBase,
     Author,
     Publication,
     create_schema,
@@ -33,7 +34,7 @@ def test_engine(monkeypatch):
     create_database(db_uri)
 
     # note: rialto_airflow.database.create_schema wants the database name not uri
-    create_schema(db_name)
+    create_schema(db_name, HarvestSchemaBase)
 
     # it's handy seeing SQL statements in the log when testing
     return engine_setup(db_name, echo=True)

--- a/test/publish/test_publication.py
+++ b/test/publish/test_publication.py
@@ -1,8 +1,17 @@
 import pandas
 import pytest
 
+from sqlalchemy_utils import create_database, database_exists, drop_database
+
 import test.publish.data as test_data
-from rialto_airflow.database import Author, Funder, Publication
+from rialto_airflow.database import (
+    create_schema,
+    engine_setup,
+    RIALTO_REPORTS_DB_NAME,
+    Author,
+    Funder,
+    Publication,
+)
 from rialto_airflow.publish import publication
 
 
@@ -133,6 +142,35 @@ def dataset(test_session):
         session.add(pub2)
 
 
+@pytest.fixture
+def setup_teardown_reports_schema(monkeypatch):
+    """
+    This pytest fixture will ensure that the test reports database exists and has
+    the database schema configured. If the database exists it will be dropped
+    and readded.
+    """
+    db_host = "postgresql+psycopg2://airflow:airflow@localhost:5432"
+
+    db_name = RIALTO_REPORTS_DB_NAME
+    db_uri = f"{db_host}/{db_name}"
+
+    if database_exists(db_uri):
+        drop_database(db_uri)
+
+    create_database(db_uri)
+
+    # note: rialto_airflow.database.create_schema wants the database name not uri
+    monkeypatch.setenv("AIRFLOW_VAR_RIALTO_POSTGRES", db_host)
+    create_schema(db_name, publication.ReportsSchemaBase)
+
+    # it's handy seeing SQL statements in the log when testing
+    engine_setup(db_name, echo=True)
+
+    yield
+
+    drop_database(db_uri)
+
+
 def test_dataset(test_session, dataset):
     with test_session.begin() as session:
         pub = (
@@ -147,6 +185,7 @@ def test_dataset(test_session, dataset):
         assert len(pub.funders) == 2
 
 
+@pytest.mark.usefixtures("setup_teardown_reports_schema")
 def test_write_publications(test_session, snapshot, dataset, caplog):
     # generate the publications csv file
     csv_path = publication.write_publications(snapshot)

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
 from rialto_airflow import database
-from rialto_airflow.database import Author
+from rialto_airflow.database import HarvestSchemaBase, Author
 from rialto_airflow.snapshot import Snapshot
 
 
@@ -104,7 +104,7 @@ def test_create_schema(
 
     try:
         database.create_database(snapshot.database_name)
-        database.create_schema(snapshot.database_name)
+        database.create_schema(snapshot.database_name, HarvestSchemaBase)
         # Verify that the tables exist and the columns match the schema
         engine = null_pool_engine(snapshot.database_name)
         with engine.connect() as conn:


### PR DESCRIPTION
to test this locally, besides unit tests, i did a small `harvest` DAG run with this branch, followed by a `publish_publications` DAG run (i commented out the upload step in the `publish_publications` DAG so i wouldn't inadvertently step on the shared drive's CSVs).  i saw the new table get populated with what looked like the contents that'd go in `publications.csv`, and using tableau desktop locally, i was able to make a simple graph visualizing DOI count vs pub year.

~~i'm not set on any of the decomposition or code placement choices in this PR.  maybe i could show it quickly as a post-standup discussion topic, and we could decide what if anything we like and want to keep, what we want to change direction on, and how to move this forward?~~  after some discussion and some naming tweaks, we've decided to push this forward as the start of a pattern for storing reporting data in database tables instead of CSV files.

closes #456 