### PR TITLE
Order post-process harvest tasks

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -189,9 +189,10 @@ def harvest():
 
     @task_group()
     def post_process(snapshot):
-        remove_duplicates(snapshot)
-        distill_publications(snapshot)
-        link_funders(snapshot)
+        dedupe = remove_duplicates(snapshot)
+        distill = distill_publications(snapshot)
+        link = link_funders(snapshot)
+        dedupe >> [distill, link]
 
     @task()
     def complete(snapshot):


### PR DESCRIPTION
Resolves #513. Confirmed the order worked by viewing the graph while the DAG was running:

Before:
<img width="348" height="456" alt="Screenshot 2025-08-28 at 9 57 11 AM" src="https://github.com/user-attachments/assets/19c92dac-c854-4071-8245-113cb698028f" />


After:

<img width="541" height="324" alt="Screenshot 2025-08-28 at 10 22 12 AM" src="https://github.com/user-attachments/assets/160a1d3a-25ee-40e6-b545-3abf2666e960" />

