### PR TITLE
piped() needs to handle None in list

### DIFF
--- a/rialto_airflow/publish/publication.py
+++ b/rialto_airflow/publish/publication.py
@@ -469,7 +469,7 @@ def _citation_count(row) -> str | int | None:
 
 def _author_list_names(row) -> list[Any]:
     """
-    Get a pipe delimited list of all the author names.
+    Get a list of all the author names.
     """
     names = first(
         row,

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -129,6 +129,9 @@ def piped(lst: list[str] | None) -> Optional[str]:
     if lst is None:
         return None
 
+    # ensure the list doesn't contain None
+    lst = list(filter(lambda item: item is not None, lst))
+
     return "|".join(lst)
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -98,3 +98,8 @@ def test_normalize_orcid():
         utils.normalize_orcid(" HTTPS://ORCID.org/0000-0002-7262-6251 ")
         == "0000-0002-7262-6251"
     )
+
+
+def test_piped():
+    assert utils.piped(["a", "b", "c"]) == "a|b|c"
+    assert utils.piped(["a", None, "c", None, "d"]) == "a|c|d"  # type: ignore


### PR DESCRIPTION
It looks like OpenAlex is now returning Works that contain authors that lack a `display_name`. Rather than fixing the problem in the `author_list_names()` this change updates `piped()` to guard against a list containing one or more `None` values.

https://api.openalex.org/w2761026767

<img width="1445" height="798" alt="Screenshot 2025-11-18 at 10 52 13 AM" src="https://github.com/user-attachments/assets/09ddb429-464a-4302-8850-824deb91bbf4" />

Here's what the data looks like in the old data model prior to the change:

https://api.openalex.org/w2761026767?data-version=1

<img width="1558" height="919" alt="Screenshot 2025-11-18 at 11 07 18 AM" src="https://github.com/user-attachments/assets/c5e91562-0417-4b5a-9c03-5f6a2720ec99" />

The change is likely due to the [Walden release](https://blog.openalex.org/openalex-rewrite-walden-launch/) of OpenAlex. I compared the pre-Walden data with what we got this week in production. Pre-walden there were no authors with `display_name` of `None`. Afterwards it found 2,580 works that contained one or more authors with a None as `display_name`. The Work URLs are attached.

[display_name_null.txt](https://github.com/user-attachments/files/23610087/display_name_null.txt)

Fixes #700