### PR TITLE
Add constraints for WOS and Dimensions ID

### DIFF
--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -16,9 +16,13 @@ from rialto_airflow.database import (
     Publication,
     get_session,
     pub_author_association,
+    get_index,
 )
 from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.utils import normalize_doi, normalize_orcid
+
+
+doi_dim_idx = get_index(Publication, "doi_dim_idx")
 
 
 def harvest(snapshot: Snapshot, limit: None | int = None) -> Path:
@@ -52,7 +56,7 @@ def harvest(snapshot: Snapshot, limit: None | int = None) -> Path:
                             insert(Publication)
                             .values(doi=doi, dim_json=dimensions_pub_json)
                             .on_conflict_do_update(
-                                constraint="publication_doi_key",
+                                constraint=doi_dim_idx,
                                 set_=dict(dim_json=dimensions_pub_json),
                             )
                             .returning(Publication.id)

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -15,11 +15,14 @@ from rialto_airflow.database import (
     Publication,
     get_session,
     pub_author_association,
+    get_index,
 )
 from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.utils import normalize_doi
 
 Params = Dict[str, Union[int, str]]
+
+doi_wos_idx = get_index(Publication, "doi_wos_idx")
 
 
 def harvest(snapshot: Snapshot, limit=None) -> Path:
@@ -60,7 +63,7 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
                                 wos_json=wos_pub,
                             )
                             .on_conflict_do_update(
-                                constraint="publication_doi_key",
+                                constraint=doi_wos_idx,
                                 set_=dict(wos_json=wos_pub),
                             )
                             .returning(Publication.id)


### PR DESCRIPTION
This commit illustrates how we can reduce duplication by adding unique constraints for platform specific identifiers like the Web of Science ID and Dimensions ID.

First it adds unique indexes:

- doi_wos_idx: (`DOI`, `wos_json ->> 'UID'`)
- doi_dim_idx: (`DOI`, `dim_json ->> 'id'`)

The DOI value is coalesced into an empty string, so that the index continues to work when a DOI is `NULL`.

Then when we are doing the "upsert" during harvesting we reference the relevant index, to catch unique constraint violations.

Unfortunately only one index can be used as a constraint during an upsert. Also, it only appears to be possible to reference an unique constraint by name, so the index name is looked up manually with get_index().

For all the tests to pass we will need similar new indexes for the upsert to reference when harvesting OpenAlex, Crossref, sul_pub. I had to relax the unique constraint on DOI, as it was getting thrown in the Dimensions and WoS testing here.

Refs #492
