### PR TITLE
Changes to airflow dags list-runs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -74,7 +74,7 @@ task :check_running_airflow_dag do
                      '"airflow dags list --columns dag_id -o json"')
       dag_list = JSON.parse(dags.split("\n").last) # the last line of the output is the list of dags we need to parse
       dag_list.each do |dag|
-        command = "airflow dags list-runs -d #{dag['dag_id']} --state running"
+        command = "airflow dags list-runs #{dag['dag_id']} --state running"
         # Check if the DAG is running
         output = capture(:docker, 'compose', 'exec', '-it', container_name, '/bin/bash', '-c', "\"#{command}\"")
         # if the output of the above command is anything other than "No data found"


### PR DESCRIPTION
In Airflow 3 the `airflow dags list-runs` now takes the dag-id as a positional argument rather than an option flag. This is a follow on to the Airflow 3 upgrade in #810.

This should fix the error you will see go by during `cap deploy`.
