### PR TITLE
Remove use of uv in rialto-db-init

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -222,9 +222,9 @@ services:
     command:
       - -c
       - |
-        uv run python bin/create_databases.py
-        uv run alembic upgrade head
-        uv run alembic history --verbose
+        python bin/create_databases.py
+        alembic upgrade head
+        alembic history --verbose
     depends_on:
       # We want PG to be up, and we want Airflow to do its own initialization first.
       # For prod, the only dependency is airflow-init, because we run PG on

--- a/compose.yaml
+++ b/compose.yaml
@@ -228,9 +228,9 @@ services:
     command:
       - -c
       - |
-        uv run python bin/create_databases.py
-        uv run alembic upgrade head
-        uv run alembic history --verbose
+        python bin/create_databases.py
+        alembic upgrade head
+        alembic history --verbose
     depends_on:
       # We want PG to be up, and we want Airflow to do its own initialization first.
       airflow-init:


### PR DESCRIPTION
The Dockerfile builds up a Python environment that is generally available by Python, since Airflow has no notion of the uv virtual environment.

https://github.com/sul-dlss/rialto-airflow/blob/640ad4e172e9f573cfb384437db6ece064fc8ceb/Dockerfile#L15-L24

I noticed there was a mismatch warning:

```
warning: `VIRTUAL_ENV=/home/airflow/.local` does not match the project environment path `.venv` and will be ignored
```

So I removed the use of `uv` and the migrations seem to apply in my dev environment. 

I tested on stage and it appeared to work fine there too?

```
rialto@sul-rialto-airflow-stage:~/rialto-airflow/current$ docker logs current-rialto-db-init-1
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
Rev: d8e2297c89bb (head)
Parent: 4b7bdf4035f0
Path: /opt/airflow/alembic/versions/d8e2297c89bb_publications_by_school_and_department.py

    publications-by-school-and-department

    Revision ID: d8e2297c89bb
    Revises: a7b78175dd8b
    Create Date: 2025-09-16 15:51:56.807963

Rev: 4b7bdf4035f0
Parent: a7b78175dd8b
Path: /opt/airflow/alembic/versions/4b7bdf4035f0_seed_full_historic_orcid_integration_.py

    Seed full historic orcid integration stats

    Revision ID: 4b7bdf4035f0
    Revises: a7b78175dd8b
    Create Date: 2025-09-16 10:37:29.794892

Rev: a7b78175dd8b
Parent: ad15040c0085
Path: /opt/airflow/alembic/versions/a7b78175dd8b_add_existing_stats_to_orcid_integration_.py

    Add existing stats to orcid_integration_stats

    Revision ID: a7b78175dd8b
    Revises: ad15040c0085
    Create Date: 2025-09-10 10:27:27.060148

Rev: ad15040c0085
Parent: 08f49e63532b
Path: /opt/airflow/alembic/versions/ad15040c0085_create_orcid_integration_stats_table.py

    create orcid_integration_stats table

    Revision ID: ad15040c0085
    Revises: 08f49e63532b
    Create Date: 2025-09-09 15:47:22.145019

Rev: 08f49e63532b
Parent: f47e769bc111
Path: /opt/airflow/alembic/versions/08f49e63532b_create_author_orcids_table.py

    create author_orcids table

    Revision ID: 08f49e63532b
    Revises: f47e769bc111
    Create Date: 2025-09-09 15:37:36.196839

Rev: f47e769bc111
Parent: <base>
Path: /opt/airflow/alembic/versions/f47e769bc111_initialize_reports_db.py

    initialize reports DB

    Revision ID: f47e769bc111
    Revises:
    Create Date: 2025-09-04 00:39:22.624265
```
