### PR TITLE
Depend on rialto-db-init contianer's successful exit where needed

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -158,6 +158,8 @@ services:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
+      rialto-db-init:
+        condition: service_completed_successfully
 
   airflow-scheduler:
     <<: *airflow-common
@@ -197,6 +199,8 @@ services:
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
+        condition: service_completed_successfully
+      rialto-db-init:
         condition: service_completed_successfully
 
   airflow-triggerer:

--- a/compose.yaml
+++ b/compose.yaml
@@ -167,6 +167,8 @@ services:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
+      rialto-db-init:
+        condition: service_completed_successfully
 
   airflow-scheduler:
     <<: *airflow-common
@@ -204,6 +206,8 @@ services:
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
+        condition: service_completed_successfully
+      rialto-db-init:
         condition: service_completed_successfully
 
   airflow-triggerer:


### PR DESCRIPTION
`airflow-webserver` and `airflow-worker` containers require our DB migrations to succeed, because they may write to our custom tables.

If `rialto-db-init` fails to exit cleanly, that indicates migrations failed.  Dependent containers failing to start in this situation has two advantages:
* `docker compose up` should fail, thus failing the capistrano deployment (since it restarts the docker stack), thus making it clear that there was an issue with deployment.
* Nagios healthcheck for the service (yet to be added) should fail, since the webserver will be down.

Since rialto-airflow is a data harvesting pipeline that runs periodically, the possible brief downtime implied by the above should be tolerable (and preferable to migrations failing silently on deploy).  The person deploying should notice that the deploy failed, and can at worst revert to a working commit while migration issues are debugged.

I confirmed that this PR will cause both laptop `docker compose up` and capistrano deployment to fail if the DB init container fails to complete sucessfully.  See https://github.com/sul-dlss/rialto-airflow/pull/598 for gory testing details.

I explicitly added the `rialto-db-init` dependency to the two containers in question in addition to the `airflow-init` dependency, even though `rialto-db-init` already depends on `airflow-init`.  This is because our team norm tends to be explicit specification of dependencies in package management configs, even if the dependency is implicitly/transitively available, for both clarity and stability (in the face of indirect dependency changes).  This seemed pretty analogous to that.

closes https://github.com/sul-dlss/rialto-airflow/issues/593