### PR TITLE
Deduplication as a post-process step

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -171,7 +171,7 @@ def harvest():
         """
         Remove duplicates based on WOS UID.
         """
-        deduplicate.remove_duplicates(snapshot)
+        deduplicate.remove_wos_duplicates(snapshot)
 
     @task()
     def distill_publications(snapshot):

--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -17,6 +17,7 @@ from rialto_airflow.harvest import (
     wos,
     pubmed,
     distill,
+    deduplicate,
 )
 from rialto_airflow.database import create_database, create_schema, HarvestSchemaBase
 from rialto_airflow.snapshot import Snapshot
@@ -166,6 +167,13 @@ def harvest():
         fill_in_pubmed(snapshot)
 
     @task()
+    def remove_duplicates(snapshot):
+        """
+        Remove duplicates based on WOS UID.
+        """
+        deduplicate.remove_duplicates(snapshot)
+
+    @task()
     def distill_publications(snapshot):
         """
         Distill the publication metadata into publication table columns.
@@ -181,6 +189,7 @@ def harvest():
 
     @task_group()
     def post_process(snapshot):
+        remove_duplicates(snapshot)
         distill_publications(snapshot)
         link_funders(snapshot)
 

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -104,9 +104,22 @@ def pg_utcnow(element, compiler, **kw):
 pub_author_association = Table(
     "pub_author_association",
     HarvestSchemaBase.metadata,
-    Column("publication_id", ForeignKey("publication.id", ondelete="CASCADE"), primary_key=True),
+    Column(
+        "publication_id",
+        ForeignKey("publication.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
     Column("author_id", ForeignKey("author.id", ondelete="CASCADE"), primary_key=True),
 )
+
+
+pub_funder_association = Table(
+    "pub_funder_association",
+    HarvestSchemaBase.metadata,
+    Column("publication_id", ForeignKey("publication.id"), primary_key=True),
+    Column("funder_id", ForeignKey("funder.id"), primary_key=True),
+)
+
 
 class Publication(HarvestSchemaBase):  # type: ignore
     __tablename__ = "publication"

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -104,18 +104,9 @@ def pg_utcnow(element, compiler, **kw):
 pub_author_association = Table(
     "pub_author_association",
     HarvestSchemaBase.metadata,
-    Column("publication_id", ForeignKey("publication.id"), primary_key=True),
-    Column("author_id", ForeignKey("author.id"), primary_key=True),
+    Column("publication_id", ForeignKey("publication.id", ondelete="CASCADE"), primary_key=True),
+    Column("author_id", ForeignKey("author.id", ondelete="CASCADE"), primary_key=True),
 )
-
-
-pub_funder_association = Table(
-    "pub_funder_association",
-    HarvestSchemaBase.metadata,
-    Column("publication_id", ForeignKey("publication.id"), primary_key=True),
-    Column("funder_id", ForeignKey("funder.id"), primary_key=True),
-)
-
 
 class Publication(HarvestSchemaBase):  # type: ignore
     __tablename__ = "publication"
@@ -135,7 +126,10 @@ class Publication(HarvestSchemaBase):  # type: ignore
     created_at = Column(DateTime, server_default=utcnow())
     updated_at = Column(DateTime, onupdate=utcnow())
     authors: RelationshipProperty = relationship(
-        "Author", secondary=pub_author_association, back_populates="publications"
+        "Author",
+        secondary=pub_author_association,
+        back_populates="publications",
+        cascade="all, delete",
     )
     funders: RelationshipProperty = relationship(
         "Funder", secondary=pub_funder_association, back_populates="publications"

--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -18,6 +18,7 @@ def remove_duplicates(snapshot: Snapshot) -> int:
         ).all()
         num_dupes = len(duplicates)
         logging.info(f"Found {num_dupes} publication(s) with duplicates.")
+        count_deleted = 0
 
         wos_uids = [row[1] for row in duplicates]
         for wos_uid in wos_uids:
@@ -34,7 +35,7 @@ def remove_duplicates(snapshot: Snapshot) -> int:
             # keep the first one and merge authors
             main_pub = pubs[0].id
             logging.info(
-                f"Keeping publication {main_pub} as the record for this publication."
+                f"Keeping publication {main_pub} as the record for this publication. Removing {len(pubs) - 1} publication records."
             )
             for pub in pubs[1:]:
                 # Move author relationships to the first instance
@@ -46,4 +47,6 @@ def remove_duplicates(snapshot: Snapshot) -> int:
                     )
                 # Delete the duplicate
                 session.execute(delete(Publication).where(Publication.id == pub.id))  # type: ignore
+                count_deleted += 1
+        logging.info(f"Deleted a total of {count_deleted} publication rows.")
     return num_dupes

--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -5,7 +5,7 @@ from rialto_airflow.database import Publication, get_session, pub_author_associa
 from rialto_airflow.snapshot import Snapshot
 
 
-def remove_duplicates(snapshot: Snapshot) -> int:
+def remove_wos_duplicates(snapshot: Snapshot) -> int:
     logging.info("Removing any duplicate publications.")
     with get_session(snapshot.database_name).begin() as session:
         # Find all duplicate WOS publications in the snapshot
@@ -17,7 +17,7 @@ def remove_duplicates(snapshot: Snapshot) -> int:
             .having(func.count() > 1)
         ).all()
         num_dupes = len(duplicates)
-        logging.info(f"Found {num_dupes} publication(s) with duplicates.")
+        logging.info(f"Found {num_dupes} publications with duplicates.")
         count_deleted = 0
 
         wos_uids = [row[1] for row in duplicates]
@@ -34,9 +34,6 @@ def remove_duplicates(snapshot: Snapshot) -> int:
             # pubs contains all Publications with this WOS UID
             # keep the first one and merge authors
             main_pub = pubs[0].id
-            logging.info(
-                f"Keeping publication {main_pub} as the record for this publication. Removing {len(pubs) - 1} publication records."
-            )
             for pub in pubs[1:]:
                 # Move author relationships to the first instance
                 for author in pub.authors:

--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -1,0 +1,55 @@
+import logging
+from sqlalchemy import delete, func, insert, select
+
+from rialto_airflow.database import Publication, get_session, pub_author_association
+from rialto_airflow.snapshot import Snapshot
+
+
+def remove_duplicates(snapshot: Snapshot) -> int:
+    logging.info("Removing any duplicate publications.")
+    with get_session(snapshot.database_name).begin() as session:
+        # Find all duplicate WOS publications in the snapshot
+        duplicates = session.execute(
+            select(func.count(), Publication.wos_json["UID"])
+            .where(Publication.doi.is_(None))
+            .where(Publication.wos_json["UID"].is_not(None))
+            .group_by(Publication.wos_json["UID"])
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} publication(s) with duplicates.")
+
+        wos_uids = [row[1] for row in duplicates]
+        for wos_uid in wos_uids:
+            pubs = (
+                session.execute(
+                    select(Publication).where(
+                        Publication.wos_json["UID"].astext == wos_uid
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            # pubs contains all Publications with this WOS UID
+            # keep the first one and merge authors
+            main_pub = pubs[0].id
+            logging.info(
+                f"Keeping publication {main_pub} as the record for this publication."
+            )
+            for pub in pubs[1:]:
+                # Move author relationships to the first instance
+                for author in pub.authors:
+                    session.execute(
+                        insert(pub_author_association).values(
+                            publication_id=main_pub, author_id=author.id
+                        )
+                    )
+                    session.execute(
+                        delete(pub_author_association)
+                        .where(pub_author_association.c.publication_id == pub.id)
+                        .where(pub_author_association.c.author_id == author.id)
+                    )
+                # Remove the duplicate publication
+                # This could strand an Author with no publications?
+                session.execute(delete(Publication).where(Publication.id == pub.id))
+    return num_dupes

--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -44,12 +44,6 @@ def remove_duplicates(snapshot: Snapshot) -> int:
                             publication_id=main_pub, author_id=author.id
                         )
                     )
-                    session.execute(
-                        delete(pub_author_association)
-                        .where(pub_author_association.c.publication_id == pub.id)
-                        .where(pub_author_association.c.author_id == author.id)
-                    )
-                # Remove the duplicate publication
-                # This could strand an Author with no publications?
-                session.execute(delete(Publication).where(Publication.id == pub.id))
+                # Delete the duplicate
+                session.execute(delete(Publication).where(Publication.id == pub.id))  # type: ignore
     return num_dupes

--- a/test/harvest/test_deduplicate.py
+++ b/test/harvest/test_deduplicate.py
@@ -81,7 +81,7 @@ def test_wos_deduplicate(test_session, dataset, snapshot):
     Test that the publication with a duplicate is found and the duplicates removed.
     Authors should be moved to the remaining record.
     """
