### PR TITLE
Zip data dictionary

### DIFF
--- a/rialto_airflow/publish/documentation/publications_by_author_data_dictionary.csv
+++ b/rialto_airflow/publish/documentation/publications_by_author_data_dictionary.csv
@@ -1,0 +1,28 @@
+Field,Type,Description
+id,Integer,RIALTO database primary key 
+doi,String,DOI (Digital Object Identifier)
+sunet,String,SUNet ID of the Stanford author associated with the publication
+orcid,String,ORCID of the Stanford author associated with the publication
+abstract,String,"Abstract, from OpenAlex, Dimensions, PubMed, or CrossRef"
+academic_council,Boolean,True if author is a member of the Stanford Academic Council
+apc,Integer,"Article Processing Charge, in order of preference: (1) API ""paid"" price data from OpenAlex (typically comes from OpenAPC, a crowdsourced APC dataset where individual researchers and institutions can add APC data), (2) open dataset of APCs prepared by the ScholCom Lab at Simon Fraser University and available at  https://doi.org/10.7910/DVN/CR1MMV, (3) ""list"" price from OpenAlex. For any remaining publication, we estimate the APC based on the Open Access category: ""Gold""=$2,450; ""Hybrid""=$3,600; all other categories = $0."
+author_list_names,String,"Pipe-delimited list of all authors. From, in order of preference: OpenAlex, Dimensions, PubMed, Web of Science, CrossRef, or Stanford University Libraries Publications (SUL-Pub database). "
+author_list_orcids,String,"Pipe-delimited list of all authors' ORCIDs available from all of OpenAlex, Dimensions, PubMed, Web of Science, CrossRef, or Stanford University Libraries Publications (SUL-Pub database)"
+citation_count,Integer,"Count of references to the publication, taking the highest citation count from OpenAlex, Dimensions, and Web of Science."
+federally_funded,Boolean,"True if at least one of the publication’s funders is federal. Funder data for each publication is provided by Dimensions or OpenAlex, and we use the OSTP Impact dataset, enhanced with ROR identifiers, to identify which funders are federal. "
+first_author_name,String,Author name that appears first on the publication
+first_author_orcid,String,"ORCID, if available, for the first author on the publication"
+issue,String,Issue number for the journal in which the publication appeared
+journal_name,String,Name of journal which published the publication
+last_author_name,String,Author name that appears last on the publication
+last_author_orcid,String,"ORCID, if available, for the last author on the publication"
+open_access,String,"Open Access category, as determined by OpenAlex or Dimensions. One of: diamond, gold, hybrid, green, bronze, closed. May be null."
+pages,String,Page numbers for the publication
+primary_department,String,The primary Stanford department a researcher is affiliated with. A researcher may have multiple affiliations beyond this primary department.
+primary_school,String,The primary Stanford school a researcher is affiliated with. A researcher may have multiple affiliations beyond this primary school. 
+pub_year,Integer,Year of publication
+publisher,String,"Publisher of the journal in which the publication appears, if applicable, obtained from OpenAlex."
+role,String,"Primary role of the author at Stanford. One of: affiliate, faculty, fellow, msstudent, phdstudent, postdoc, registry, resident, staff, student, other"
+title,String,Title of the publication
+types,String,"Types of publication, normalized to values: Article, Book, Chapter, Correction/Retraction, Dataset, Dissertation, Editorial Material, Other. Types are pipe-delimited when there are multiple."
+volume,String,"Volume of the journal in which the publication appeared, if available"

--- a/rialto_airflow/publish/documentation/publications_by_department_data_dictionary.csv
+++ b/rialto_airflow/publish/documentation/publications_by_department_data_dictionary.csv
@@ -1,0 +1,14 @@
+Field,Type,Description
+id,Integer,RIALTO database primary key 
+doi,String,DOI (Digital Object Identifier)
+academic_council_authored,Boolean,True if any Stanford author is a member of the Stanford Academic Council
+apc,Integer,"Article Processing Charge, in order of preference: (1) API ""paid"" price data from OpenAlex (typically comes from OpenAPC, a crowdsourced APC dataset where individual researchers and institutions can add APC data), (2) open dataset of APCs prepared by the ScholCom Lab at Simon Fraser University and available at  https://doi.org/10.7910/DVN/CR1MMV, (3) ""list"" price from OpenAlex. For any remaining publication, we estimate the APC based on the Open Access category: ""Gold""=$2,450; ""Hybrid""=$3,600; all other categories = $0."
+faculty_authored,Boolean,True if any Stanford author has a primary role of faculty
+federally_funded,Boolean,"True if at least one of the publication’s funders is federal. Funder data for each publication is provided by Dimensions or OpenAlex, and we use the OSTP Impact dataset, enhanced with ROR identifiers, to identify which funders are federal. "
+journal_name,String,Name of journal which published the publication
+open_access,String,"Open Access category, as determined by OpenAlex or Dimensions. One of: diamond, gold, hybrid, green, bronze, closed. May be null."
+primary_department,String,The primary Stanford department a researcher is affiliated with. A researcher may have multiple affiliations beyond this primary department.
+primary_school,String,The primary Stanford school a Stanford author is affiliated with. There is a row in the dataset for each primary_school associated with an author. 
+pub_year,Integer,Year of publication
+publisher,String,"Publisher of the journal in which the publication appears, if applicable, obtained from OpenAlex."
+types,String,"Types of publication, normalized to values: Article, Book, Chapter, Correction/Retraction, Dataset, Dissertation, Editorial Material, Other. Types are pipe-delimited when there are multiple."

