### PR TITLE
cli utility for rialto

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ Getting errors with dependencies when trying to run the tests that look somethin
 
 Try clearing the virtual env folder and let it rebuild on the next run: `rm -rf .venv`
 
+## CLI
+
+The `rialto` command line utility lets you run some bespoke data export tasks, like exporting a CSV of publications for a particular author:
+
+```
+uv run rialto publications makeller
+```
+
+Or there is this mouthful if you want to run it in a running Docker environment:
+
+```
+docker compose exec -u airflow -ti airflow-worker uv run rialto publications makeller
+```
+
 ## Deployment
 
 Deployment to https://sul-rialto-airflow-XXXX.stanford.edu/ is handled like other SDR services using Capistrano. You'll need to have Ruby installed and then:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,15 @@ dependencies = [
     "types-xmltodict>=0.14.0.20241009",
     "dominate>=2.9.1",
     "sqlalchemy-utils==0.41.2", # see: https://github.com/kvesteri/sqlalchemy-utils/issues/791
+    "typer>=0.20.0",
 ]
+
+[project.scripts]
+rialto = "rialto_airflow.cli:app"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
 addopts = "-v --cov --cov-report=html --cov-report=term --log-level INFO --log-file test.log"
-
 
 [tool.coverage.run]
 omit = ["test/*"]
@@ -43,7 +46,17 @@ omit = ["test/*"]
 check_untyped_defs = true # Type-checks the interior of functions without type annotations.
 
 [[tool.mypy.overrides]]
-module = ["dimcli", "honeybadger", "pyalex", "requests_oauthlib", "sqlalchemy_utils", "jsonpath_ng", "googleapiclient.http", "dominate", "dominate.tags"]
+module = [
+    "dimcli",
+    "honeybadger",
+    "pyalex",
+    "requests_oauthlib",
+    "sqlalchemy_utils",
+    "jsonpath_ng",
+    "dominate",
+    "dominate.tags",
+    "typing_extensions"
+]
 ignore_missing_imports = true
 
 [dependency-groups]

