### PR TITLE
Use patched dimcli for 202 responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ package-mode = false
 
 dependencies = [
     "alembic>=1.16.5",
-    "dimcli",
+    # TODO: remove when https://github.com/digital-science/dimcli/issues/95 is resolved
+    "dimcli @ git+https://github.com/edsu/dimcli@handle-202",
     "jsonpath-ng>=1.7.0",
     "honeybadger>=0.21",
     "more-itertools",
@@ -79,6 +80,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["rialto_airflow"]
+
+[tool.hatch.metadata]
+# TODO: remove when there are no github branches as dependencies
+allow-direct-references = true
 
 [tool.alembic]
 

--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -214,7 +214,9 @@ def query_with_retry(q, retry=5):
             # Using a limit param set to 25 rather than the default of 1,000 to avoid 408 errors about the size
             # of a response. Consider raising or removing the limit if the issue is resolved and
             # removing the force param to view errors.
-            return dsl().query_iterative(q, show_results=False, limit=25, force=True)
+            return dsl().query_iterative(
+                q, show_results=False, limit=25, force=True, retry=5
+            )
         except requests.exceptions.RequestException as e:
             if try_count > retry:
                 logging.error(


### PR DESCRIPTION
Until dimcli can handle 202 responses, the dependencies have been updated to use a forked version that can.

https://github.com/edsu/dimcli/tree/handle-202

Ideally this change (or something like it) will get merged into dimcli or we can move off of dimcli to something a bit more fit to purpose. There is a lot in dimcli that we just don't need.

Closes #821

I was able to see the HTTP 202 responses getting retried, and then succeeding over in production: https://github.com/sul-dlss/rialto-airflow/issues/821#issuecomment-4224270174

I created a backlogged ticket to remember we should remove the forked dependency: #827 
