### PR TITLE
Reduce Pubmed DOI lookup size

### DIFF
--- a/test/harvest/test_pubmed.py
+++ b/test/harvest/test_pubmed.py
@@ -236,26 +236,6 @@ def test_pubmed_search_unexpected_response(requests_mock, caplog):
     )
 
 
-def test_pubmed_search_handles_500(requests_mock, caplog):
-    """
-    This is a test of the Pubmed Search API to ensures we don't crash with a 500 response.
-    """
-    caplog.set_level(logging.INFO)
-
-    requests_mock.get(
-        re.compile(".*"),
-        json={},
-        status_code=500,
-        headers={"Content-Type": "application/json"},
-    )
-    result = pubmed.pmids_from_orcid("12345")
-    assert result == []
-    assert (
-        "Error searching pubmed query {'term': '12345[auid]'}: 500 Server Error"
-        in caplog.text
-    )
-
-
 def test_pubmed_search_orcid_found_publications():
     """
     This is a live test of the Pubmed Search API to ensure we can get PMIDs back given an ORCID.


### PR DESCRIPTION
We were hitting HTTP 414 errors when looking up too many DOIs at one time. The errors were logged but we didn't notice the problem till recently.

This commit reduces the number of DOIs looked up at one time to 50 (from 75) and also ensures that HTTP errors when talking to PubMed cause the harvesting to stop so that we will notice problems sooner.

I ran this in my dev environment with a harvest limit of 10K and it worked.

Fixes #725
