### PR TITLE
update location of mais uat credentials for running tests in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ For MaIS tests, update your .env with values shown below / pulled from vault as 
 ```
 AIRFLOW_VAR_MAIS_TOKEN_URL=https://mais-uat.auth.us-west-2.amazoncognito.com
 AIRFLOW_VAR_MAIS_BASE_URL=https://mais.suapiuat.stanford.edu
-AIRFLOW_VAR_MAIS_CLIENT_ID=${get from vault at `puppet/application/rialto-airflow/stage/mais_client_id`}
-AIRFLOW_VAR_MAIS_SECRET=${get from vault at `puppet/application/rialto-airflow/stage/mais_secret`}
+AIRFLOW_VAR_MAIS_CLIENT_ID=${get from vault at `puppet/application/rialto-airflow/test/mais_client_id`}
+AIRFLOW_VAR_MAIS_SECRET=${get from vault at `puppet/application/rialto-airflow/test/mais_secret`}
 ```
 
 Note: The MaIS `test_mais.py` file depends on the MaIS API being configured specifically with the UAT (not prod) credentials.  If no credentials are available in the environment variables, the tests will be skipped completely.  If production credentials are supplied, some of the tests may fail, since they assert checks against UAT data.


### PR DESCRIPTION
The tests need to use the UAT credentials for the MaIS API, but stage airflow is using the prod credentials.  The UAT credentials were put in vault in a new location, and this updates the reference to where they are.  The URLs in the README are already correct.