### PR TITLE
Pubmed http refactor

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,8 +98,7 @@ x-airflow-common:
     AIRFLOW_VAR_CLEANUP_INTERVAL_DAYS: 10
     AIRFLOW_VAR_EMAIL_ADDRESS_FOR_ERRORS: ''
     AIRFLOW_VAR_EMAIL_ON_ERROR: False # if True, will use email address above to send error emails
-    AIRFLOW__LOGGING__LOGGING_LEVEL: INFO
-
+    AIRFLOW__LOGGING__LOGGING_LEVEL: DEBUG
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/rialto_airflow:/opt/airflow/rialto_airflow
     #?- ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags

--- a/rialto_airflow/harvest/pubmed.py
+++ b/rialto_airflow/harvest/pubmed.py
@@ -2,15 +2,17 @@ import json
 import logging
 import os
 import re
+import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
+from urllib3.util import Retry
 
 import requests
 import xmltodict
-
-from typing import Optional, Dict, Union
+from requests.adapters import HTTPAdapter
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert
+from xml.parsers.expat import ExpatError
 
 from rialto_airflow.database import get_session
 from rialto_airflow.schema.harvest import (
@@ -19,19 +21,40 @@ from rialto_airflow.schema.harvest import (
     pub_author_association,
 )
 from rialto_airflow.snapshot import Snapshot
-from rialto_airflow.utils import normalize_doi, add_orcid
+from rialto_airflow.utils import add_orcid, normalize_doi
 
-Params = Dict[str, Union[int, str]]
 
+PUBMED_KEY = os.environ.get("AIRFLOW_VAR_PUBMED_KEY")
 BASE_URL = "https://eutils.ncbi.nlm.nih.gov"
-MAX_RESULTS = 1000  # the maximum number of pubmed IDs we will get for the query
-SEARCH_PATH = f"/entrez/eutils/esearch.fcgi?db=pubmed&retmode=json&retmax={MAX_RESULTS}"  # this endpoint supports json
-FETCH_PATH = f"/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml&retmax={MAX_RESULTS}"  # only xml is supported by this endpoint
+
+BASE_PARAMS = {
+    "db": "pubmed",
+    "retmax": 1000,
+    "api_key": PUBMED_KEY,
+}
+
 HEADERS = {"User-Agent": "stanford-library-rialto", "Accept": "application/json"}
 
+SEARCH_URL = f"{BASE_URL}/entrez/eutils/esearch.fcgi"
+FETCH_URL = f"{BASE_URL}/entrez/eutils/efetch.fcgi"
 
-def pubmed_key():
-    return os.environ.get("AIRFLOW_VAR_PUBMED_KEY")
+# create an http session that will retry any 429 statuses to stay within rate limits
+# will retry ten times, backing off with each requests, the last of which is 102.4 seconds
+# see: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html
+
+http = requests.Session()
+http.mount(
+    "https://",
+    HTTPAdapter(
+        max_retries=Retry(
+            status=10,
+            status_forcelist=[429, 500],
+            backoff_factor=0.1,
+            backoff_jitter=2,
+            allowed_methods=["GET", "POST"],
+        )
+    ),
+)
 
 
 def harvest(snapshot: Snapshot, limit=None) -> Path:
@@ -176,35 +199,48 @@ def pmids_from_dois(dois: list[str]) -> list[str]:
     return _pubmed_search_api(batch_query)
 
 
-def publications_from_pmids(pmids: list[str]) -> list[dict[Any, Any]]:
+def publications_from_pmids(pmids: list[str], retries=10) -> list[dict[Any, Any]]:
     """
-    Returns full pubmed records given a list of PMIDs.
+    Returns full pubmed records given a list of PMIDs. The retries behavior
+    controls how many times to retry if we get back bad XML (XML that won't
+    parse).
     """
     if len(pmids) == 0:
         return []
 
-    query = "id=" + "&id=".join(pmids)
+    logging.debug(f"fetching full records from pubmed for {pmids}")
 
-    full_url = f"{BASE_URL}{FETCH_PATH}&api_key={pubmed_key()}"
-    logging.debug(f"fetching full records from pubmed with {query}")
+    data = {
+        **BASE_PARAMS,
+        "id": pmids,
+        "retmode": "xml",
+    }
+
+    response = http.post(FETCH_URL, data=data, headers=HEADERS)
+    response.raise_for_status()
+
     try:
-        response = requests.post(full_url, params=query, headers=HEADERS)
-        response.raise_for_status()
+        xml_results = response.content
+        json_results = xmltodict.parse(xml_results)
+    except ExpatError as e:
+        time.sleep(1)
 
-        results = response.content
-
-        json_results = xmltodict.parse(results)
-        pubs = json_results.get("PubmedArticleSet", {}).get("PubmedArticle")
-        if pubs is None:
-            return []
-        if not isinstance(pubs, list):
-            # if there is only one record, it will not be in a list, but we want to be in one so we can iterate over it
-            return [pubs]
+        if retries > 0:
+            logging.warn(f"retrying a response with bad xml {response.text}")
+            return publications_from_pmids(pmids, retries=retries - 1)
         else:
-            return pubs
-    except requests.exceptions.RequestException as e:  # Catch all requests exceptions
-        logging.error(f"Error fetching full pubmed records {query}: {e}")
+            logging.warn(f"too many retries with bad xml {response.text}")
+            raise e
+
+    pubs = json_results.get("PubmedArticleSet", {}).get("PubmedArticle")
+
+    if pubs is None:
         return []
+    if not isinstance(pubs, list):
+        # if there is only one record, it will not be in a list, but we want to be in one so we can iterate over it
+        return [pubs]
+    else:
+        return pubs
 
 
 def _pubmed_search_api(query) -> list:
@@ -212,12 +248,10 @@ def _pubmed_search_api(query) -> list:
     Return a list of pmids given a general search query.
     """
 
-    params: Params = {"term": query}
-
-    full_url = f"{BASE_URL}{SEARCH_PATH}&api_key={pubmed_key()}"
+    params = {**BASE_PARAMS, "retmode": "json", "term": query}
     logging.debug(f"searching pubmed with {params}")
 
-    response = requests.get(full_url, params=params, headers=HEADERS)
+    response = http.get(SEARCH_URL, params=params, headers=HEADERS)
     response.raise_for_status()
     results = response.json()
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+import dotenv
 import pytest
 from sqlalchemy import insert
 from sqlalchemy.orm import sessionmaker
@@ -15,6 +16,9 @@ from rialto_airflow.schema.harvest import (
 from rialto_airflow.schema.reports import ReportsSchemaBase
 from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.publish import publication
+
+
+dotenv.load_dotenv()
 
 
 @pytest.fixture

--- a/test/harvest/test_pubmed.py
+++ b/test/harvest/test_pubmed.py
@@ -1,13 +1,12 @@
 import logging
-import pytest
 import re
-import dotenv
 
-from rialto_airflow.schema.harvest import Publication
+import pytest
+from xml.parsers.expat import ExpatError
+
 from rialto_airflow.harvest import pubmed
-from test.utils import num_jsonl_objects, load_jsonl_file, num_log_record_matches
-
-dotenv.load_dotenv()
+from rialto_airflow.schema.harvest import Publication
+from test.utils import load_jsonl_file, num_jsonl_objects, num_log_record_matches
 
 
 @pytest.fixture
@@ -55,6 +54,35 @@ def existing_publication(test_session):
         )
         session.add(pub)
         return pub
+
+
+@pytest.fixture
+def pubmed_book_xml():
+    return """<?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2025//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_250101.dtd">
+        <PubmedArticleSet>
+            <PubmedBookArticle>
+                <BookDocument>
+                    <PMID Version="1">38478703</PMID>
+                    <ArticleIdList><ArticleId IdType="bookaccession">NBK601514</ArticleId><ArticleId IdType="doi">10.25302/01.2021.ME.150731469</ArticleId></ArticleIdList>
+                    <Book>
+                    <Publisher><PublisherName>Patient-Centered Outcomes Research Institute (PCORI)</PublisherName><PublisherLocation>Washington (DC)</PublisherLocation></Publisher>
+                    <BookTitle book="pcori12021me15073146">Comparing Preferences for Depression and Diabetes Treatment among Adults of Different Racial and Ethnic Groups Who Reported Discrimination in Health Care</BookTitle>
+                    <PubDate><Year>2021</Year><Month>01</Month></PubDate>
+                    <CollectionTitle book="pcoricollect">PCORI Final Research Reports</CollectionTitle>
+                    <ELocationID EIdType="doi">10.25302/01.2021.ME.150731469</ELocationID>
+                    <PublicationType UI="D016454">Review</PublicationType>
+                    <Abstract><AbstractText Label="BACKGROUND">The abstract.</AbstractText></Abstract>
+                    </Book>
+                </BookDocument>
+                <PubmedBookData>
+                    <ArticleIdList>
+                        <ArticleId IdType="pubmed">38478703</ArticleId>
+                    </ArticleIdList>
+                </PubmedBookData>
+            </PubmedBookArticle>
+        </PubmedArticleSet>
+        """
 
 
 def pubmed_json():
@@ -274,25 +302,6 @@ def test_pubmed_fetch_missing_publications():
         "first publication is json"
     )  # check that we got a dict back
     assert "PubmedData" in pubs[0], "found the PubmedData key in the first publication"
-
-
-def test_pubmed_fetch_handles_500(requests_mock, caplog):
-    """
-    This is a test of the Pubmed Fetch API to ensures we don't crash with a 500 response.
-    """
-    caplog.set_level(logging.INFO)
-
-    requests_mock.post(
-        re.compile(".*"),
-        json={},
-        status_code=500,
-        headers={"Content-Type": "application/json"},
-    )
-    result = pubmed.publications_from_pmids(["12345"])
-    assert result == []
-    assert (
-        "Error fetching full pubmed records id=12345: 500 Server Error" in caplog.text
-    )
 
 
 def test_pubmed_fetch_publications_expects_list():
@@ -591,25 +600,74 @@ def test_pubs_from_pmids_no_articles(requests_mock, pubmed_book_xml):
     assert pubs == []
 
 
-@pytest.fixture
-def pubmed_book_xml():
-    return """<?xml version="1.0" ?>
-        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2025//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_250101.dtd">
-        <PubmedArticleSet><PubmedBookArticle>
-        <BookDocument>
-            <PMID Version="1">38478703</PMID>
-            <ArticleIdList><ArticleId IdType="bookaccession">NBK601514</ArticleId><ArticleId IdType="doi">10.25302/01.2021.ME.150731469</ArticleId></ArticleIdList>
-            <Book>
-            <Publisher><PublisherName>Patient-Centered Outcomes Research Institute (PCORI)</PublisherName><PublisherLocation>Washington (DC)</PublisherLocation></Publisher>
-            <BookTitle book="pcori12021me15073146">Comparing Preferences for Depression and Diabetes Treatment among Adults of Different Racial and Ethnic Groups Who Reported Discrimination in Health Care</BookTitle>
-            <PubDate><Year>2021</Year><Month>01</Month></PubDate>
-            <CollectionTitle book="pcoricollect">PCORI Final Research Reports</CollectionTitle>
-            <ELocationID EIdType="doi">10.25302/01.2021.ME.150731469</ELocationID>
-            <PublicationType UI="D016454">Review</PublicationType>
-            <Abstract><AbstractText Label="BACKGROUND">The abstract.</AbstractText></Abstract>
-            </Book>
-        </BookDocument>
-        <PubmedBookData>
-            <ArticleIdList><ArticleId IdType="pubmed">38478703</ArticleId></ArticleIdList></PubmedBookData>
-        </PubmedBookArticle></PubmedArticleSet>
-        """
+def test_http_session_retries():
+    """
+    Verify the http session is configured to retry 429 responses on both GET and POST
+    requests. requests_mock bypasses urllib3 entirely so cannot exercise this, but we
+    can inspect the adapter's Retry configuration directly.
+
+    get_adapter() returns BaseAdapter in the type stubs, but at runtime it returns
+    HTTPAdapter which does have max_retries.
+    """
+    adapter = pubmed.http.get_adapter("https://")
+    retry = adapter.max_retries  # type: ignore
+    assert 429 in retry.status_forcelist
+    assert 500 in retry.status_forcelist
+    assert "POST" in retry.allowed_methods
+    assert "GET" in retry.allowed_methods
+
+
+def test_retry_bad_xml(requests_mock, caplog, pubmed_book_xml):
+    """
+    PubMed API can sometimes return invalid XML, which then works on retry. This
+    tests that these get retried.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.register_uri(
+        "POST",
+        pubmed.FETCH_URL,
+        # a list of mocked http responses: first returns bad xml, second returns good xml
+        [
+            {"status_code": 200, "text": "this ain't xml"},
+            {
+                "status_code": 200,
+                "text": pubmed_book_xml,
+            },
+        ],
+    )
+
+    assert pubmed.publications_from_pmids(["123456"]) == []
+    assert "retrying a response with bad xml" in caplog.text
+
+
+def test_too_many_bad_xml(requests_mock, caplog, pubmed_book_xml):
+    """
+    PubMed API can sometimes return invalid XML, which then works on retry. This
+    tests that these get retried, and that we give up after 10 retries.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.register_uri(
+        "POST",
+        pubmed.FETCH_URL,
+        # 10 failures in a row should cause publications_from_pmids to fail
+        [
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+        ],
+    )
+
+    with pytest.raises(ExpatError):
+        pubmed.publications_from_pmids(["123456"]) == []
+
+    assert "too many retries with bad xml" in caplog.text


### PR DESCRIPTION
This commit consolidates some of the PubMed API configuration, and introduces a requests session object for retrying HTTP 429 and 500 errors. The 429 errors are coming back when there are too many requests in too short a time. The 500 errors seem sporadic, and also seem to work on retry. This retry behavior will also cover intermittent Connection Reset errors.

Additional retry behavior was added for XML parsing errors when malformed XML is returned, which can succeed on retry.

This has been tested in stage with a limit of 50k, without any errors being thrown.

fixes #769
