### PR TITLE
Change reports database name

### DIFF
--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -18,7 +18,7 @@ from sqlalchemy.types import DateTime
 
 # a database with a consistent name, to which we publish summary and denormalized data
 # derived from harvests, for use by e.g. Tableau reports and visualizations
-RIALTO_REPORTS_DB_NAME: str = "rialto_reports_data"
+RIALTO_REPORTS_DB_NAME: str = "rialto_reports"
 
 
 HarvestSchemaBase = declarative_base()


### PR DESCRIPTION
Resolves #511 to shorten name of the reports database. 

HOLD merging/deploying in order to coordinate with Tableau configuration of data source connection. 

Tested renaming the database locally using the psql command below. The same command would need to be run on stage and prod. 
`ALTER DATABASE rialto_reports_data RENAME TO rialto_reports;`