### PR TITLE
Add indexes for platform identifiers

### DIFF
--- a/rialto_airflow/database.py
+++ b/rialto_airflow/database.py
@@ -2,7 +2,7 @@ import logging
 import os
 from functools import cache
 
-from sqlalchemy import Table, Boolean, Column, ForeignKey, Integer, String
+from sqlalchemy import Table, Boolean, Column, ForeignKey, Index, Integer, String
 from sqlalchemy import create_engine, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.ext.compiler import compiles
@@ -174,6 +174,13 @@ class Publication(HarvestSchemaBase):  # type: ignore
     )
     funders: RelationshipProperty = relationship(
         "Funder", secondary=pub_funder_association, back_populates="publications"
+    )
+
+    __table_args__ = (
+        Index("idx_openalex_id", text("(openalex_json->>'id')")),
+        Index("idx_wos_id", text("(wos_json->>'UID')")),
+        Index("idx_sulpub_id", text("(sulpub_json->>'sulpubid')")),
+        Index("idx_dim_id", text("(dim_json->>'id')")),
     )
 
 


### PR DESCRIPTION
Adds indexes for 4 platform IDs which are in the JSONB column. Resolves #529 to improve queries of the publication table in the remove_duplicates task, and avoiding full table scans. 