### PR TITLE
Dimensions login logging

### DIFF
--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -143,6 +143,7 @@ def login():
     """
     Login to Dimensions API and cache the result.
     """
+    logging.info("logging in to Dimensions API")
     dimcli.login(
         key=os.environ.get("AIRFLOW_VAR_DIMENSIONS_API_KEY"),
         endpoint="https://app.dimensions.ai/api/dsl/v2",
@@ -185,7 +186,7 @@ def query_with_retry(q, retry=5):
                 ):  # Response could be None
                     # Likely the token expired, clear cache. login() will be retried on next dsl() call
                     login.cache_clear()
-                logging.debug(
+                logging.warning(
                     "Dimensions query error retry %s of %s: %s", try_count, retry, e
                 )
                 time.sleep(try_count * 10)

--- a/test/harvest/test_dimensions.py
+++ b/test/harvest/test_dimensions.py
@@ -88,7 +88,6 @@ def mock_dimensions_dsl_query_error(monkeypatch):
 
 
 def test_query_with_retry(mock_dimensions_dsl_query_error, caplog):
-    caplog.set_level(logging.DEBUG)
     pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
     assert len(pubs) == 17
     assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
@@ -96,7 +95,7 @@ def test_query_with_retry(mock_dimensions_dsl_query_error, caplog):
     assert len(pubs[1].keys()) == 70, "second publication has 70 columns"
     assert num_log_record_matches(
         caplog.records,
-        logging.DEBUG,
+        logging.WARNING,
         "Dimensions query error retry 1 of 5: transient error",
     )
 
@@ -139,12 +138,11 @@ def mock_dimensions_dsl_query_login_error(monkeypatch):
 
 
 def test_query_with_login_retry(mock_dimensions_dsl_query_login_error, caplog):
-    caplog.set_level(logging.DEBUG)
     pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
     assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
     assert num_log_record_matches(
         caplog.records,
-        logging.DEBUG,
+        logging.WARNING,
         "Dimensions query error retry 1 of 5: login error",
     )
 


### PR DESCRIPTION
This PR slightly adjusts our logging around Dimensions API login to make it a bit more obvious when we are seeing HTTP errors, and also when we are logging in:

I saw this in the Airflow log:

```
[2026-01-05, 00:15:03 UTC] {dimensions.py:178} ERROR - Dimensions API call 6 resulted in error: 401 Client Error: Unauthorized for url: https://app.dimensions.ai/api/dsl/v2
```

But I also expected to see this message from dimcli repeated when it logs in again:

```
[2026-01-05, 15:49:46 UTC] {logging_mixin.py:190} INFO - Dimcli - Dimensions API Client (v1.4)
```

Which happens here:

https://github.com/digital-science/dimcli/blob/9280a278528ca61758c99b4801e84c3f4e596254/dimcli/__init__.py#L133
