### PR TITLE
openalex pyalex library is now throwing generic 400 instead of a specific exception

### DIFF
--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -272,7 +272,7 @@ def test_comma():
     this starts working again we can stop ignoring them when looking them up by
     DOI when doing the fill-in process.
     """
-    with pytest.raises(pyalex.api.QueryError, match="Invalid query parameter"):
+    with pytest.raises(requests.exceptions.HTTPError, match="Bad Request for url"):
         dois = "10.1103/physrevd.72,031101"
         pyalex.Works().filter(doi=dois).get()
 
@@ -284,9 +284,7 @@ def test_colon():
     filter using an OR boolean. If this test starts passing we can consider
     stopping ignoring them.
     """
-    with pytest.raises(
-        pyalex.api.QueryError, match="It looks like you're trying to do an OR query"
-    ):
+    with pytest.raises(requests.exceptions.HTTPError, match="Bad Request for url"):
         dois = "abc123|doi:abc123"
         pyalex.Works().filter(doi=dois).get()
 


### PR DESCRIPTION
Our tests currently look for a pyalex specific exception, but it's now coming back as a 400.  This just updates the test expectations.  I believe our actual harvesting code is filtering these cases out before they get to the API call (see the method here: https://github.com/sul-dlss/rialto-airflow/blob/main/rialto_airflow/harvest/openalex.py#L155), so it shouldn't be happening the actual harvesting so I don't think there is a need to update code elsewhere.
