### PR TITLE
Consolidate database environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,6 @@ jobs:
           uv run alembic upgrade head
           uv run alembic history --verbose
         env:
-          DATABASE_USERNAME: airflow
-          DATABASE_PASSWORD: airflow
-          DATABASE_HOSTNAME: localhost # localhost because the migration is running from the host VM, not container-land
           AIRFLOW_VAR_RIALTO_POSTGRES: "postgresql+psycopg2://airflow:airflow@localhost"
 
       - name: Run type checking
@@ -64,9 +61,7 @@ jobs:
           AIRFLOW_VAR_MAIS_BASE_URL: ${{ secrets.AIRFLOW_VAR_MAIS_BASE_URL }}
           AIRFLOW_VAR_MAIS_CLIENT_ID: ${{ secrets.AIRFLOW_VAR_MAIS_CLIENT_ID }}
           AIRFLOW_VAR_MAIS_SECRET: ${{ secrets.AIRFLOW_VAR_MAIS_SECRET }}
-          DATABASE_USERNAME: airflow
-          DATABASE_PASSWORD: airflow
-          DATABASE_HOSTNAME: localhost
+          AIRFLOW_VAR_RIALTO_POSTGRES: "postgresql+psycopg2://airflow:airflow@localhost"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,4 +1,3 @@
-import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
@@ -6,6 +5,7 @@ from sqlalchemy import pool
 
 from alembic import context
 
+from rialto_airflow.database import db_uri
 from rialto_airflow.schema.reports import RIALTO_REPORTS_DB_NAME, ReportsSchemaBase
 
 # this is the Alembic Config object, which provides
@@ -60,7 +60,7 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    sqlalchemy_url = f"postgresql+psycopg2://{os.getenv('DATABASE_USERNAME')}:{os.getenv('DATABASE_PASSWORD')}@{os.getenv('DATABASE_HOSTNAME')}/{RIALTO_REPORTS_DB_NAME}"
+    sqlalchemy_url = db_uri(RIALTO_REPORTS_DB_NAME)
     config.set_section_option(
         config.config_ini_section, "sqlalchemy.url", sqlalchemy_url
     )

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -219,11 +219,6 @@ services:
     <<: *airflow-common
     entrypoint: /bin/bash
     user: airflow
-    environment:
-      DATABASE_HOSTNAME: ${DATABASE_HOSTNAME}
-      DATABASE_USERNAME: ${DATABASE_USERNAME}
-      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
-      AIRFLOW_VAR_RIALTO_POSTGRES: "postgresql+psycopg2://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOSTNAME}"
     command:
       - -c
       - |

--- a/compose.yaml
+++ b/compose.yaml
@@ -225,11 +225,6 @@ services:
     <<: *airflow-common
     entrypoint: /bin/bash
     user: airflow
-    environment:
-      DATABASE_HOSTNAME: postgres
-      DATABASE_USERNAME: airflow
-      DATABASE_PASSWORD: airflow
-      AIRFLOW_VAR_RIALTO_POSTGRES: "postgresql+psycopg2://airflow:airflow@postgres"
     command:
       - -c
       - |


### PR DESCRIPTION
closes https://github.com/sul-dlss/rialto-airflow/issues/569

I realized after looking again at the usage of `DATABASE_USERNAME`, `DATABASE_PASSWORD`, and `DATABASE_HOSTNAME`, that my use in the codebase of these `DATABASE_*` env vars was actually unnecessary, and was just the expedient thing to do when developing, since I had those env vars in my local `.env`, and they were what I thought to reference first.

But I was actually able to switch back to using only `AIRFLOW_VAR_RIALTO_POSTGRES` in the codebase, with the `DATABASE_*` env vars only being used to build the `AIRFLOW_VAR_RIALTO_POSTGRES` in compose.prod.yml.  That should keep local dev config simpler, with less churn.  And it should keep details of the DB URL construction from leaking into the codebase (when we already want to construct it in the compose file so Airflow has `AIRFLOW_VAR_RIALTO_POSTGRES`, which our code was just constructing redundantly in the same way from the `DATABASE_*` values).

Migrations work locally on `docker compose up`, but I'd also like to try a small harvest locally, and deploy to stage, to make sure I didn't break anything.

Testing
- [x] local `docker compose up` `rialto-db-init` run
- [x] small local harvest
- [x] deploy to stage, check `current-rialto-db-init-1` logs to confirm migrations ran, run `publish_to_reports` dag