### PR TITLE
Log fill-in JSON-L files separately

### DIFF
--- a/rialto_airflow/harvest/crossref.py
+++ b/rialto_airflow/harvest/crossref.py
@@ -23,7 +23,7 @@ RIALTO_EMAIL = os.environ.get(
 
 def fill_in(snapshot: Snapshot) -> Path:
     """Harvest Crossref data for DOIs from other publication sources."""
-    jsonl_file = snapshot.path / "crossref.jsonl"
+    jsonl_file = snapshot.path / "crossref-fillin.jsonl"
     count = 0
     with jsonl_file.open("a") as jsonl_output:
         with get_session(snapshot.database_name).begin() as select_session:

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -20,7 +20,7 @@ from rialto_airflow.schema.harvest import (
     pub_author_association,
 )
 from rialto_airflow.snapshot import Snapshot
-from rialto_airflow.utils import normalize_doi
+from rialto_airflow.utils import normalize_doi, add_orcid
 
 Params = Dict[str, Union[int, str]]
 
@@ -77,14 +77,16 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
                             .on_conflict_do_nothing()
                         )
 
-                        jsonl_output.write(json.dumps(wos_pub) + "\n")
+                        jsonl_output.write(
+                            json.dumps(add_orcid(wos_pub, author.orcid)) + "\n"
+                        )
 
     return jsonl_file
 
 
 def fill_in(snapshot: Snapshot):
     """Harvest WebOfScience data for DOIs from other publication sources."""
-    jsonl_file = snapshot.path / "wos.jsonl"
+    jsonl_file = snapshot.path / "wos-fillin.jsonl"
     count = 0
     with jsonl_file.open("a") as jsonl_output:
         with get_session(snapshot.database_name).begin() as select_session:

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -2,7 +2,7 @@ import re
 import logging
 from functools import cache
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
 
 
 def rialto_authors_file(data_dir):
@@ -158,3 +158,11 @@ def join_keys(d: dict, *keys):
             values.append(value)
 
     return " ".join(values)
+
+
+def add_orcid(data: dict[Any, Any], orcid: str):
+    """
+    Envelope the provided dictionary inside another dictionary with the addition
+    of an orcid key.
+    """
+    return {"orcid": orcid, "data": data}

--- a/test/harvest/test_crossref.py
+++ b/test/harvest/test_crossref.py
@@ -200,5 +200,5 @@ def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
         }
 
     # adds 1 publication to the jsonl file
-    assert num_jsonl_objects(snapshot.path / "crossref.jsonl") == 1
+    assert num_jsonl_objects(snapshot.path / "crossref-fillin.jsonl") == 1
     assert "filled in 1 publications" in caplog.text


### PR DESCRIPTION
To use the JSON-L harvest logs in our study of ORCID reliability  it is helpful to be able to distinguish between what was collected by ORCID, and what was collected as part of the "fill in" process by DOI.

This commit separates out the harvest and fill-in JSON-L files. It also creates an "envelope" for data that is harvested by ORCID that includes the ORCID that was used. So harvested data that looked like this:

```json
{
  "id": 123
}
```

will now look like:

```json
{
  "orcid": "0000-0002-1825-0097", 
  "data": {
    "id": 123
  }
}
```

Separating out the fill in JSON-L means that we can remove some JSON-L mocks that were testing that the JSON-L file was being appended to.

I ran this in my development environment with a limit of 1000 and it seemed to work fine, but led me to noticing #757 