### PR TITLE
Database deletion cleanup improvements

### DIFF
--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -46,7 +46,7 @@ def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
                     shutil.rmtree(folder_path)  # delete folder and all contents
                 except Exception as exc:
                     logging.exception(
-                        f"Failed to delete folder {folder_path} (error: {exc.__class__.__name__})"
+                        f"Failed to delete folder {folder_path} (error: {exc})"
                     )
     # next consider all of the the databases
     for database_name in database_names():
@@ -64,5 +64,5 @@ def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
                     drop_database(database_name)
                 except Exception as exc:
                     logging.exception(
-                        f"Failed to drop database {database_name} (error: {exc.__class__.__name__})"
+                        f"Failed to drop database {database_name} (error: {exc})"
                     )

--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -48,7 +48,7 @@ def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
                     logging.exception(
                         f"Failed to delete folder {folder_path} (error: {exc})"
                     )
-    # next consider all of the the databases
+    # next consider all of the databases (note: the `database_names` method already excludes postgres and airflow)
     for database_name in database_names():
         logging.info(f"Considering database {database_name}")
         # Check if database name matches the expected format "rialto_%Y%m%d%H%M%S"

--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -58,6 +58,9 @@ def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
             age = current_time - database_time
             if age.days > cleanup_interval_days:
                 try:
+                    logging.info(
+                        f"Dropping database: {database_name} (age: {age.days} days)"
+                    )
                     drop_database(database_name)
                 except Exception as exc:
                     logging.exception(

--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -3,7 +3,8 @@ import shutil
 from pathlib import Path
 from datetime import datetime
 
-from rialto_airflow.database import database_exists, drop_database
+from rialto_airflow.database import drop_database, database_names
+import re
 
 
 def cleanup_author_files(cleanup_interval_days: int, data_dir: str):
@@ -29,23 +30,36 @@ def cleanup_author_files(cleanup_interval_days: int, data_dir: str):
 def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
     current_time = datetime.now()
 
+    logging.info(f"Current time: {current_time}")
+    # first the data folders
     base_snapshot_folder = Path(data_dir) / "snapshots"
     for folder_path in base_snapshot_folder.iterdir():
         if folder_path.is_dir():
+            logging.info(f"Considering snapshot folder {folder_path}")
             folder_time = datetime.strptime(folder_path.name, "%Y%m%d%H%M%S")
             age = current_time - folder_time
             if age.days > cleanup_interval_days:
                 logging.info(
                     f"Removing snapshot folder: {folder_path} (age: {age.days} days)"
                 )
-                shutil.rmtree(folder_path)  # delete folder and all contents
-
-                database_name = f"rialto_{folder_path.name}"
-                logging.info(f"Searching for database named {database_name}")
-                if database_exists(database_name):
-                    try:
-                        drop_database(database_name)
-                    except Exception as exc:
-                        logging.exception(
-                            f"Failed to drop database {database_name} for snapshot {folder_path} (error: {exc.__class__.__name__})"
-                        )
+                try:
+                    shutil.rmtree(folder_path)  # delete folder and all contents
+                except Exception as exc:
+                    logging.exception(
+                        f"Failed to delete folder {folder_path} (error: {exc.__class__.__name__})"
+                    )
+    # next consider all of the the databases
+    for database_name in database_names():
+        logging.info(f"Considering database {database_name}")
+        # Check if database name matches the expected format "rialto_%Y%m%d%H%M%S"
+        if re.match(r"^rialto_\d{14}$", database_name):
+            database_name_date_part = database_name.removeprefix("rialto_")
+            database_time = datetime.strptime(database_name_date_part, "%Y%m%d%H%M%S")
+            age = current_time - database_time
+            if age.days > cleanup_interval_days:
+                try:
+                    drop_database(database_name)
+                except Exception as exc:
+                    logging.exception(
+                        f"Failed to drop database {database_name} (error: {exc.__class__.__name__})"
+                    )

--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -43,4 +43,9 @@ def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
                 database_name = f"rialto_{folder_path.name}"
                 logging.info(f"Searching for database named {database_name}")
                 if database_exists(database_name):
-                    drop_database(database_name)
+                    try:
+                        drop_database(database_name)
+                    except Exception as exc:
+                        logging.exception(
+                            f"Failed to drop database {database_name} for snapshot {folder_path} (error: {exc.__class__.__name__})"
+                        )

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -111,12 +111,7 @@ def database_names() -> list:
                 "SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true AND datname != 'postgres' ORDER BY datname"
             )
         )
