### PR TITLE
Harvest a subset of Dimensions available fields

### DIFF
--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -108,12 +108,19 @@ def publications_from_orcid(orcid: str, batch_size=200):
 
 
 def publication_fields():
-    # See Dimensions docs for a description of what is included in the basics, book, and extras fieldsets:
+    # See Dimensions docs for a description of what is included in the basics and book fieldsets:
     # https://docs.dimensions.ai/dsl/datasource-publications.html#publications-fieldsets
     return [
         "basics",
         "book",
-        "extras",
+        "altmetric",
+        "date",
+        "doi",
+        "funders",
+        "open_access",
+        "pmcid",
+        "pmid",
+        "times_cited",
         "abstract",
         "altmetric_id",
         "issn",
@@ -125,7 +132,7 @@ def publication_fields():
 
 
 def unpacked_pub_fields():
-    # Response will include fields unpacked from the basics, book, and extras fieldsets requested.
+    # Response will include fields unpacked from the basics and book fieldsets requested.
     return [
         # basics
         "authors",
@@ -141,7 +148,7 @@ def unpacked_pub_fields():
         "book_doi",
         "book_series_title",
         "book_title",
-        # extras
+        # specific fields
         "altmetric",
         "date",
         "doi",
@@ -149,16 +156,7 @@ def unpacked_pub_fields():
         "open_access",
         "pmcid",
         "pmid",
-        "relative_citation_ratio",
-        "research_org_cities",
-        "research_org_countries",
-        "research_org_country_names",
-        "research_org_state_codes",
-        "research_org_state_names",
-        "research_orgs",
-        "researchers",
         "times_cited",
-        # specific fields
         "abstract",
         "altmetric_id",
         "issn",

--- a/test/harvest/test_dimensions.py
+++ b/test/harvest/test_dimensions.py
@@ -23,16 +23,16 @@ def test_publications_from_dois():
     )
     assert len(pubs) == 2
     assert pubs[0]["doi"] == "10.48550/arxiv.1706.03762"
-    assert len(pubs[0].keys()) == 35, "first publication has 35 columns"
+    assert len(pubs[0].keys()) == 27, "first publication has 27 columns"
     assert "book_title" in pubs[0].keys()
-    assert len(pubs[1].keys()) == 35, "second publication has 35 columns"
+    assert len(pubs[1].keys()) == 27, "second publication has 27 columns"
 
 
 def test_publication_fields():
     fields = dimensions.publication_fields()
-    assert len(fields) == 10
+    assert len(fields) == 17
     assert "basics" in fields
-    assert "extras" in fields
+    assert "book" in fields
 
 
 def test_publications_from_orcid():


### PR DESCRIPTION
Trying two approaches to speeding up Dimensions harvesting:
* Requesting a subset of fields from Dimensions (35) rather than all (70)
* Increasing the number of publications per request from 15 to 30.

Reviewed all uses of `dim_json` to confirm that we are still getting all of the fields needed for distilling and publishing. I also added a few not currently used but potentially used soon: 
* `altmetric_id`
* `supporting_grant_ids`
* `book_*` fields in the book fieldset
