### PR TITLE
Don't use DOIs with HTML entities

### DIFF
--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -62,6 +62,7 @@ def doi_known_format_regex_list():
         "^10\\.1021/\\w\\w\\d+$",  # matches e.g. '10.1021/a_1029384756'
         "^10\\.1207/[\\w\\d]+\\&\\d+_\\d+$",  # matches e.g. '10.1207/a12b0z&456_765'
         "^\\b(10[\\.][0-9]{4,}(?:[\\.][0-9]+)*/(?:(?![\"&'<>])\\S)+)\\b$",  # matches e.g. '10.1016.12.31/nature.S0735-1097(98)2000/12/31/34:7-7' (SO post builds to this regex)
+        "^\\d",
     ]
     return [re.compile(p) for p in doi_filter_patterns]
 
@@ -91,6 +92,11 @@ def normalize_doi(doi):
 
     doi = doi.lower().replace(" ", "")
     doi = doi.replace("\\", "")
+    if ("&gt" in doi) or ("&lt" in doi):
+        # the couple of DOIs from OpenAlex with these characters are not easily modified to
+        # resolvable DOIs and cause errors when querying Dimensions
+        return None
+
     doi = normalize_arxiv_id_to_doi(doi)
     doi = doi_candidate_extract(doi)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -77,6 +77,10 @@ def test_normalize_doi():
         utils.normalize_doi("10.1007/978-3-030-46640-4\\_21")
         == "10.1007/978-3-030-46640-4_21"
     )
+    assert (
+        utils.normalize_doi("10.1562/0031-8655(2004)79&lt;76:aocrtt&gt;2.0.co;2")
+        is None
+    )
 
 
 def test_normalize_pmid():


### PR DESCRIPTION
Resolves #753 to handle a few more DOI patterns that cause problems for Dimensions querying. 

If we experience further issues along these lines with Dimensions, we should consider logging errors `413: Request Entity Too Large` and carrying on with the next batch. 