### PR TITLE
cli can use remote db

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,36 @@ Or there is this mouthful if you want to run it in a running Docker environment:
 docker compose exec -u airflow -ti airflow-worker uv run rialto publications makeller
 ```
 
+This will by default look at the latest snapshot, that may not be complete yet. If you'd like to export data from another snapshot you can list them with:
+
+```
+uv run rialto snapshots
+```
+
+And then use one of them:
+
+```
+uv run rialto publications makeller --db-name rialto_20251207000005
+```
+
+If you would like to connect to a Postgres database running elsewhere (perhaps the production database via a [tunnel](https://github.com/sul-dlss/rialto-airflow/wiki/Connecting-to-rialto%E2%80%90airflow-PostgreSQL-from-developer-laptops-and-external-services)) you can use the `--database-uri` option with all the commands. So if you wanted to get a list of snapshot databases in production you can substitute the `{password-here}` text for the `analyst` user's password:
+
+```
+uv run rialto snapshots --db-uri "postgresql+psycopg2://analyst:{password-here}@localhost:9999"
+```
+
+And list the users:
+
+```
+uv run rialto snapshots --db-uri "postgresql+psycopg2://analyst:{password-here}@localhost:9999"
+```
+
+Or list the publications:
+
+```
+uv run rialto publications --db-uri "postgresql+psycopg2://analyst:{password-here}" @localhost:9999" makeller
+```
+
 ## Deployment
 
 Deployment to https://sul-rialto-airflow-XXXX.stanford.edu/ is handled like other SDR services using Capistrano. You'll need to have Ruby installed and then:

--- a/rialto_airflow/cli.py
+++ b/rialto_airflow/cli.py
@@ -1,14 +1,14 @@
 import os
 import csv
 import sys
-from pathlib import Path
+from typing import Optional
 
 import dotenv
 import typer
 from typing_extensions import Annotated
 from sqlalchemy import select
+from sqlalchemy.orm.session import sessionmaker
 
-from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.database import get_session
 from rialto_airflow.schema.harvest import Author
 
@@ -18,13 +18,41 @@ app = typer.Typer()
 
 
 @app.command()
-def publications(sunet: str, db_name: Annotated[str, typer.Option()] = "") -> None:
+def snapshots(
+    db_uri: Annotated[
+        str,
+        typer.Option(
+            help="Override the default Postgres database URI from the environment"
+        ),
+    ] = "",
+) -> None:
+    """
+    List Rialto snapshot databases that are available.
+    """
+    for database in _get_snapshots(db_uri):
+        print(database)
+
+
+@app.command()
+def publications(
+    sunet: Annotated[
+        str,
+        typer.Argument(
+            help="The SUNET of the author you want to list publications for"
+        ),
+    ],
+    db_name: str = typer.Option(
+        default="", help="The snapshot database to use (use snapshots to list them)"
+    ),
+    db_uri: str = typer.Option(
+        default="",
+        help="Override the default Postgres database URI from the environment",
+    ),
+) -> None:
     """
     List publications for an Author with a given SUNET.
     """
-    db_name = _get_db_name(db_name)
-
-    with get_session(db_name).begin() as session:
+    with _get_db(db_uri, db_name).begin() as session:  # type: ignore
         author = (
             session.execute(select(Author).where(Author.sunet == sunet))
             .scalars()
@@ -47,25 +75,18 @@ def publications(sunet: str, db_name: Annotated[str, typer.Option()] = "") -> No
                 "journal_name",
                 "authors",
                 "funders",
-                "sources",
+                "sulpub_id",
+                "crossref_id",
+                "dimensions_id",
+                "wos_id",
+                "openalex_id",
+                "pubmed_id",
             ],
         )
 
         writer.writeheader()
 
         for pub in author.publications:
-            sources = []
-            for source_name in [
-                "sulpub",
-                "crossref",
-                "dim",
-                "wos",
-                "openalex",
-                "pubmed",
-            ]:
-                if getattr(pub, f"{source_name}_json") is not None:
-                    sources.append(source_name)
-
             writer.writerow(
                 {
                     "doi": pub.doi,
@@ -73,34 +94,99 @@ def publications(sunet: str, db_name: Annotated[str, typer.Option()] = "") -> No
                     "publisher": pub.publisher,
                     "pub_year": pub.pub_year,
                     "open_access": pub.open_access,
-                    "types": "|".join(pub.types),
+                    "types": "|".join(pub.types or []),
                     "journal_name": pub.journal_name,
                     "authors": "|".join([a.sunet for a in pub.authors]),
                     "funders": "|".join([f.name for f in pub.funders]),
-                    "sources": "|".join(sources),
+                    "sulpub_id": _sulpub_id(pub),
+                    "crossref_id": _crossref_id(pub),
+                    "dimensions_id": _dimensions_id(pub),
+                    "wos_id": _wos_id(pub),
+                    "openalex_id": _openalex_id(pub),
+                    "pubmed_id": _pubmed_id(pub),
                 }
             )
 
 
 @app.command()
-def authors(db_name: Annotated[str, typer.Option()] = "") -> None:
+def authors(
+    db_name: str = typer.Option(default="", help="The Rialto database snapshot to use"),
+    db_uri: str = typer.Option(
+        default="", help="Override the Postgres database URI from the environment"
+    ),
+) -> None:
     """
-    List the SUNET IDs for authors in the database.
+    List the SUNET IDs for authors in the snapshot.
     """
-    db_name = _get_db_name(db_name)
-
-    with get_session(db_name).begin() as session:
+    with _get_db(db_uri, db_name).begin() as session:  # type: ignore
         for author in session.query(Author).all():
             print(author.sunet)
 
 
-def _get_db_name(db_name: str) -> str:
+def _get_db(db_uri: str, db_name: str) -> sessionmaker:
+    """
+    Given a database URI and database name, return the a sqlsession object.
+    """
+
+    # optionally override the default database URI if it was supplied
+    # this can be useful if you want to connect to a PostgreSQL database running
+    # somewhere else
+    if db_uri != "":
+        os.environ["AIRFLOW_VAR_RIALTO_POSTGRES"] = db_uri
+
     if db_name == "":
-        data_dir = os.environ.get("AIRFLOW_VAR_DATA_DIR", "data")
-        snapshot = Snapshot.get_latest(data_dir=Path(data_dir))
-        return snapshot.database_name
+        db_name = list(_get_snapshots(db_uri)).pop()
+
+    return get_session(db_name)
+
+
+def _get_snapshots(db_uri: str):
+    with _get_db(db_uri, "postgres").begin() as session:  # type: ignore
+        for row in session.execute(
+            r"SELECT datname FROM pg_database WHERE datname ~ '^rialto_\d+' ORDER BY datname ASC"
+        ):
+            yield row[0]
+
+
+def _sulpub_id(pub) -> Optional[str]:
+    if pub.sulpub_json is not None:
+        return pub.sulpub_json["sulpubid"]
     else:
-        return db_name
+        return None
+
+
+def _crossref_id(pub) -> Optional[str]:
+    if pub.crossref_json is not None:
+        return pub.crossref_json.get("DOI")
+    else:
+        return None
+
+
+def _dimensions_id(pub) -> Optional[str]:
+    if pub.dim_json is not None:
+        return pub.dim_json.get("id")
+    else:
+        return None
+
+
+def _wos_id(pub) -> Optional[str]:
+    if pub.wos_json is not None:
+        return pub.wos_json.get("UID")
+    return None
+
+
+def _openalex_id(pub) -> Optional[str]:
+    if pub.openalex_json is not None:
+        return pub.openalex_json.get("id")
+    else:
+        return None
+
+
+def _pubmed_id(pub) -> Optional[str]:
+    if pub.pubmed_json is not None:
+        return pub.pubmed_json.get("MedlineCitation", {}).get("PMID", {}).get("#text")
+    else:
+        return None
 
 
 if __name__ == "__main__":

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,8 +1,6 @@
-import os
 from io import StringIO
 
 import pandas
-import pytest
 from typer.testing import CliRunner
 
 from rialto_airflow.cli import app
@@ -16,19 +14,17 @@ def test_publications(test_session, snapshot, dataset):
 
     df = pandas.read_csv(StringIO(result.output))
     assert len(df) == 2
-    assert len(df.columns) == 10
+    assert len(df.columns) == 15
 
     row = df.iloc[0]
     assert row.doi == "10.000/000001"
     assert row.title == "My Life"
     assert row.pub_year == 2023
-    assert row.sources == "sulpub|crossref|dim|wos|openalex|pubmed"
 
     row = df.iloc[1]
     assert row.doi == "10.000/000002"
     assert row.title == "My Life Part 2"
     assert row.pub_year == 2024
-    assert row.sources == "sulpub|dim|wos|pubmed"
 
 
 def test_publications_no_author(test_session, snapshot, dataset):
@@ -37,21 +33,6 @@ def test_publications_no_author(test_session, snapshot, dataset):
     )
     assert result.exit_code == 1
     assert result.output.strip() == "The author fiddlesticks does not exist"
-
-
-@pytest.fixture()
-def empty_data_dir(tmp_path):
-    os.environ["AIRFLOW_VAR_DATA_DIR"] = str(tmp_path)
-
-
-def test_publications_no_db_name(empty_data_dir):
-    result = runner.invoke(app, ["publications", "janes"])
-    assert result.exit_code == 1
-
-
-def test_authors_no_db_name(empty_data_dir):
-    result = runner.invoke(app, ["authors"])
-    assert result.exit_code == 1
 
 
 def test_authors(test_session, snapshot, dataset):


### PR DESCRIPTION
This commit adds:

- a `--db-uri` option to connect to a remote database
- a `snapshots` command to list snapshot databases available
- output platform identifiers for tracking down data if necessary
