### PR TITLE
honeybadger: ignore missing import at config level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ omit = ["test/*"]
 check_untyped_defs = true # Type-checks the interior of functions without type annotations.
 
 [[tool.mypy.overrides]]
-module = ["dimcli", "pyalex", "requests_oauthlib", "sqlalchemy_utils", "jsonpath_ng", "googleapiclient.http", "dominate", "dominate.tags"]
+module = ["dimcli", "honeybadger", "pyalex", "requests_oauthlib", "sqlalchemy_utils", "jsonpath_ng", "googleapiclient.http", "dominate", "dominate.tags"]
 ignore_missing_imports = true
 
 [dependency-groups]

--- a/rialto_airflow/honeybadger.py
+++ b/rialto_airflow/honeybadger.py
@@ -1,4 +1,4 @@
-from honeybadger import honeybadger  # type: ignore
+from honeybadger import honeybadger
 from airflow.models import Variable
 import logging
 
@@ -6,7 +6,7 @@ honeybadger.configure(
     api_key=Variable.get("honeybadger_api_key"),
     environment=Variable.get("honeybadger_env"),
     force_sync=True,
-)  # type: ignore
+)
 
 
 def task_failure_notify(context):


### PR DESCRIPTION
instead of inline with the import and the use of the imported code