### PR TITLE
remove unnecessary columns from publications_by_author table

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ pip3 install --upgrade uv # in stage and prod, will install to ~/.local/bin/uv (
 # create the database(s) for which Alembic manages migrations -- this must happen before migrations run
 uv run python bin/create_databases.py
 
-uv run alembic upgrade head # run the migrations to get to the current DB schema for the deployment
-uv run alembic current # show the current migration revision for this env
-uv run alembic history --verbose # show the history of migrations that have been run in this env
+uv run dotenv alembic upgrade head # run the migrations to get to the current DB schema for the deployment
+uv run dotenv alembic current # show the current migration revision for this env
+uv run dotenv alembic history --verbose # show the history of migrations that have been run in this env
 ```
 
 ## Run Tests

--- a/alembic/versions/148d276f0f9c_remove_funder_list_columns_from_.py
+++ b/alembic/versions/148d276f0f9c_remove_funder_list_columns_from_.py
@@ -1,0 +1,37 @@
+"""Remove funder_list columns from publication_by_authors
+
+Revision ID: 148d276f0f9c
+Revises: b832bef1963f
+Create Date: 2025-12-01 14:26:45.501111
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "148d276f0f9c"
+down_revision: Union[str, Sequence[str], None] = "b832bef1963f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_column("publications_by_author", "funder_list_grid")
+    op.drop_column("publications_by_author", "funder_list_name")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "publications_by_author",
+        sa.Column("funder_list_grid", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "publications_by_author",
+        sa.Column("funder_list_name", sa.Text(), nullable=True),
+    )

--- a/rialto_airflow/schema/reports.py
+++ b/rialto_airflow/schema/reports.py
@@ -80,8 +80,6 @@ class PublicationsByAuthor(ReportsSchemaBase):  # type: ignore
     federally_funded = Column(Boolean)
     first_author_name = Column(String)
     first_author_orcid = Column(String)
-    funder_list_grid = Column(Text)
-    funder_list_name = Column(Text)
     grant_ids = Column(Text)
     issue = Column(String)
     journal_name = Column(String)


### PR DESCRIPTION
Fixes #711 - remove the columns from the database table because the CSV file is simply produced by exporting the entire table (see https://github.com/sul-dlss/rialto-airflow/blob/main/rialto_airflow/publish/publication.py#L307-L340)
