### PR TITLE
Deduplicate by sulpubid

### DIFF
--- a/rialto_airflow/dags/harvest.py
+++ b/rialto_airflow/dags/harvest.py
@@ -165,7 +165,9 @@ def harvest():
     @task()
     def remove_duplicates(snapshot):
         """
-        Remove duplicates based on WOS UID.
+        Remove duplicates. This task is run *before* the distill_publications
+        task because we want to fold together any duplicates prior to extracting
+        values from metadata.
         """
         deduplicate.remove_duplicates(snapshot)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -341,6 +341,7 @@ def wos_json_no_page_info():
 @pytest.fixture
 def sulpub_json():
     return {
+        "sulpubid": "123456",
         "journal": {
             "name": "Bad Limes Journal of Science",
             "issue": "9",


### PR DESCRIPTION
We noticed that the sulpub API can return the same publication multiple times. This commit adds a deduplicate by sulpubid to the existing remove_duplicates task.

This PR takes a different approach from that taken in #690 and should be more resilient to restarts of the harvest_sulpub task, if they were to happen, since it doesn't depend on an in memory set of all sulpub IDs that have been harvested.

Fixes #684
