### PR TITLE
reduce log activity by adjusting log levels and consolidating some log statements

### DIFF
--- a/rialto_airflow/cleanup.py
+++ b/rialto_airflow/cleanup.py
@@ -30,12 +30,12 @@ def cleanup_author_files(cleanup_interval_days: int, data_dir: str):
 def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
     current_time = datetime.now()
 
-    logging.info(f"Current time: {current_time}")
+    logging.debug(f"Current time: {current_time}")
     # first the data folders
     base_snapshot_folder = Path(data_dir) / "snapshots"
     for folder_path in base_snapshot_folder.iterdir():
         if folder_path.is_dir():
-            logging.info(f"Considering snapshot folder {folder_path}")
+            logging.debug(f"Considering snapshot folder {folder_path}")
             folder_time = datetime.strptime(folder_path.name, "%Y%m%d%H%M%S")
             age = current_time - folder_time
             if age.days > cleanup_interval_days:
@@ -50,7 +50,7 @@ def cleanup_snapshots(cleanup_interval_days: int, data_dir: str):
                     )
     # next consider all of the databases (note: the `database_names` method already excludes postgres and airflow)
     for database_name in database_names():
-        logging.info(f"Considering database {database_name}")
+        logging.debug(f"Considering database {database_name}")
         # Check if database name matches the expected format "rialto_%Y%m%d%H%M%S"
         if re.match(r"^rialto_\d{14}$", database_name):
             database_name_date_part = database_name.removeprefix("rialto_")

--- a/rialto_airflow/dags/cleanup.py
+++ b/rialto_airflow/dags/cleanup.py
@@ -26,7 +26,7 @@ def cleanup():
         """
         Remove author files older than the specified number of days from the data directory.
         """
