### PR TITLE
New publication type distill rules

### DIFF
--- a/rialto_airflow/distiller.py
+++ b/rialto_airflow/distiller.py
@@ -91,9 +91,11 @@ class FuncRule:
 Rule = JsonPathRule | FuncRule
 
 
-def first(pub: Row, rules: list[Rule]) -> Optional[str | int]:
+def first(pub: Row, rules: list[Rule]) -> Optional[str | int | list]:
     """
-    Examines a Publication row using a list of rules and returns the result of the first rule that matches.
+    Examines a Publication row using a list of rules and returns the result of
+    the first rule that matches. A rule could potentially return a list of
+    values.
     """
     results = all(pub, rules=rules)
     return results[0] if len(results) > 0 else None
@@ -121,8 +123,8 @@ def all(pub: Row, rules: list[Rule]) -> list[str | int]:
         elif isinstance(rule, FuncRule):
             result = _func_match(rule, data)
 
-        # a non-None result indicates the rule hit a match
-        if result is not None:
+        # a non-None, non-empty result indicates the rule hit a match
+        if result is not None and result != []:
             results.append(result)
 
     return results


### PR DESCRIPTION
These changes ensure that publication types are extracted in priority order, returning the first match, instead of aggregating all the publication types from all metadata sources.

In standup we discussed keeping the column as a list until we have seen what data is generated with the new rules. Once we can determine whether we need a preference for types, e.g. to prefer `"preprint"` when there `["preprint", "article"]`, etc.

I ran the harvest DAG in my development environment with a limit of 10,000 and it finished ok.

I did a bit of exploration of publication types that occur together for Web of Science and PubMed in this notebook: https://github.com/sul-dlss-labs/rialto-notebooks/blob/main/pubtypes.ipynb

Closes #607
