### PR TITLE
Handle pubmed identifier lists

### DIFF
--- a/rialto_airflow/publish/publication.py
+++ b/rialto_airflow/publish/publication.py
@@ -618,12 +618,8 @@ def _author_list_orcids(row) -> list[str]:
         ],
     )
 
-    logging.info(orcids)
-
     # restructure a list of lists into a flat list of strings
     orcids = list(itertools.chain(*orcids))
-
-    logging.info(orcids)
 
     orcids = [normalize_orcid(orcid) for orcid in orcids if orcid is not None]
 
@@ -638,8 +634,16 @@ def _pubmed_orcids(row):
     for result in json_path(
         "MedlineCitation.Article.AuthorList.Author[*].Identifier"
     ).find(row):
-        if result.value.get("@Source") == "ORCID":
-            orcids.append(result.value["#text"])
+        ids = result.value
+
+        # Identifier can be a single dict, or a list of dicts.
+        # Ensure that it is a list of dicts.
+        if type(ids) is dict:
+            ids = [ids]
+
+        for id_ in ids:
+            if id_.get("@Source") == "ORCID":
+                orcids.append(id_["#text"])
 
     return orcids
 
@@ -703,7 +707,14 @@ def _pubmed_author_orcid(pub, pos: int) -> str | None:
         ).find(pub)
 
     for result in results:
-        if result.value.get("@Source") == "ORCID":
-            return result.value.get("#text")
+        ids = result.value
+
+        # Identifier can be a single dict or a list of dicts
+        if type(ids) is dict:
+            ids = [ids]
+
+        for id_ in ids:
+            if id_.get("@Source") == "ORCID":
+                return id_.get("#text")
 
     return None

--- a/test/publish/test_publications_by_author.py
+++ b/test/publish/test_publications_by_author.py
@@ -798,6 +798,41 @@ def test_one_author():
     assert publication._first_author_orcid(pub) == "jane-wos"
 
 
+def test_pubmed_identifier_list():
+    """
+    PubMed authors sometimes have a list of identifiers instead of just having one.
+    """
+    pub = Publication(
+        doi="10.000/example",
+        title="I'm a Book",
+        apc=None,
+        open_access="gold",
+        pub_year=2023,
+        pubmed_json={
+            "MedlineCitation": {
+                "Article": {
+                    "AuthorList": {
+                        "Author": {
+                            "ForeName": "Jane",
+                            "LastName": "Pubmed",
+                            "Identifier": [
+                                {
+                                    "@Source": "ORCID",
+                                    "#text": "jane-pubmed",
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+    assert publication._author_list_orcids(pub) == ["jane-pubmed"]
+    assert publication._first_author_orcid(pub) == "jane-pubmed"
+    assert publication._last_author_orcid(pub) == "jane-pubmed"
+
+
 def test_crossref_missing_given_name():
     pub = Publication(
         doi="10.000/example",


### PR DESCRIPTION
Sometimes there can be a list of identifiers for a pubmed author. We need to be able to handle when there are lists and single objects.

This was tested in stage and production by running the `publish_to_reports` DAG.

This is follow on work from #666 