--- a/rialto_airflow/publish/documentation/publications_by_school_data_dictionary.csv
+++ b/rialto_airflow/publish/documentation/publications_by_school_data_dictionary.csv
@@ -1,0 +1,13 @@
+Field,Type,Description
+id,Integer,RIALTO database primary key 
+doi,String,DOI (Digital Object Identifier)
+academic_council_authored,Boolean,True if any Stanford author is a member of the Stanford Academic Council
+apc,Integer,"Article Processing Charge, in order of preference: (1) API ""paid"" price data from OpenAlex (typically comes from OpenAPC, a crowdsourced APC dataset where individual researchers and institutions can add APC data), (2) open dataset of APCs prepared by the ScholCom Lab at Simon Fraser University and available at  https://doi.org/10.7910/DVN/CR1MMV, (3) ""list"" price from OpenAlex. For any remaining publication, we estimate the APC based on the Open Access category: ""Gold""=$2,450; ""Hybrid""=$3,600; all other categories = $0."
+faculty_authored,Boolean,True if any Stanford author has a primary role of faculty
+federally_funded,Boolean,"True if at least one of the publication’s funders is federal. Funder data for each publication is provided by Dimensions or OpenAlex, and we use the OSTP Impact dataset, enhanced with ROR identifiers, to identify which funders are federal. "
+journal_name,String,Name of journal which published the publication
+open_access,String,"Open Access category, as determined by OpenAlex or Dimensions. One of: diamond, gold, hybrid, green, bronze, closed. May be null."
+primary_school,String,The primary Stanford school a Stanford author is affiliated with. There is a row in the dataset for each primary_school associated with an author. 
+pub_year,Integer,Year of publication
+publisher,String,"Publisher of the journal in which the publication appears, if applicable, obtained from OpenAlex."
+types,String,"Types of publication, normalized to values: Article, Book, Chapter, Correction/Retraction, Dataset, Dissertation, Editorial Material, Other. Types are pipe-delimited when there are multiple."

--- a/rialto_airflow/publish/documentation/publications_data_dictionary.csv
+++ b/rialto_airflow/publish/documentation/publications_data_dictionary.csv
@@ -1,0 +1,12 @@
+Field,Type,Description
+id,Integer,RIALTO database primary key 
+doi,String,DOI (Digital Object Identifier)
+academic_council_authored,Boolean,True if any Stanford author is a member of the Stanford Academic Council
+apc,Integer,"Article Processing Charge, in order of preference: (1) API ""paid"" price data from OpenAlex (typically comes from OpenAPC, a crowdsourced APC dataset where individual researchers and institutions can add APC data), (2) open dataset of APCs prepared by the ScholCom Lab at Simon Fraser University and available at  https://doi.org/10.7910/DVN/CR1MMV, (3) ""list"" price from OpenAlex. For any remaining publication, we estimate the APC based on the Open Access category: ""Gold""=$2,450; ""Hybrid""=$3,600; all other categories = $0."
+faculty_authored,Boolean,True if any Stanford author has a primary role of faculty
+federally_funded,Boolean,"True if at least one of the publication’s funders is federal. Funder data for each publication is provided by Dimensions or OpenAlex, and we use the OSTP Impact dataset, enhanced with ROR identifiers, to identify which funders are federal. "
+journal_name,String,Name of journal which published the publication
+open_access,String,"Open Access category, as determined by OpenAlex or Dimensions. One of: diamond, gold, hybrid, green, bronze, closed. May be null."
+pub_year,Integer,Year of publication
+publisher,String,"Publisher of the journal in which the publication appears, if applicable, obtained from OpenAlex."
+types,String,"Types of publication, normalized to values: Article, Book, Chapter, Correction/Retraction, Dataset, Dissertation, Editorial Material, Other. Types are pipe-delimited when there are multiple."

--- a/rialto_airflow/publish/publication.py
+++ b/rialto_airflow/publish/publication.py
@@ -374,10 +374,13 @@ def _zip_files(data_dir) -> None:
     Zip the files and remove the original CSVs
     """
     for table in TABLES:
+        # include the latest data_dictionary file
+        data_dictionary = f"{os.path.dirname(os.path.abspath(__file__))}/documentation/{table}_data_dictionary.csv"
         filepath = f"{downloads_dir(data_dir)}/{table}.csv"
         zip_temp_filepath = f"{downloads_dir(data_dir)}/{table}-temp.zip"
 
         with zipfile.ZipFile(zip_temp_filepath, "w", zipfile.ZIP_DEFLATED) as zipf:
+            zipf.write(data_dictionary, arcname=os.path.basename(data_dictionary))
             zipf.write(filepath, arcname=os.path.basename(filepath))
         zip_filepath = f"{downloads_dir(data_dir)}/{table}.zip"
         # Move the temp zip to the final zip filepath and delete the original CSV

--- a/test/publish/test_publication.py
+++ b/test/publish/test_publication.py
@@ -93,6 +93,8 @@ def test_generate_download_files(tmp_path, rialto_reports_db_name):
     # Assert that publications.csv exists
     csv_file = downloads_dir / "publications.csv"
     assert csv_file.is_file()
+    dictionary_file = downloads_dir / "publications_data_dictionary.csv"
+    assert dictionary_file.is_file()
 
     # Check that 'true' not 't' exists for the first publication
     with open(csv_file, "r") as f:


### PR DESCRIPTION
Resolves #714 to zip a data dictionary with each download file. 

Note that the web app's downloads page shows a filesize for each dataset. (https://github.com/sul-dlss/rialto-web/blob/b5024a5dd99687a8053c1070c961b192389bab39/app/models/download_file.rb#L23) 

That will still work with the addition of the data dictionary, which is itself very small in size and would only affect the overall download trivially. 