-        logging.info(
+        logging.debug(
             f"Cleanup any author files older than {cleanup_interval_days} days from {data_dir}"
         )
         cleanup_author_files(cleanup_interval_days, data_dir)
@@ -37,7 +37,7 @@ def cleanup():
         """
         Remove snapshot folders and databases older than the specified number of days from the data directory.
         """
-        logging.info(
+        logging.debug(
             f"Cleanup any snapshot folders and databases older than {cleanup_interval_days} days from {data_dir}"
         )
         cleanup_snapshots(cleanup_interval_days, data_dir)

--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -38,11 +38,11 @@ except ValueError:
     pass
 
 if harvest_limit:
-    logging.info(
+    logging.warning(
         f"⚠️ harvest_limit is set to {harvest_limit}, running harvest will stop at the limit number of publications per source"
     )
 else:
-    logging.info(
+    logging.debug(
         "‼️ no harvest_limit is set, running harvest will attempt to retrieve all results"
     )
 

--- a/rialto_airflow/distiller.py
+++ b/rialto_airflow/distiller.py
@@ -139,8 +139,17 @@ def _jsonpath_match(rule: JsonPathRule, data) -> Optional[str | int]:
         result = results[0].value
         if rule.only_positive_number:
             result = _ensure_positive_number(result)
+            if result is None:
+                logging.debug(
+                    f"could not cast '{results[0].value}' to a positive number; jpath={jpath}; data={data}"
+                )
         elif rule.is_valid_year:
             result = _ensure_valid_year(result)
+            if result is None:
+                logging.debug(
+                    f"could not cast '{results[0].value}' to a non-future year; jpath={jpath}; data={data}"
+                )
+
     else:
         result = None
 
@@ -152,10 +161,9 @@ def _ensure_positive_number(value: str | int) -> Optional[int]:
     try:
         result = int(value)
         if result < 0:
-            logging.warning(f"got a non-positive number {value}")
             result = None
     except (ValueError, TypeError):
-        logging.warning(f'got "{value}" instead of a positive number')
+        pass
 
     return result
 
@@ -165,10 +173,9 @@ def _ensure_valid_year(value: str | int) -> Optional[int]:
     try:
         result = int(value)
         if result > datetime.datetime.now().year:
-            logging.warning(f"got a year {value} that is in the future")
             result = None
     except (ValueError, TypeError):
-        logging.warning(f'got "{value}" instead of int')
+        pass
 
     return result
 

--- a/rialto_airflow/funders/linker.py
+++ b/rialto_airflow/funders/linker.py
@@ -45,8 +45,8 @@ def link_dim_publications(snapshot) -> int:
 
         for row in session.execute(stmt):
             count += 1
-            if count % 100 == 0:
-                logging.info(f"processed {count} publications from Dimensions")
+            if count % 50000 == 0:
+                logging.debug(f"processing publication number {count} from Dimensions")
 
             pub = row[0]
 
@@ -62,7 +62,7 @@ def link_dim_publications(snapshot) -> int:
                             .values(publication_id=pub.id, funder_id=funder_id)
                             .on_conflict_do_nothing()
                         )
-    logging.info(f"processed {count} publications from Dimensions")
+    logging.debug(f"processed {count} publications from Dimensions")
     return count
 
 
@@ -80,8 +80,8 @@ def link_openalex_publications(snapshot) -> int:
 
     for row in session.execute(stmt):
         count += 1
-        if count % 100 == 0:
-            logging.info(f"processed {count} publications from OpenAlex")
+        if count % 50000 == 0:
+            logging.debug(f"processed {count} publications from OpenAlex")
 
         pub = row[0]
 
@@ -100,7 +100,7 @@ def link_openalex_publications(snapshot) -> int:
                         .values(publication_id=pub.id, funder_id=funder_id)
                         .on_conflict_do_nothing()
                     )
-    logging.info(f"processed {count} publications from OpenAlex")
+    logging.debug(f"processed {count} publications from OpenAlex")
     return count
 
 
@@ -109,7 +109,7 @@ def _find_or_create_dim_funder(session: Session, funder: dict) -> Optional[int]:
     name = funder.get("name")
 
     if grid_id is None or name is None:
-        logging.info(f"missing GRID ID in {funder}")
+        logging.warning(f"missing GRID ID in {funder}")
         return None
 
     federal = is_federal_grid_id(grid_id) or is_federal(name)
@@ -162,7 +162,7 @@ def _lookup_openalex_funder(openalex_id: str) -> Optional[dict]:
     """
     try:
         funder = Funders()[openalex_id]
-        logging.info(f"found funder data in openalex for {openalex_id}")
+        logging.debug(f"found funder data in openalex for {openalex_id}")
     except requests.exceptions.HTTPError:
         logging.warning(f"OpenAlex API returned error for {openalex_id}")
         return None

--- a/rialto_airflow/harvest/authors.py
+++ b/rialto_airflow/harvest/authors.py
@@ -19,7 +19,7 @@ def load_authors_table(snapshot) -> None:
     authors_file = rialto_authors_file(snapshot.path)
     check_headers(authors_file)
 
-    logging.info(
+    logging.debug(
         f"Loading authors from {authors_file} into database {snapshot.database_name}"
     )
     with open(authors_file, "r") as file:
@@ -46,7 +46,9 @@ def load_authors_table(snapshot) -> None:
                     session.add(author)
             except IntegrityError as e:
                 message = f"Skipping author: {row['sunetid'], row['orcidid']}: {e}"
-                logging.warning(message)
+                logging.debug(
+                    message
+                )  # this is debug level so we can watch as it goes if need be, but errors are logged in aggregate at warning level at end
                 errors.append(message)
                 continue
             finally:
@@ -80,7 +82,7 @@ def check_headers(authors_file: str) -> None:
             raise ValueError(
                 f"Headers in {authors_file} are {headers}, expected to include {required_headers}"
             )
-        logging.info(f"Headers in {authors_file}: {headers}")
+        logging.debug(f"Headers in {authors_file}: {headers}")
 
 
 def to_boolean(value: str) -> bool:

--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -12,7 +12,7 @@ def remove_duplicates(snapshot: Snapshot) -> int:
     Remove duplicate publications from the database.
     Returns the number of duplicates found (not the number of rows deleted).
     """
-    logging.info("Removing duplicate publications from each source.")
+    logging.debug("Removing duplicate publications from each source.")
     wos_dupes = remove_wos_duplicates(snapshot)
     openalex_dupes = remove_openalex_duplicates(snapshot)
     total_deleted = wos_dupes + openalex_dupes
@@ -23,7 +23,7 @@ def remove_duplicates(snapshot: Snapshot) -> int:
 
 
 def remove_wos_duplicates(snapshot: Snapshot) -> int:
-    logging.info("Removing any duplicate WOS publications.")
+    logging.debug("Removing any duplicate WOS publications.")
     with get_session(snapshot.database_name).begin() as session:
         # Find all duplicate WOS publications in the snapshot
         duplicates = session.execute(
@@ -34,7 +34,7 @@ def remove_wos_duplicates(snapshot: Snapshot) -> int:
             .having(func.count() > 1)
         ).all()
         num_dupes = len(duplicates)
-        logging.info(f"Found {num_dupes} publications with duplicates.")
+        logging.info(f"Found {num_dupes} WOS publications with duplicates.")
         count_deleted = 0
         wos_uids = [row[1] for row in duplicates]
         for wos_uid in wos_uids:
@@ -54,7 +54,7 @@ def remove_wos_duplicates(snapshot: Snapshot) -> int:
 
 
 def remove_openalex_duplicates(snapshot: Snapshot) -> int:
-    logging.info("Removing any duplicate OpenAlex publications.")
+    logging.debug("Removing any duplicate OpenAlex publications.")
     with get_session(snapshot.database_name).begin() as session:
         # Find all duplicate OpenAlex publications in the snapshot
         duplicates = session.execute(
@@ -65,7 +65,7 @@ def remove_openalex_duplicates(snapshot: Snapshot) -> int:
             .having(func.count() > 1)
         ).all()
         num_dupes = len(duplicates)
-        logging.info(f"Found {num_dupes} publications with duplicates.")
+        logging.info(f"Found {num_dupes} OpenAlex publications with duplicates.")
         count_deleted = 0
         openalex_ids = [row[1] for row in duplicates]
         for openalex_id in openalex_ids:

--- a/rialto_airflow/harvest/distill.py
+++ b/rialto_airflow/harvest/distill.py
@@ -22,8 +22,8 @@ def distill(snapshot: Snapshot) -> int:
 
         for row in select_session.execute(stmt):
             count += 1
-            if count % 100 == 0:
-                logging.info(f"processed {count} publications")
+            if count % 50000 == 0:
+                logging.debug(f"processed {count} publications")
 
             pub = row[0]
 

--- a/rialto_airflow/harvest/sul_pub.py
+++ b/rialto_airflow/harvest/sul_pub.py
@@ -86,7 +86,7 @@ def publications(host, key, per_page=1000, limit=None):
         page += 1
         params["page"] = page
 
-        logging.info(f"fetching sul_pub results {url} {params}")
+        logging.debug(f"fetching sul_pub results {url} {params}")
         resp = http.get(url, params=params, headers=http_headers)
         resp.raise_for_status()
 
@@ -97,7 +97,7 @@ def publications(host, key, per_page=1000, limit=None):
         for record in records:
             record_count += 1
             if limit is not None and record_count > limit:
-                logging.info(f"stopping with limit={limit}")
+                logging.warning(f"stopping with limit={limit}")
                 more = False
                 break
 
@@ -110,7 +110,7 @@ def extract_doi(pub):
 
     for id in pub.get("identifier"):
         if id.get("type") == "doi" and "id" in id:
-            logging.info(
+            logging.debug(
                 f"doi was not available in top level for sulpub id {pub.get('sulpubid')} but found in identifier block"
             )
             return normalize_doi(id["id"])

--- a/rialto_airflow/mais.py
+++ b/rialto_airflow/mais.py
@@ -73,7 +73,7 @@ def fetch_orcid_users(
     access_token = get_token(mais_client_id, mais_client_secret, mais_token_url)
 
     while True:  # paging
-        logging.info(f"Fetching {url}")
+        logging.debug(f"Fetching {url}")
         tries = 0
         while True:  # retry loop for token expiration
             try:

--- a/test/harvest/test_deduplicate.py
+++ b/test/harvest/test_deduplicate.py
@@ -95,7 +95,7 @@ def test_wos_deduplicate(test_session, dataset, snapshot, caplog):
         # the second author remains and is linked to one publication
         author2 = session.query(Author).where(Author.orcid == "02980983434").one()
         assert len(author2.publications) == 1
-        assert "Found 1 publications with duplicates." in caplog.text
+        assert "Found 1 WOS publications with duplicates." in caplog.text
         assert "Deleted 1 publication rows from WOS." in caplog.text
 
 
@@ -120,7 +120,7 @@ def test_openalex_deduplicate(test_session, dataset, snapshot, caplog):
         assert len(author2.publications) == 1, (
             "second author exists and is linked to the remaining publication"
         )
-        assert "Found 1 publications with duplicates." in caplog.text
+        assert "Found 1 OpenAlex publications with duplicates." in caplog.text
         assert "Deleted 1 publication rows from OpenAlex." in caplog.text
 
 

--- a/test/harvest/test_distill.py
+++ b/test/harvest/test_distill.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from rialto_airflow.schema.harvest import Publication, Author
@@ -608,6 +609,8 @@ def test_non_int_year_fallback(test_session, snapshot, caplog):
     """
     Test that higher priority non-integer year doesn't prevent a year coming from another source.
     """
+    caplog.set_level(logging.DEBUG)
+
     with test_session.begin() as session:
         session.bulk_save_objects(
             [
@@ -621,7 +624,10 @@ def test_non_int_year_fallback(test_session, snapshot, caplog):
 
     distill(snapshot)
     assert _pub(session).pub_year == 2022
-    assert 'got "nope" instead of int' in caplog.text
+    assert (
+        "could not cast 'nope' to a non-future year; jpath=year; data={'year': 'nope'}"
+        in caplog.text
+    )
 
 
 def test_types(test_session, snapshot, caplog):

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -7,7 +7,7 @@ import pyalex
 from rialto_airflow.harvest import openalex
 from rialto_airflow.schema.harvest import Publication
 
-from test.utils import num_jsonl_objects
+from test.utils import num_jsonl_objects, num_log_record_matches
 
 dotenv.load_dotenv()
 
@@ -290,7 +290,7 @@ def test_colon():
         pyalex.Works().filter(doi=dois).get()
 
 
-def test_clean_dois_for_query():
+def test_clean_dois_for_query(caplog):
     assert openalex._clean_dois_for_query(
         [
             "doi:123",
@@ -301,3 +301,9 @@ def test_clean_dois_for_query():
             "10.1093/noajnl/vdad070.013pmcid:pmc10402389",
         ]
     ) == ["aaa/111", "abc/123"]
+
+    assert num_log_record_matches(
+        caplog.records,
+        logging.WARNING,
+        "dropped 4 DOIs from openalex lookup: ['doi:123', 'abc/123,45', '123/abc pmcid:123', '10.1093/noajnl/vdad070.013pmcid:pmc10402389']",
+    )

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 
 def num_jsonl_objects(jsonl_path):
@@ -16,3 +17,17 @@ def load_jsonl_file(path):
         for line in f:
             result.append(json.loads(line))
     return result
+
+
+def is_matching_log_record(
+    r: logging.LogRecord, levelno: int, renderd_msg_fragment: str
+) -> bool:
+    return r.levelno == levelno and renderd_msg_fragment in r.getMessage()
+
+
+def num_log_record_matches(
+    records: list[logging.LogRecord], levelno: int, renderd_msg_fragment: str
+) -> int:
+    return len(
+        [r for r in records if is_matching_log_record(r, levelno, renderd_msg_fragment)]
+    )


### PR DESCRIPTION
part of #632 (maybe wait for a production run we're happy with to close?)

turn some info level statements to debug level, especially inside of loops, with the expectation that logging level in deployed envs will usually be set to info or warning.

turn a couple info level statements to warning level (esp around harvest limit setting used in test envs), so that they always show up in prod envs, where we woult typically not want limited harvests.

switching info statements to debug lets us keep them around in case they'd be useful again for troubleshooting, without adding noise in normal operation.

add a couple functions to test.utils for asserting expectations on log output.