### PR TITLE
Catch and retry ChunkedEncodingError from PubMed

### DIFF
--- a/rialto_airflow/harvest/pubmed.py
+++ b/rialto_airflow/harvest/pubmed.py
@@ -10,6 +10,7 @@ from urllib3.util import Retry
 import requests
 import xmltodict
 from requests.adapters import HTTPAdapter
+from requests.exceptions import ChunkedEncodingError
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert
 from xml.parsers.expat import ExpatError
@@ -216,20 +217,19 @@ def publications_from_pmids(pmids: list[str], retries=10) -> list[dict[Any, Any]
         "retmode": "xml",
     }
 
-    response = http.post(FETCH_URL, data=data, headers=HEADERS)
-    response.raise_for_status()
-
     try:
+        response = http.post(FETCH_URL, data=data, headers=HEADERS)
+        response.raise_for_status()
         xml_results = response.content
         json_results = xmltodict.parse(xml_results)
-    except ExpatError as e:
+    except (ExpatError, ChunkedEncodingError) as e:
         time.sleep(1)
 
         if retries > 0:
-            logging.warning(f"retrying a response with bad xml {response.text}")
+            logging.warning(f"retrying after error: {type(e)} {e}")
             return publications_from_pmids(pmids, retries=retries - 1)
         else:
-            logging.warning(f"too many retries with bad xml {response.text}")
+            logging.warning(f"too many retries: {type(e)} {e}")
             raise e
 
     pubs = json_results.get("PubmedArticleSet", {}).get("PubmedArticle")

--- a/test/harvest/test_pubmed.py
+++ b/test/harvest/test_pubmed.py
@@ -638,7 +638,10 @@ def test_retry_bad_xml(requests_mock, caplog, pubmed_book_xml):
     )
 
     assert pubmed.publications_from_pmids(["123456"]) == []
-    assert "retrying a response with bad xml" in caplog.text
+    assert (
+        "retrying after error: <class 'xml.parsers.expat.ExpatError'> syntax error: line 1, column 0"
+        in caplog.text
+    )
 
 
 def test_too_many_bad_xml(requests_mock, caplog, pubmed_book_xml):
@@ -670,4 +673,55 @@ def test_too_many_bad_xml(requests_mock, caplog, pubmed_book_xml):
     with pytest.raises(ExpatError):
         pubmed.publications_from_pmids(["123456"]) == []
 
-    assert "too many retries with bad xml" in caplog.text
+    assert (
+        "too many retries: <class 'xml.parsers.expat.ExpatError'> syntax error: line 1, column 0"
+        in caplog.text
+    )
+
+
+def test_retry_chunked_encoding_error(requests_mock, caplog, pubmed_book_xml):
+    """
+    PubMed API can sometimes drop the connection mid-response. This tests
+    that ChunkedEncodingError is retried.
+    """
+    from requests.exceptions import ChunkedEncodingError
+
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.register_uri(
+        "POST",
+        pubmed.FETCH_URL,
+        [
+            {"exc": ChunkedEncodingError()},
+            {"status_code": 200, "text": pubmed_book_xml},
+        ],
+    )
+
+    assert pubmed.publications_from_pmids(["123456"]) == []
+    assert (
+        "retrying after error: <class 'requests.exceptions.ChunkedEncodingError'>"
+        in caplog.text
+    )
+
+
+def test_too_many_chunked_encoding_errors(requests_mock, caplog):
+    """
+    If ChunkedEncodingError persists beyond the retry limit, the exception is raised.
+    """
+    from requests.exceptions import ChunkedEncodingError
+
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.register_uri(
+        "POST",
+        pubmed.FETCH_URL,
+        [{"exc": ChunkedEncodingError()}] * 11,
+    )
+
+    with pytest.raises(ChunkedEncodingError):
+        pubmed.publications_from_pmids(["123456"])
+
+    assert (
+        "too many retries: <class 'requests.exceptions.ChunkedEncodingError'>"
+        in caplog.text
+    )


### PR DESCRIPTION
This commit will catch and retry ChunkedEncodingError from the PubMed API. We don't see them very often, but they do occur.

Fixes #824