--- a/rialto_airflow/cli.py
+++ b/rialto_airflow/cli.py
@@ -1,0 +1,107 @@
+import os
+import csv
+import sys
+from pathlib import Path
+
+import dotenv
+import typer
+from typing_extensions import Annotated
+from sqlalchemy import select
+
+from rialto_airflow.snapshot import Snapshot
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.harvest import Author
+
+
+dotenv.load_dotenv()
+app = typer.Typer()
+
+
+@app.command()
+def publications(sunet: str, db_name: Annotated[str, typer.Option()] = "") -> None:
+    """
+    List publications for an Author with a given SUNET.
+    """
+    db_name = _get_db_name(db_name)
+
+    with get_session(db_name).begin() as session:
+        author = (
+            session.execute(select(Author).where(Author.sunet == sunet))
+            .scalars()
+            .first()
+        )
+
+        if author is None:
+            print(f"The author {sunet} does not exist")
+            raise typer.Exit(code=1)
+
+        writer = csv.DictWriter(
+            sys.stdout,
+            fieldnames=[
+                "doi",
+                "title",
+                "publisher",
+                "pub_year",
+                "open_access",
+                "types",
+                "journal_name",
+                "authors",
+                "funders",
+                "sources",
+            ],
+        )
+
+        writer.writeheader()
+
+        for pub in author.publications:
+            sources = []
+            for source_name in [
+                "sulpub",
+                "crossref",
+                "dim",
+                "wos",
+                "openalex",
+                "pubmed",
+            ]:
+                if getattr(pub, f"{source_name}_json") is not None:
+                    sources.append(source_name)
+
+            writer.writerow(
+                {
+                    "doi": pub.doi,
+                    "title": pub.title,
+                    "publisher": pub.publisher,
+                    "pub_year": pub.pub_year,
+                    "open_access": pub.open_access,
+                    "types": "|".join(pub.types),
+                    "journal_name": pub.journal_name,
+                    "authors": "|".join([a.sunet for a in pub.authors]),
+                    "funders": "|".join([f.name for f in pub.funders]),
+                    "sources": "|".join(sources),
+                }
+            )
+
+
+@app.command()
+def authors(db_name: Annotated[str, typer.Option()] = "") -> None:
+    """
+    List the SUNET IDs for authors in the database.
+    """
+    db_name = _get_db_name(db_name)
+
+    with get_session(db_name).begin() as session:
+        for author in session.query(Author).all():
+            print(author.sunet)
+
+
+def _get_db_name(db_name: str) -> str:
+    if db_name == "":
+        data_dir = os.environ.get("AIRFLOW_VAR_DATA_DIR", "data")
+        snapshot = Snapshot.get_latest(data_dir=Path(data_dir))
+        return snapshot.database_name
+    else:
+        return db_name
+
+
+if __name__ == "__main__":
+    app()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,60 @@
+import os
+from io import StringIO
+
+import pandas
+import pytest
+from typer.testing import CliRunner
+
+from rialto_airflow.cli import app
+
+runner = CliRunner()
+
+
+def test_publications(test_session, snapshot, dataset):
+    result = runner.invoke(app, ["publications", "janes", "--db-name", "rialto_test"])
+    assert result.exit_code == 0
+
+    df = pandas.read_csv(StringIO(result.output))
+    assert len(df) == 2
+    assert len(df.columns) == 10
+
+    row = df.iloc[0]
+    assert row.doi == "10.000/000001"
+    assert row.title == "My Life"
+    assert row.pub_year == 2023
+    assert row.sources == "sulpub|crossref|dim|wos|openalex|pubmed"
+
+    row = df.iloc[1]
+    assert row.doi == "10.000/000002"
+    assert row.title == "My Life Part 2"
+    assert row.pub_year == 2024
+    assert row.sources == "sulpub|dim|wos|pubmed"
+
+
+def test_publications_no_author(test_session, snapshot, dataset):
+    result = runner.invoke(
+        app, ["publications", "fiddlesticks", "--db-name", "rialto_test"]
+    )
+    assert result.exit_code == 1
+    assert result.output.strip() == "The author fiddlesticks does not exist"
+
+
+@pytest.fixture()
+def empty_data_dir(tmp_path):
+    os.environ["AIRFLOW_VAR_DATA_DIR"] = str(tmp_path)
+
+
+def test_publications_no_db_name(empty_data_dir):
+    result = runner.invoke(app, ["publications", "janes"])
+    assert result.exit_code == 1
+
+
+def test_authors_no_db_name(empty_data_dir):
+    result = runner.invoke(app, ["authors"])
+    assert result.exit_code == 1
+
+
+def test_authors(test_session, snapshot, dataset):
+    result = runner.invoke(app, ["authors", "--db-name", "rialto_test"])
+    assert result.exit_code == 0
+    assert "janes" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -3860,6 +3860,7 @@ dependencies = [
     { name = "requests-oauthlib" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-utils" },
+    { name = "typer" },
     { name = "types-xmltodict" },
     { name = "xmltodict" },
 ]
@@ -3895,6 +3896,7 @@ requires-dist = [
     { name = "requests-oauthlib" },
     { name = "sqlalchemy", specifier = ">=1.4.36,<2.0" },
     { name = "sqlalchemy-utils", specifier = "==0.41.2" },
+    { name = "typer", specifier = ">=0.20.0" },
     { name = "types-xmltodict", specifier = ">=0.14.0.20241009" },
     { name = "xmltodict", specifier = ">=0.14.2" },
 ]
@@ -4469,6 +4471,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/28/7c85c8032b91dbe79725b6f17d2fffc595dff06a35c7a30a37bef73a1ab4/typer-0.20.0.tar.gz", hash = "sha256:1aaf6494031793e4876fb0bacfa6a912b551cf43c1e63c800df8b1a866720c37", size = 106492, upload-time = "2025-10-20T17:03:49.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/64/7713ffe4b5983314e9d436a90d5bd4f63b6054e2aca783a3cfc44cb95bbf/typer-0.20.0-py3-none-any.whl", hash = "sha256:5b463df6793ec1dca6213a3cf4c0f03bc6e322ac5e16e13ddd622a889489784a", size = 47028, upload-time = "2025-10-20T17:03:47.617Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is the start of a cli tool for rialto database. It will generate a CSV of publications for a given sunet. We could expand it to do other things though?

```
uv run rialto publications makeller
```

or to list the authors:

```
uv run rialto authors
```

There was no pressing need for the `authors` subcommand, but if there was only one subcommand typer just made it the default command, and I wanted it to be `publications`.