### PR TITLE
Adding natural key deduplication

### DIFF
--- a/rialto_airflow/distiller/__init__.py
+++ b/rialto_airflow/distiller/__init__.py
@@ -15,6 +15,7 @@ from .volume import volume
 from .citation_count import citation_count
 from .author_names import author_list_names, first_author_name, last_author_name
 from .author_orcids import author_list_orcids, first_author_orcid, last_author_orcid
+from .natural_key import natural_key
 
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "JsonPathRule",
     "last_author_name",
     "last_author_orcid",
+    "natural_key",
     "open_access",
     "pages",
     "pub_year",

--- a/rialto_airflow/distiller/natural_key.py
+++ b/rialto_airflow/distiller/natural_key.py
@@ -1,0 +1,33 @@
+import re
+
+from rialto_airflow.distiller.title import title
+from rialto_airflow.distiller.author_names import first_author_name
+from rialto_airflow.distiller.pub_year import pub_year
+
+
+def natural_key(pub):
+    title_str = title(pub)
+    first_author_str = first_author_name(pub)
+    pub_year_int = pub_year(pub)
+
+    # we need these to generate a natural key for the publication
+    if title_str is None or first_author_str is None or pub_year_int is None:
+        return None
+
+    parts = [title_str, first_author_str, str(pub_year_int)]
+
+    parts = list(map(_normalize, parts))
+
+    return ":".join(parts)
+
+
+def _normalize(s):
+    """
+    Remove punctuation, whitespace, and lowercase.
+    """
+    if s is None:
+        return None
+    s = re.sub(r"[^\w\s]", "", s)
+    s = re.sub(r" ", "", s)
+    s = s.lower()
+    return s

--- a/test/distiller/test_natural_key.py
+++ b/test/distiller/test_natural_key.py
@@ -1,0 +1,14 @@
+from rialto_airflow.distiller import natural_key
+from rialto_airflow.schema.harvest import Publication
+
+
+def test_natural_key():
+    pub = Publication(
+        openalex_json={
+            "title": "I'm a Book",
+            "publication_year": 1880,
+            "authorships": [{"author": {"display_name": "Jane Stanford"}}],
+        }
+    )
+
+    assert natural_key(pub) == "imabook:janestanford:1880"


### PR DESCRIPTION
This commit adds a step to the deduplication Airflow task to fold together publications that have similar title, publication year and first author.

Closes #685
