### PR TITLE
Remove backslashes from DOIs

### DIFF
--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -90,6 +90,7 @@ def normalize_doi(doi):
     context = {"doi_candidate": doi}
 
     doi = doi.lower().replace(" ", "")
+    doi = doi.replace("\\", "")
     doi = normalize_arxiv_id_to_doi(doi)
     doi = doi_candidate_extract(doi)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -73,6 +73,10 @@ def test_normalize_doi():
     assert utils.normalize_doi(None) is None
     assert utils.normalize_doi("") is None
     assert utils.normalize_doi("   ") is None
+    assert (
+        utils.normalize_doi("10.1007/978-3-030-46640-4\\_21")
+        == "10.1007/978-3-030-46640-4_21"
+    )
 
 
 def test_normalize_pmid():


### PR DESCRIPTION
DOIs should not have backslashes, but a DOI from a sulpub record (881074) contains an escaped backslash: `"10.1007/978-3-030-46640-4\\_21"`. This causes syntax errors when querying with Dimensions. The DOI with no backslashes resolves correctly to the article. 

There is one other pub with a DOI containing a backslash in our current database. It's from OpenAlex. That DOI is clearly also not correct: `"10.17159/1727-&#13;\\n3781/2021/v24i0a802"`. However in this case, it's not clear what the correct DOI would be. The DOI listed on the [article's web page ](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3898558) does not resolve either: http://dx.doi.org/10.17159/1727-3781/2021/v24i0a802

This PR strips out backslashes.