### PR TITLE
Do not log empty DOIs

### DIFF
--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -85,7 +85,6 @@ def normalize_arxiv_id_to_doi(possible_arxiv_doi: str):
 
 def normalize_doi(doi):
     if doi is None or doi.strip() == "":
-        _data_quality_warning("Empty DOI")
         return None
 
     context = {"doi_candidate": doi}


### PR DESCRIPTION
Harvest logs have lots lines with `WARNING - [DATA QUALITY ISSUE] Empty DOI -- {}` but it is expected there will be some publications without DOIs . Since there is not typically any steps we would take when there are no DOIs, removing the logging for this particular normalization. 