### PR TITLE
Fix handling of atypical pubmed abstracts

### DIFF
--- a/rialto_airflow/publish/publication.py
+++ b/rialto_airflow/publish/publication.py
@@ -305,7 +305,12 @@ def _pubmed_abstract(pubmed_json: dict) -> str | None:
                 full_abstract.append(abstract.value)
             else:
                 full_abstract.append(abstract.value.get("#text", None))
-
+        # remove any None or empty-string segments before joining
+        full_abstract = [
+            text
+            for text in full_abstract
+            if text is not None and str(text).strip() != ""
+        ]
         return " ".join(full_abstract)
     return None
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -353,6 +353,8 @@ def pubmed_json():
                         {
                             "#text": "E2006-G000-304 was a phase 3, one-month polysomnography trial in adults aged ≥55 years with insomnia.",
                         },
+                        {"#text": None},
+                        {"@Label": "METHODS"},
                     ]
                 },
                 "Title": "Example Journal",


### PR DESCRIPTION
The code to extract an abstract from `pubmed_json` was not handling situations where a `None` could end up in the list of abstract values. 

This caused the following error in the `publish_publications_by_author` task:

```
  File "/opt/airflow/rialto_airflow/publish/publication.py", line 309, in _pubmed_abstract
    return " ".join(full_abstract)
```