### PR TITLE
notify honeybadger on deployment

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -15,5 +15,7 @@ require 'capistrano/maintenance'
 require 'dlss/docker/capistrano'
 require 'capistrano/bundler'
 
+require 'capistrano/honeybadger'
+
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }


### PR DESCRIPTION
turns out I just needed to read the docs and do the idiomatic thing ✨ (third try's a charm)

see https://docs.honeybadger.io/lib/ruby/getting-started/tracking-deployments/#capistrano-deployment-tracking

closes #602

didn't have to do any further configuration to get the deployment notification to report correctly the target env or deploying user.

<img width="1072" height="459" alt="Screenshot 2025-10-10 at 7 15 16 PM" src="https://github.com/user-attachments/assets/81b18bf3-28bc-47e9-916a-2770c5a39b2a" />
<img width="843" height="308" alt="Screenshot 2025-10-10 at 7 16 22 PM" src="https://github.com/user-attachments/assets/64b9d0f3-4a96-4dcc-afe6-973d643ee08c" />
<img width="838" height="244" alt="Screenshot 2025-10-10 at 7 18 11 PM" src="https://github.com/user-attachments/assets/82af72ef-d716-4167-bfd7-158417bde7b8" />
