### PR TITLE
Ensure that login is called

### DIFF
--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -182,7 +182,7 @@ def query_with_retry(q, retry=5):
                 raise e
             else:
                 if (
-                    e.response and e.response.status_code == 401
+                    e.response is not None and e.response.status_code == 401
                 ):  # Response could be None
                     # Likely the token expired, clear cache. login() will be retried on next dsl() call
                     login.cache_clear()


### PR DESCRIPTION
Evaluating the response object in a boolean context will return `False` when the status_code is < 400:

https://github.com/psf/requests/blob/70298332899f25826e35e42f8d83425124f755a5/src/requests/models.py#L730-L738

This means that we never were clearing the cached login since it would always evaluate to False when we got a 401.
