### PR TITLE
Give celery-worker hostname

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -176,7 +176,7 @@ services:
   airflow-worker:
     <<: *airflow-common
     image: current-airflow-worker
-    command: celery worker -H celery@%h
+    command: celery worker -H celery@airflow-worker
     healthcheck:
       # yamllint disable rule:line-length
       test:

--- a/compose.yaml
+++ b/compose.yaml
@@ -182,7 +182,7 @@ services:
 
   airflow-worker:
     <<: *airflow-common
-    command: celery worker -H celery@%h
+    command: celery worker -H celery@airflow-worker
     healthcheck:
       # yamllint disable rule:line-length
       test:


### PR DESCRIPTION
We can use the actual hostname instead of the magic metavariable?
