### PR TITLE
Ignore DOIs that contain a quote

### DIFF
--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -81,7 +81,7 @@ def publications_from_dois(dois: list, batch_size=200):
     fields = " + ".join(publication_fields())
     for doi_batch in batched(dois, batch_size):
         doi_list = ",".join(['"{}"'.format(doi) for doi in doi_batch])
-        logging.debug(f"looking up: {doi_list}")
+        logging.info(f"looking up: {doi_list}")
 
         q = f"""
             search publications where doi in [{doi_list}]
@@ -98,7 +98,7 @@ def publications_from_orcid(orcid: str, batch_size=200):
     Get the publications metadata for a given ORCID.
     """
     orcid = normalize_orcid(orcid)
-    logging.debug(f"looking up publications for orcid {orcid}")
+    logging.info(f"looking up publications for orcid {orcid}")
     fields = " + ".join(publication_fields())
     q = f"""
         search publications where researchers.orcid_id = "{orcid}"

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -88,6 +88,9 @@ def normalize_doi(doi):
     if doi is None or doi.strip() == "":
         return None
 
+    if '"' in doi:
+        return None
+
     context = {"doi_candidate": doi}
 
     doi = doi.lower().replace(" ", "")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -81,6 +81,7 @@ def test_normalize_doi():
         utils.normalize_doi("10.1562/0031-8655(2004)79&lt;76:aocrtt&gt;2.0.co;2")
         is None
     )
+    assert utils.normalize_doi('10.1562/0031-8655(2004)"79') is None
 
 
 def test_normalize_pmid():


### PR DESCRIPTION
We have one publication in our database that has a DOI that contains a quote character `"`. This causes problems for the Dimensions DOI lookup during the "fill in" task.

This small change ensures that we don't use DOIs that contain a quote character. The one publication that has it is from OpenAlex, the DOI looks like this:

```
https://doi.org/10.1001/jamanetworkopen.2025.47455">https://doi.org/10.1001/jamanetworkopen.2025.47455</a></p
```

It is from https://api.openalex.org/w7125380542 which hopefully will get cleaned up some day when people can submit changes to OpenAlex metadata.

Fixes #777 