-        # prefer scalars() when available to get a list[str]
-        try:
-            return result.scalars().all()
-        except Exception:
-            # fallback for older SQLAlchemy result objects
-            return [row[0] for row in result]
+    return result.scalars().all()
 
 
 class utcnow(expression.FunctionElement):

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -101,6 +101,24 @@ def database_exists(database_name: str) -> bool:
         return result.fetchone() is not None
 
 
+def database_names() -> list:
+    """Returns a list of database names"""
+
+    engine = engine_setup("postgres")
+    with engine.connect() as connection:
+        result = connection.execute(
+            text(
+                "SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true AND datname != 'postgres' ORDER BY datname"
+            )
+        )
+        # prefer scalars() when available to get a list[str]
+        try:
+            return result.scalars().all()
+        except Exception:
+            # fallback for older SQLAlchemy result objects
+            return [row[0] for row in result]
+
+
 class utcnow(expression.FunctionElement):
     """
     Create a UTC timestamp

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -60,7 +60,7 @@ def create_database(database_name: str) -> str:
     return database_name
 
 
-def drop_database(database_name: str, force: bool = False):
+def drop_database(database_name: str, force: bool = True):
     """Drop a DAG-specific database for publications and author/orgs data"""
 
     # set up the connection using the default postgres database
@@ -83,7 +83,7 @@ def drop_database(database_name: str, force: bool = False):
 
         # now drop the database
         connection.execute(text(f"drop database {database_name}"))
-    logging.info(f"Dropped database {database_name}")
+        logging.info(f"Dropped database {database_name}")
 
 
 def database_exists(database_name: str) -> bool:

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -60,7 +60,7 @@ def create_database(database_name: str) -> str:
     return database_name
 
 
-def drop_database(database_name: str):
+def drop_database(database_name: str, force: bool = False):
     """Drop a DAG-specific database for publications and author/orgs data"""
 
     # set up the connection using the default postgres database
@@ -69,16 +69,17 @@ def drop_database(database_name: str):
         # ensure we can run DDL outside of a transaction
         connection.execution_options(isolation_level="AUTOCOMMIT")
 
-        # terminate all other backends connected to the target database
-        # (exclude the current session)
-        connection.execute(
-            text(
-                "SELECT pg_terminate_backend(pid) "
-                "FROM pg_stat_activity "
-                "WHERE datname = :db_name AND pid <> pg_backend_pid()"
-            ),
-            {"db_name": database_name},
-        )
+        if force:
+            # terminate all other backends connected to the target database
+            # (exclude the current session)
+            connection.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) "
+                    "FROM pg_stat_activity "
+                    "WHERE datname = :db_name AND pid <> pg_backend_pid()"
+                ),
+                {"db_name": database_name},
+            )
 
         # now drop the database
         connection.execute(text(f"drop database {database_name}"))

--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -108,7 +108,7 @@ def database_names() -> list:
     with engine.connect() as connection:
         result = connection.execute(
             text(
-                "SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true AND datname != 'postgres' ORDER BY datname"
+                "SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true AND datname NOT IN ('postgres', 'airflow', 'rialto-airflow') ORDER BY datname"
             )
         )
     return result.scalars().all()

--- a/test/test_cleanup.py
+++ b/test/test_cleanup.py
@@ -179,6 +179,8 @@ def test_cleanup_ignores_non_timestamped_rialto_names(tmp_path, monkeypatch):
     # ensure the non-timestamped names were not dropped
     assert "rialto-airflow" not in calls
     assert "rialto_reports_data" not in calls
+    # ensure postgres is not dropped!
+    assert "postgres" not in calls
     # the timestamped name should have been passed to drop_database
     assert "rialto_20000101000000" in calls
 

--- a/test/test_cleanup.py
+++ b/test/test_cleanup.py
@@ -145,11 +145,9 @@ def test_cleanup_snapshots_continues_on_drop_error(tmp_path, monkeypatch, caplog
     # the failure from the first drop (for the first name) should have been logged
     assert any(
         f"Failed to drop database rialto_{s1.name}" in rec.getMessage()
+        and "boom" in rec.getMessage()
         for rec in caplog.records
     )
-
-    # the exception class name should be included in the log message
-    assert any("RuntimeError" in rec.getMessage() for rec in caplog.records)
 
 
 def test_cleanup_ignores_non_timestamped_rialto_names(tmp_path, monkeypatch):
@@ -210,10 +208,9 @@ def test_logs_when_rmtree_fails(tmp_path, monkeypatch, caplog):
 
     cleanup_snapshots(0, str(tmp_path))
 
-    # The failing rmtree should have been logged with exception name
+    # The failing rmtree should have been logged with exception
     assert any(
-        "Failed to delete folder" in rec.getMessage()
-        and "RuntimeError" in rec.getMessage()
+        "Failed to delete folder" in rec.getMessage() and "boom" in rec.getMessage()
         for rec in caplog.records
     )
 

--- a/test/test_cleanup.py
+++ b/test/test_cleanup.py
@@ -183,3 +183,61 @@ def test_cleanup_ignores_non_timestamped_rialto_names(tmp_path, monkeypatch):
     assert "rialto_reports_data" not in calls
     # the timestamped name should have been passed to drop_database
     assert "rialto_20000101000000" in calls
+
+
+def test_logs_when_rmtree_fails(tmp_path, monkeypatch, caplog):
+    """Ensure that an exception during shutil.rmtree is logged and does not crash cleanup."""
+    # create a snapshots directory and a single old snapshot folder
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir()
+
+    folder = snapshots / "20000101000000"
+    folder.mkdir()
+    (folder / "file.txt").write_text("x")
+
+    # monkeypatch rmtree in the cleanup module to raise
+    def fake_rmtree(path):
+        raise RuntimeError("rmtree boom")
+
+    monkeypatch.setattr("rialto_airflow.cleanup.shutil.rmtree", fake_rmtree)
+    # avoid touching the database layer during this test
+    monkeypatch.setattr("rialto_airflow.cleanup.database_names", lambda: [])
+
+    caplog.set_level(logging.ERROR)
+
+    # run cleanup; use interval 0 so the folder is considered old
+    from rialto_airflow.cleanup import cleanup_snapshots
+
+    cleanup_snapshots(0, str(tmp_path))
+
+    # The failing rmtree should have been logged with exception name
+    assert any(
+        "Failed to delete folder" in rec.getMessage()
+        and "RuntimeError" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_cleanup_drops_timestamped_database(tmp_path, monkeypatch):
+    """Ensure cleanup_snapshots calls drop_database for timestamped rialto databases."""
+    # create snapshots dir so cleanup iterates without error
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir()
+
+    calls = []
+
+    def fake_drop(name):
+        calls.append(name)
+
+    # return a single timestamped database name that should be dropped
+    monkeypatch.setattr(
+        "rialto_airflow.cleanup.database_names",
+        lambda: ["rialto_20000101000000"],
+    )
+    monkeypatch.setattr("rialto_airflow.cleanup.drop_database", fake_drop)
+
+    from rialto_airflow.cleanup import cleanup_snapshots
+
+    cleanup_snapshots(0, str(tmp_path))
+
+    assert calls == ["rialto_20000101000000"]

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -211,3 +212,26 @@ def author(test_session):
 def test_author_fixture(test_session, author):
     with test_session.begin() as session:
         assert session.query(Author).where(Author.sunet == "janes").count() == 1
+
+
+def test_database_names(mock_rialto_postgres, teardown_database):
+    # create two unique databases and ensure database_names() returns them
+    name1 = f"rialto_test_{uuid.uuid4().hex[:8]}"
+    name2 = f"rialto_test_{uuid.uuid4().hex[:8]}"
+
+    try:
+        database.create_database(name1)
+        database.create_database(name2)
+
+        # database.database_names() returns a list of names
+        names = database.database_names()
+
+        assert name1 in names
+        assert name2 in names
+
+    finally:
+        # tear down both databases if they exist
+        if database.database_exists(name1):
+            teardown_database(name1)
+        if database.database_exists(name2):
+            teardown_database(name2)

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -223,11 +223,13 @@ def test_database_names(mock_rialto_postgres, teardown_database):
         database.create_database(name1)
         database.create_database(name2)
 
-        # database.database_names() returns a list of names
+        # database.database_names() returns a list of names, but excludes airflow and postgres databases
         names = database.database_names()
 
         assert name1 in names
         assert name2 in names
+        assert "rialto-airflow" not in names
+        assert "postgres" not in names
 
     finally:
         # tear down both databases if they exist


### PR DESCRIPTION
Fixes #502 (based on some research I did). 

Does a few things:
- force drop databases (drop any lingering connections)
- rescue and continue if still hits an error (so we don't stop the whole dag)
- separate out data folder and database deletions, so they can both occur separately -- this makes them independent of each other instead of forcing the database checks to match the data folders (can cause dangling databases if the folder gets deleted before the database is cleaned up)
- also rescue folder delete errors, logs and allows the dag to continue
- adds extra l ogging

Tested on stage and it cleared older databases and folders, even when they didn't have exact matches with each other and forced closed older databases with connections.  

~~I am not clear on how/where Honeybadger gets notified, that's a separate question.~~