### PR TITLE
Harvest Dimensions concepts

### DIFF
--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -131,6 +131,7 @@ def publication_fields():
         "publisher",
         "recent_citations",
         "supporting_grant_ids",
+        "concepts",
     ]
 
 
@@ -153,6 +154,7 @@ def unpacked_pub_fields():
         "book_title",
         # specific fields
         "altmetric",
+        "concepts",
         "date",
         "doi",
         "funders",

--- a/test/harvest/test_dimensions.py
+++ b/test/harvest/test_dimensions.py
@@ -22,14 +22,14 @@ def test_publications_from_dois():
     )
     assert len(pubs) == 2
     assert pubs[0]["doi"] == "10.48550/arxiv.1706.03762"
-    assert len(pubs[0].keys()) == 27, "first publication has 27 columns"
+    assert len(pubs[0].keys()) == 28, "first publication has 28 columns"
     assert "book_title" in pubs[0].keys()
-    assert len(pubs[1].keys()) == 27, "second publication has 27 columns"
+    assert len(pubs[1].keys()) == 28, "second publication has 28 columns"
 
 
 def test_publication_fields():
     fields = dimensions.publication_fields()
-    assert len(fields) == 17
+    assert len(fields) == 18
     assert "basics" in fields
     assert "book" in fields
 


### PR DESCRIPTION
Concepts were useful to have for the h3 team, and shouldn't flake out the Dimensions API hopefully? We had pared back what we were requesting a few weeks ago because the API became very unreliable when we requested every field that was possible. It seems like Dimensions concepts would be useful to have for RIALTO as well.
