### PR TITLE
[test only] Depend on rialto-db-init contianer's successful exit where needed

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -158,6 +158,8 @@ services:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
+      rialto-db-init:
+        condition: service_completed_successfully
 
   airflow-scheduler:
     <<: *airflow-common
@@ -197,6 +199,8 @@ services:
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
+        condition: service_completed_successfully
+      rialto-db-init:
         condition: service_completed_successfully
 
   airflow-triggerer:

--- a/compose.yaml
+++ b/compose.yaml
@@ -167,6 +167,8 @@ services:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
+      rialto-db-init:
+        condition: service_completed_successfully
 
   airflow-scheduler:
     <<: *airflow-common
@@ -204,6 +206,8 @@ services:
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
+        condition: service_completed_successfully
+      rialto-db-init:
         condition: service_completed_successfully
 
   airflow-triggerer:


### PR DESCRIPTION
airflow-webserver and airflow-worker containers require our DB migrations to succeed, because they may write to our custom tables.

If rialto-db-init fails to exit cleanly, that indicates migrations failed.  Dependent containers failing to start in this situation has two advantages:
* `docker compose up` should fail, thus failing the capistrano deployment (since it restarts the docker stack), thus making it clear that there was an issue with deployment.
* Nagios healthcheck for the service (yet to be added) should fail, since the webserver will be down.

Since rialto-airflow is a data harvesting pipeline that runs periodically, the possible brief downtime implied by the above should be tolerable (and preferable to migrations failing silently on deploy).  The person deploying should notice that the deploy failed, and can at worst revert to a working commit while migration issues are debugged.

_**NOTE: this PR is just here to show what was used for testing its rebased version.**_

the branch in this PR is based on the commit before https://github.com/sul-dlss/rialto-airflow/pull/594.  that PR fixed an issue that was preventing migrations from running successfully.  thus, this is a test case for the changes in this branch that show it does indeed loudly fail `docker compose up`, whether locally or as part of a capistrano deployment.  on my laptop, i got:
```
rialto-db-init-1 exited with code 2

service "rialto-db-init" didn't complete successfully: exit 2
```

and `docker compose up` exited unsuccessfully.  when i deployed this branch to stage, i got a similar error, failing the cap deployment, and taking down the webserver:

```
 Container current-airflow-webserver-1  Creating
 Container current-airflow-webserver-1  Created
 Container current-airflow-worker-1  Created
 Container current-redis-1  Starting
 Container current-redis-1  Started
 Container current-redis-1  Waiting
 Container current-redis-1  Healthy
 Container current-airflow-init-1  Starting
 Container current-airflow-init-1  Started
 Container current-redis-1  Waiting
 Container current-airflow-init-1  Waiting
 Container current-airflow-init-1  Waiting
 Container current-redis-1  Waiting
 Container current-airflow-init-1  Waiting
 Container current-redis-1  Healthy
 Container current-redis-1  Healthy
 Container current-airflow-init-1  Exited
 Container current-rialto-db-init-1  Starting
 Container current-airflow-init-1  Exited
 Container current-airflow-triggerer-1  Starting
 Container current-airflow-init-1  Exited
 Container current-airflow-scheduler-1  Starting
 Container current-airflow-triggerer-1  Started
 Container current-rialto-db-init-1  Started
 Container current-airflow-init-1  Waiting
 Container current-rialto-db-init-1  Waiting
 Container current-redis-1  Waiting
 Container current-rialto-db-init-1  Waiting
 Container current-redis-1  Waiting
 Container current-airflow-init-1  Waiting
 Container current-airflow-scheduler-1  Started
 Container current-redis-1  Healthy
 Container current-redis-1  Healthy
 Container current-airflow-init-1  Exited
 Container current-airflow-init-1  Exited
 Container current-rialto-db-init-1  service "rialto-db-init" didn't complete successfully: exit 2
 Container current-rialto-db-init-1  service "rialto-db-init" didn't complete successfully: exit 2
service "rialto-db-init" didn't complete successfully: exit 2


** DEPLOY FAILED
```

so, i think this approach should work to alert us to situations where the migrations are not running successfully.