### PR TITLE
Small refactor in WoS tests

### DIFF
--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -219,7 +219,7 @@ def _wos_api(
     count = 100
 
     params: Params = {
-        "databaseId": "WOK",
+        "databaseId": "WOS",
         "usrQuery": query,
         "count": count,
         "firstRecord": 1,

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -219,7 +219,7 @@ def _wos_api(
     count = 100
 
     params: Params = {
-        "databaseId": "WOS",
+        "databaseId": "WOK",
         "usrQuery": query,
         "count": count,
         "firstRecord": 1,

--- a/test/harvest/test_wos.py
+++ b/test/harvest/test_wos.py
@@ -237,7 +237,7 @@ def test_not_found_error(test_session, tmp_path, caplog, mock_authors, requests_
     wos.harvest(snapshot, limit=50)
     assert test_session().query(Publication).count() == 0, "no publications loaded"
     assert (
-        "404 Client Error: Not Found for url: https://wos-api.clarivate.com/api/wos?databaseId=WOS&usrQuery=AI"
+        "404 Client Error: Not Found for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK&usrQuery=AI"
         in caplog.text
     )
 
@@ -258,7 +258,7 @@ def test_server_error(test_session, tmp_path, caplog, mock_authors, requests_moc
     wos.harvest(snapshot, limit=50)
     assert test_session().query(Publication).count() == 0, "no publications loaded"
     assert (
-        "500 Server Error: Internal Server Error for url: https://wos-api.clarivate.com/api/wos?databaseId=WOS&usrQuery=AI"
+        "500 Server Error: Internal Server Error for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK&usrQuery=AI"
         in caplog.text
     )
     assert " -- shrug" in caplog.text

--- a/test/harvest/test_wos.py
+++ b/test/harvest/test_wos.py
@@ -237,7 +237,7 @@ def test_not_found_error(test_session, tmp_path, caplog, mock_authors, requests_
     wos.harvest(snapshot, limit=50)
     assert test_session().query(Publication).count() == 0, "no publications loaded"
     assert (
-        "404 Client Error: Not Found for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK&usrQuery=AI"
+        "404 Client Error: Not Found for url: https://wos-api.clarivate.com/api/wos?databaseId=WOS&usrQuery=AI"
         in caplog.text
     )
 
@@ -258,7 +258,7 @@ def test_server_error(test_session, tmp_path, caplog, mock_authors, requests_moc
     wos.harvest(snapshot, limit=50)
     assert test_session().query(Publication).count() == 0, "no publications loaded"
     assert (
-        "500 Server Error: Internal Server Error for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK&usrQuery=AI"
+        "500 Server Error: Internal Server Error for url: https://wos-api.clarivate.com/api/wos?databaseId=WOS&usrQuery=AI"
         in caplog.text
     )
     assert " -- shrug" in caplog.text
@@ -432,12 +432,12 @@ def test_get_list_of_publications_from_dois():
     """
 
     dois = [
-        "10.1061/(asce)0733-9429(1997)123:9(828)",  # DOI with a parens
-        "10.1002/adma.202103646",
-        "10.1001/jamacardio.2021.6059",
-        "10.1021/ef'7003333",  # DOI with a single quote
+        "10.1061/(asce)0733-9429(1997)123:9(828)",  # found actual DOI (with a parens)
+        "10.1002/adma.202103646",  # found actual DOI
+        "10.1001/jamacardio.2021.6059",  # found actual DOI
+        "10.1021/ef'7003333",  # not found DOI, with a single quote (actual DOI is 10.1021/ef7003333)
+        '10.1021/ef"7003333',  # not found DOI, with a double quote
         "doi_not_found",  # not found DOI, not really a DOI
-        '10.1021/ef"7003333',  # DOI with a double quote
     ]
 
     pubs = list(wos.publications_from_dois(dois))


### PR DESCRIPTION
~~The WoS API appears to have changed.  It takes a database parameter, and we have been using a value of "WOK", which is supposed to be "all databases").  However, the API now appears to be returning fewer results with "WOK" that it does with a parameter of "WOS" (which is their primary database, the Web of Science Expanded API).  This is unexpected, since WOK is supposed to be ALL databases, including the WOS database.  I will contact them about this, since it will also affect sul-pub.  I verified it has nothing to do with our RIALTO API key (I verified same issues with sul-pub key, WOK now has fewer results than WOS databases).~~

The above is now all resolved.  But a small refactor to the test to make it clear is left here for consideration.  No change in functionality.