-    dupes = deduplicate.remove_duplicates(snapshot)
+    dupes = deduplicate.remove_wos_duplicates(snapshot)
     assert dupes == 1
     with test_session.begin() as session:
         # only one publication remains and dupe has been deleted

--- a/test/harvest/test_deduplicate.py
+++ b/test/harvest/test_deduplicate.py
@@ -1,0 +1,92 @@
+import pytest
+
+from rialto_airflow.harvest import deduplicate
+import test.publish.data as test_data
+from rialto_airflow.database import Author, Publication
+
+
+@pytest.fixture
+def dataset(test_session):
+    """
+    This fixture will create two publications that are duplicates and lack DOIs.
+    """
+    with test_session.begin() as session:
+        pub = Publication(
+            doi=None,
+            title="My Life",
+            apc=123,
+            open_access="green",
+            pub_year=2024,
+            dim_json=test_data.dim_json(),
+            openalex_json=test_data.openalex_json(),
+            wos_json=test_data.wos_json(),
+            sulpub_json=test_data.sulpub_json(),
+            pubmed_json=test_data.pubmed_json(),
+        )
+
+        pub2 = Publication(
+            doi=None,
+            title="My Life",
+            apc=123,
+            open_access="green",
+            pub_year=2024,
+            dim_json=test_data.dim_json(),
+            openalex_json=test_data.openalex_json(),
+            wos_json=test_data.wos_json(),
+            sulpub_json=test_data.sulpub_json(),
+            pubmed_json=test_data.pubmed_json(),
+        )
+
+        author1 = Author(
+            first_name="Jane",
+            last_name="Stanford",
+            sunet="janes",
+            cap_profile_id="1234",
+            orcid="0298098343",
+            primary_school="School of Humanities and Sciences",
+            primary_dept="Social Sciences",
+            primary_role="faculty",
+            schools=[
+                "Vice Provost for Undergraduate Education",
+                "School of Humanities and Sciences",
+            ],
+            departments=["Inter-Departmental Programs", "Social Sciences"],
+            academic_council=True,
+        )
+
+        author2 = Author(
+            first_name="Leland",
+            last_name="Stanford",
+            sunet="lelands",
+            cap_profile_id="12345",
+            orcid="02980983434",
+            primary_school="School of Humanities and Sciences",
+            primary_dept="Social Sciences",
+            primary_role="staff",
+            schools=[
+                "School of Humanities and Sciences",
+            ],
+            departments=["Social Sciences"],
+            academic_council=False,
+        )
+
+        pub.authors.append(author1)
+        pub2.authors.append(author2)
+        session.add(pub)
+        session.add(pub2)
+
+
+def test_wos_deduplicate(test_session, dataset, snapshot):
+    """
+    Test that the publication with a duplicate is found and the duplicates removed.
+    Authors should be moved to the remaining record.
+    """
+    dupes = deduplicate.remove_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1
+        pubs = session.query(Publication).where(
+            Publication.wos_json["UID"].astext == "WOS:000123456789"
+        )
+        assert pubs.count() == 1
+        assert len(pubs.one().authors) == 2

--- a/test/publish/data.py
+++ b/test/publish/data.py
@@ -58,6 +58,7 @@ def openalex_no_title_json():
 
 def wos_json():
     return {
+        "UID": "WOS:000123456789",
         "fullrecord_metadata": {
             "normalized_doctypes": {"doctype": ["Article", "Abstract"]}
         },


### PR DESCRIPTION
Sample code for deduplication as a post process step with only one platforms's identifiers (WOS). Relates to #491.

~I think there should be a better way to handle deleting the pub_author_association. The things I tried initially didn't work, so there's more to look at.~ I set up a delete cascade on the publication / author many to many relationship.


