### PR TITLE
Drop unnecessary timestamp columns from publications table

### DIFF
--- a/alembic/versions/ef9157a6df79_drop_timestamp_columns.py
+++ b/alembic/versions/ef9157a6df79_drop_timestamp_columns.py
@@ -1,0 +1,38 @@
+"""Drop timestamp columns
+
+Revision ID: ef9157a6df79
+Revises: 148d276f0f9c
+Create Date: 2025-12-02 16:21:58.554124
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from rialto_airflow.database import utcnow
+
+
+# revision identifiers, used by Alembic.
+revision: str = "ef9157a6df79"
+down_revision: Union[str, Sequence[str], None] = "148d276f0f9c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_column("publications", "created_at")
+    op.drop_column("publications", "updated_at")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "publications",
+        sa.Column("created_at", sa.DateTime, server_default=utcnow()),
+    )
+    op.add_column(
+        "publications",
+        sa.Column("updated_at", sa.DateTime, onupdate=utcnow()),
+    )

--- a/rialto_airflow/schema/reports.py
+++ b/rialto_airflow/schema/reports.py
@@ -29,8 +29,6 @@ class Publications(ReportsSchemaBase):  # type: ignore
     federally_funded = Column(Boolean)
     academic_council_authored = Column(Boolean)
     faculty_authored = Column(Boolean)
-    created_at = Column(DateTime, server_default=utcnow())
-    updated_at = Column(DateTime, onupdate=utcnow())
 
 
 class PublicationsBySchool(ReportsSchemaBase):  # type: ignore


### PR DESCRIPTION
We have `created_at` and `updated_at` columns in the rialto_reports publications table, but those columns have not turned out to be relevant. We truncate and reload the data, and don't update rows or need a creation date.

 