### PR TITLE
parse output of airflow dag list by only looking at last line

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -64,7 +64,7 @@ task :check_running_airflow_dag do
       # get a list of all DAGs
       dags = capture(:docker, 'compose', 'exec', '-it', 'airflow-worker', '/bin/bash', '-c',
                      '"airflow dags list --columns dag_id -o json"')
-      dag_list = JSON.parse(dags)
+      dag_list = JSON.parse(dags.split("\n").last) # the last line of the output is the list of dags we need to parse
       dag_list.each do |dag|
         command = "airflow dags list-runs -d #{dag['dag_id']} --state running"
         # Check if the DAG is running


### PR DESCRIPTION
Deal with #766

The output of the airflow command to list the names of the dags includes some lines we can ignore (see below).  Assuming the last line is what we care about (which it seems to be), this would also fix it by only parsing the last line of the output (and it would also work if it is the only line like we expect it to be).

```
docker compose exec -it airflow-worker /bin/bash -c "airflow dags list --columns dag_id -o json"

WARN[0000] project has been loaded without an explicit name from a symlink. Using name "current"
WARN[0000] The "AIRFLOW_UID" variable is not set. Defaulting to a blank string.
WARN[0000] The "AIRFLOW_UID" variable is not set. Defaulting to a blank string.
/home/airflow/.local/lib/python3.12/site-packages/airflow/configuration.py:765 FutureWarning: The auth_backends setting in [api] has had airflow.api.auth.backend.session added in the running config, which is needed by the UI. Please update your config before Apache Airflow 3.0.
[2026-01-20T18:21:26.099+0000] {plugins.py:37} INFO - setup plugin alembic.autogenerate.schemas
[2026-01-20T18:21:26.100+0000] {plugins.py:37} INFO - setup plugin alembic.autogenerate.tables
[2026-01-20T18:21:26.101+0000] {plugins.py:37} INFO - setup plugin alembic.autogenerate.types
[2026-01-20T18:21:26.101+0000] {plugins.py:37} INFO - setup plugin alembic.autogenerate.constraints
[2026-01-20T18:21:26.102+0000] {plugins.py:37} INFO - setup plugin alembic.autogenerate.defaults
[2026-01-20T18:21:26.102+0000] {plugins.py:37} INFO - setup plugin alembic.autogenerate.comments
[{"dag_id": "cleanup"}, {"dag_id": "harvest"}, {"dag_id": "publish_orcid_to_reports"}, {"dag_id": "publish_to_reports"}]
```