### PR TITLE
Speed up WoS fill-in

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -99,6 +99,7 @@ x-airflow-common:
     AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 10
     AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS: ''
     AIRFLOW_VAR_EMAIL_ON_ERROR: False # if True, will use email address above to send error emails
+    AIRFLOW__LOGGING__LOGGING_LEVEL: INFO
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/rialto_airflow:/opt/airflow/rialto_airflow
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -103,7 +103,7 @@ def fill_in(snapshot: Snapshot):
 
                 logging.debug(f"looking up DOIs {dois}")
                 for wos_pub in publications_from_dois(dois):
-                    doi = normalize_doi(wos_pub.get("doi"))
+                    doi = normalize_doi(get_doi(wos_pub))
                     if doi is None:
                         continue
 
@@ -178,13 +178,11 @@ def _wos_api_retry() -> Retry:
     # indicates we're being rate limited.
     # Retry up to 10 times on status code errors.
     #
+    # For each try the time to sleep will be set using:
     # {backoff_factor} * (2 ** ({number of previous retries})) + random.uniform(0, {backoff_jitter})
-    #
-    # For our configuration that means there's an immediate retry; then:
-    # * wait another 6 seconds before trying again (then 12s, then 24s, ..., 25m 36s).
-    #  * Additionally, add up to one minute of wait time to each retry, regardless of which iteration it is.
-    #  * This could total up to just under an hour of waiting for retries for each occurrence.
-    return Retry(status=10, status_forcelist=[429], backoff_factor=3, backoff_jitter=60)
+    return Retry(
+        status=10, status_forcelist=[429], backoff_factor=0.3, backoff_jitter=5
+    )
 
 
 def _wos_api(

--- a/test/harvest/test_wos.py
+++ b/test/harvest/test_wos.py
@@ -95,10 +95,18 @@ def mock_wos_doi(monkeypatch):
 
     def f(*args, **kwargs):
         yield {
-            "doi": "10.1515/9781503624199",
             "title": "An example title",
             "type": "article",
             "publication_year": 1891,
+            "dynamic_data": {
+                "cluster_related": {
+                    "identifiers": {
+                        "identifier": [
+                            {"type": "doi", "value": "10.1515/9781503624199"}
+                        ]
+                    }
+                }
+            },
         }
 
     monkeypatch.setattr(wos, "publications_from_dois", f)
@@ -357,10 +365,18 @@ def test_fill_in(snapshot, test_session, mock_no_wos_publication, mock_wos_doi, 
             .first()
         )
         assert pub.wos_json == {
-            "doi": "10.1515/9781503624199",
             "title": "An example title",
             "type": "article",
             "publication_year": 1891,
+            "dynamic_data": {
+                "cluster_related": {
+                    "identifiers": {
+                        "identifier": [
+                            {"type": "doi", "value": "10.1515/9781503624199"}
+                        ]
+                    }
+                }
+            },
         }
 
     # adds 1 publication to the jsonl file


### PR DESCRIPTION
This commit updates the Wos fill-in process to wait less time between HTTP 429 requests. We were noticing that our fill_in_wos Airflow task was taking a long time (multiple days) and never completed. The sleep time between requests was too big, when requesting metadata one DOI at a time. The time was lowered to be no longer than 1 minute on the 10th retry.

Also this change ensures that the DOI is extracted correctly from the WoS metadata when determining what publication to update in the database. Apparently the fill-in process for WoS has never been updating the database because we weren't getting the DOI out of the metadata correctly. This only became apparent once we started logging the fill-in JSON-L metadata separate from the harvest.

Refs #765
