### PR TITLE
Handle empty string in arxiv doi extraction

### DIFF
--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -70,15 +70,11 @@ def normalize_arxiv_id_to_doi(possible_arxiv_doi: str):
     colon with a period). For example, the arXiv ID arXiv:2202.01037 will
     translate to the DOI link https://doi.org/10.48550/arXiv.2202.01037."
     """
-    return (
-        re.sub("^arxiv:", "10.48550/arxiv.", possible_arxiv_doi, flags=re.IGNORECASE)
-        if possible_arxiv_doi
-        else None
-    )
+    return re.sub("^arxiv:", "10.48550/arxiv.", possible_arxiv_doi, flags=re.IGNORECASE)
 
 
 def normalize_doi(doi):
-    if doi is None:
+    if doi is None or doi.strip() == "":
         _data_quality_warning("Empty DOI")
         return None
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -71,6 +71,8 @@ def test_normalize_doi():
         == "10.48550/arxiv.2202.01037"
     )
     assert utils.normalize_doi(None) is None
+    assert utils.normalize_doi("") is None
+    assert utils.normalize_doi("   ") is None
 
 
 def test_normalize_pmid():


### PR DESCRIPTION
It looks like empty string DOI (or DOIs solely comprised of spaces) are being passed to normalize_doi() which then causes normalize_arxiv_id_to_doi() to return None, since "" evaluates to False. This then causes the doi_candidate_extract() to fail since it isn't expecting a DOI of None.

The solution here is to have noramlize_arxiv_id_to_doi() to always expect a str, it should blow up if passed a None. A check early in normalize_doi was added to make sure empty string, or strings of just spaces are normalized to None.

Aside: I'm just noticing now that the DOI validation functions seem to lack type annotations. I think it would be helpful to add them, but I think it may cause some ripple effect changes elsewhere in the code. refs #698 

Fixes #696
