### PR TITLE
Dedupe across platforms using Pubmed and WOS IDs.

### DIFF
--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -16,7 +16,11 @@ def remove_duplicates(snapshot: Snapshot) -> int:
     wos_dupes = remove_wos_duplicates(snapshot)
     openalex_dupes = remove_openalex_duplicates(snapshot)
     sulpub_dupes = remove_sulpub_duplicates(snapshot)
-    total_deleted = wos_dupes + openalex_dupes + sulpub_dupes
+    wos_id_dupes = remove_wos_id_duplicates(snapshot)
+    pubmed_id_dupes = remove_pubmed_id_duplicates(snapshot)
+    total_deleted = (
+        wos_dupes + openalex_dupes + sulpub_dupes + wos_id_dupes + pubmed_id_dupes
+    )
     logging.info(
         f"Deleted a total of {total_deleted} duplicate publication rows from all sources."
     )
@@ -113,6 +117,62 @@ def remove_sulpub_duplicates(snapshot: Snapshot) -> int:
             deleted = merge_pubs(pubs=pubs, session=session)
             count_deleted += deleted
         logging.info(f"Deleted {count_deleted} publication rows from sulpub.")
+    return num_dupes
+
+
+def remove_wos_id_duplicates(snapshot: Snapshot) -> int:
+    logging.debug("Removing any publications with duplicate wos_id.")
+    with get_session(snapshot.database_name).begin() as session:
+        duplicates = session.execute(
+            select(func.count(), Publication.wos_id)
+            .where(Publication.doi.is_(None))
+            .where(Publication.wos_id.is_not(None))
+            .group_by(Publication.wos_id)
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} publications with duplicate wos_id.")
+        count_deleted = 0
+        wos_ids = [row[1] for row in duplicates]
+        for wos_id in wos_ids:
+            pubs = (
+                session.execute(select(Publication).where(Publication.wos_id == wos_id))
+                .scalars()
+                .all()
+            )
+            deleted = merge_pubs(pubs=pubs, session=session)
+            count_deleted += deleted
+        logging.info(f"Deleted {count_deleted} publication rows with duplicate wos_id.")
+    return num_dupes
+
+
+def remove_pubmed_id_duplicates(snapshot: Snapshot) -> int:
+    logging.debug("Removing any publications with duplicate pubmed_id.")
+    with get_session(snapshot.database_name).begin() as session:
+        duplicates = session.execute(
+            select(func.count(), Publication.pubmed_id)
+            .where(Publication.doi.is_(None))
+            .where(Publication.pubmed_id.is_not(None))
+            .group_by(Publication.pubmed_id)
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} publications with duplicate pubmed_id.")
+        count_deleted = 0
+        pubmed_ids = [row[1] for row in duplicates]
+        for pubmed_id in pubmed_ids:
+            pubs = (
+                session.execute(
+                    select(Publication).where(Publication.pubmed_id == pubmed_id)
+                )
+                .scalars()
+                .all()
+            )
+            deleted = merge_pubs(pubs=pubs, session=session)
+            count_deleted += deleted
+        logging.info(
+            f"Deleted {count_deleted} publication rows with duplicate pubmed_id."
+        )
     return num_dupes
 
 

--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -18,7 +18,12 @@ from rialto_airflow.schema.harvest import (
     pub_author_association,
 )
 from rialto_airflow.snapshot import Snapshot
-from rialto_airflow.utils import normalize_doi, normalize_orcid, add_orcid
+from rialto_airflow.utils import (
+    normalize_doi,
+    normalize_orcid,
+    normalize_pmid,
+    add_orcid,
+)
 
 
 def harvest(snapshot: Snapshot, limit: None | int = None) -> Path:
@@ -46,14 +51,25 @@ def harvest(snapshot: Snapshot, limit: None | int = None) -> Path:
                         break
 
                     doi = normalize_doi(dimensions_pub_json.get("doi", None))
+                    pubmed_id = (
+                        normalize_pmid(str(dimensions_pub_json["pmid"]))
+                        if dimensions_pub_json.get("pmid") is not None
+                        else None
+                    )
                     with get_session(snapshot.database_name).begin() as insert_session:
                         # if there's a DOI constraint violation, update the existing row's JSON
                         pub_id = insert_session.execute(
                             insert(Publication)
-                            .values(doi=doi, dim_json=dimensions_pub_json)
+                            .values(
+                                doi=doi,
+                                dim_json=dimensions_pub_json,
+                                pubmed_id=pubmed_id,
+                            )
                             .on_conflict_do_update(
                                 constraint="publication_doi_key",
-                                set_=dict(dim_json=dimensions_pub_json),
+                                set_=dict(
+                                    dim_json=dimensions_pub_json, pubmed_id=pubmed_id
+                                ),
                             )
                             .returning(Publication.id)
                         ).scalar_one()
@@ -262,10 +278,15 @@ def fill_in(snapshot: Snapshot):
                         continue
 
                     with get_session(snapshot.database_name).begin() as update_session:
+                        pubmed_id = (
+                            normalize_pmid(str(dimensions_pub["pmid"]))
+                            if dimensions_pub.get("pmid") is not None
+                            else None
+                        )
                         update_stmt = (
                             update(Publication)
                             .where(Publication.doi == doi)
-                            .values(dim_json=dimensions_pub)
+                            .values(dim_json=dimensions_pub, pubmed_id=pubmed_id)
                         )
                         update_session.execute(update_stmt)
 

--- a/rialto_airflow/harvest/dimensions.py
+++ b/rialto_airflow/harvest/dimensions.py
@@ -52,7 +52,7 @@ def harvest(snapshot: Snapshot, limit: None | int = None) -> Path:
 
                     doi = normalize_doi(dimensions_pub_json.get("doi", None))
                     pubmed_id = (
-                        normalize_pmid(str(dimensions_pub_json["pmid"]))
+                        normalize_pmid(dimensions_pub_json.get("pmid"))
                         if dimensions_pub_json.get("pmid") is not None
                         else None
                     )

--- a/rialto_airflow/harvest/openalex.py
+++ b/rialto_airflow/harvest/openalex.py
@@ -17,7 +17,7 @@ from rialto_airflow.schema.harvest import (
     pub_author_association,
 )
 from rialto_airflow.snapshot import Snapshot
-from rialto_airflow.utils import normalize_doi, add_orcid
+from rialto_airflow.utils import normalize_doi, normalize_pmid, add_orcid
 
 config.max_retries = 5
 config.retry_backoff_factor = 0.1
@@ -54,6 +54,8 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
 
                     doi = normalize_doi(openalex_pub.get("doi", None))
 
+                    pubmed_id = normalize_pmid(openalex_pub.get("ids", {}).get("pmid"))
+
                     with get_session(snapshot.database_name).begin() as insert_session:
                         # if there's a DOI constraint violation we need to update instead of insert
                         pub_id = insert_session.execute(
@@ -61,10 +63,14 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
                             .values(
                                 doi=doi,
                                 openalex_json=openalex_pub,
+                                pubmed_id=pubmed_id,
                             )
                             .on_conflict_do_update(
                                 constraint="publication_doi_key",
-                                set_=dict(openalex_json=openalex_pub),
+                                set_=dict(
+                                    openalex_json=openalex_pub,
+                                    pubmed_id=pubmed_id,
+                                ),
                             )
                             .returning(Publication.id)
                         ).scalar_one()
@@ -137,11 +143,16 @@ def fill_in(snapshot) -> Path:
                         )
                         continue
 
+                    pubmed_id = normalize_pmid(openalex_pub.get("ids", {}).get("pmid"))
+
                     with get_session(snapshot.database_name).begin() as update_session:
                         update_stmt = (
                             update(Publication)
                             .where(Publication.doi == doi)
-                            .values(openalex_json=openalex_pub)
+                            .values(
+                                openalex_json=openalex_pub,
+                                pubmed_id=pubmed_id,
+                            )
                         )
                         update_session.execute(update_stmt)
 

--- a/rialto_airflow/harvest/pubmed.py
+++ b/rialto_airflow/harvest/pubmed.py
@@ -21,7 +21,7 @@ from rialto_airflow.schema.harvest import (
     pub_author_association,
 )
 from rialto_airflow.snapshot import Snapshot
-from rialto_airflow.utils import add_orcid, normalize_doi
+from rialto_airflow.utils import add_orcid, normalize_doi, normalize_pmid
 
 
 PUBMED_KEY = os.environ.get("AIRFLOW_VAR_PUBMED_KEY")
@@ -87,6 +87,7 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
                         break
 
                     doi = normalize_doi(get_doi(pubmed_pub))
+                    pubmed_id = normalize_pmid(get_identifier(pubmed_pub, "pubmed"))
 
                     with get_session(snapshot.database_name).begin() as insert_session:
                         # if there's a DOI constraint violation we need to update instead of insert
@@ -95,10 +96,11 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
                             .values(
                                 doi=doi,
                                 pubmed_json=pubmed_pub,
+                                pubmed_id=pubmed_id,
                             )
                             .on_conflict_do_update(
                                 constraint="publication_doi_key",
-                                set_=dict(pubmed_json=pubmed_pub),
+                                set_=dict(pubmed_json=pubmed_pub, pubmed_id=pubmed_id),
                             )
                             .returning(Publication.id)
                         ).scalar_one()
@@ -155,10 +157,11 @@ def fill_in(snapshot: Snapshot):
                         continue
 
                     with get_session(snapshot.database_name).begin() as update_session:
+                        pubmed_id = normalize_pmid(get_identifier(pubmed_pub, "pubmed"))
                         update_stmt = (
                             update(Publication)
                             .where(Publication.doi == doi)
-                            .values(pubmed_json=pubmed_pub)
+                            .values(pubmed_json=pubmed_pub, pubmed_id=pubmed_id)
                         )
                         update_session.execute(update_stmt)
 

--- a/rialto_airflow/harvest/sul_pub.py
+++ b/rialto_airflow/harvest/sul_pub.py
@@ -128,7 +128,7 @@ def extract_doi(pub):
     return None
 
 
-def extract_wos_uid(pub):
+def extract_wos_uid(pub) -> str | None:
     """
     Extract and normalize the WOS UID from a sulpub record.
     Checks top-level 'wos_uid' first, then the identifier list for type 'WosUID',
@@ -145,7 +145,7 @@ def extract_wos_uid(pub):
     return None
 
 
-def extract_pmid(pub):
+def extract_pmid(pub) -> str | None:
     """
     Extract and normalize the PubMed ID from a sulpub record.
     Checks top-level 'pmid' first, then the identifier list for type 'pmid' or 'PMID'.

--- a/rialto_airflow/harvest/sul_pub.py
+++ b/rialto_airflow/harvest/sul_pub.py
@@ -139,9 +139,7 @@ def extract_wos_uid(pub):
 
     for id in pub.get("identifier", []):
         id_type = id.get("type", "")
-        if id_type == "WosUID":
-            return normalize_wos_id(id.get("id"))
-        if id_type in ("WoSItemID", "WosItemID"):
+        if id_type in ("WoSItemID", "WosItemID", "WosUID"):
             # These are bare accession numbers without the WOS: prefix
             return normalize_wos_id(id.get("id"))
     return None

--- a/rialto_airflow/harvest/sul_pub.py
+++ b/rialto_airflow/harvest/sul_pub.py
@@ -13,7 +13,7 @@ from rialto_airflow.schema.harvest import (
     Publication,
     pub_author_association,
 )
-from rialto_airflow.utils import normalize_doi
+from rialto_airflow.utils import normalize_doi, normalize_pmid, normalize_wos_id
 
 
 def harvest(snapshot, host, key, per_page=1000, limit=None):
@@ -27,14 +27,25 @@ def harvest(snapshot, host, key, per_page=1000, limit=None):
 
                 # only write approved publications to the database
                 if approved(sulpub_pub):
+                    wos_id = extract_wos_uid(sulpub_pub)
+                    pubmed_id = extract_pmid(sulpub_pub)
                     # if when inserting the row we get a constraint violation
                     # on the DOI then we have to do an update
                     pub_id = session.execute(
                         insert(Publication)
-                        .values(doi=doi, sulpub_json=sulpub_pub)
+                        .values(
+                            doi=doi,
+                            sulpub_json=sulpub_pub,
+                            wos_id=wos_id,
+                            pubmed_id=pubmed_id,
+                        )
                         .on_conflict_do_update(
                             constraint="publication_doi_key",
-                            set_=dict(sulpub_json=sulpub_pub),
+                            set_=dict(
+                                sulpub_json=sulpub_pub,
+                                wos_id=wos_id,
+                                pubmed_id=pubmed_id,
+                            ),
                         )
                         .returning(Publication.id)
                     ).scalar_one()
@@ -114,6 +125,39 @@ def extract_doi(pub):
                 f"doi was not available in top level for sulpub id {pub.get('sulpubid')} but found in identifier block"
             )
             return normalize_doi(id["id"])
+    return None
+
+
+def extract_wos_uid(pub):
+    """
+    Extract and normalize the WOS UID from a sulpub record.
+    Checks top-level 'wos_uid' first, then the identifier list for type 'WosUID',
+    'WoSItemID', or 'WosItemID'.
+    """
+    if pub.get("wos_uid"):
+        return normalize_wos_id(pub["wos_uid"])
+
+    for id in pub.get("identifier", []):
+        id_type = id.get("type", "")
+        if id_type == "WosUID":
+            return normalize_wos_id(id.get("id"))
+        if id_type in ("WoSItemID", "WosItemID"):
+            # These are bare accession numbers without the WOS: prefix
+            return normalize_wos_id(id.get("id"))
+    return None
+
+
+def extract_pmid(pub):
+    """
+    Extract and normalize the PubMed ID from a sulpub record.
+    Checks top-level 'pmid' first, then the identifier list for type 'pmid' or 'PMID'.
+    """
+    if pub.get("pmid"):
+        return normalize_pmid(str(pub["pmid"]))
+
+    for id in pub.get("identifier", []):
+        if id.get("type", "").lower() == "pmid":
+            return normalize_pmid(id.get("id"))
     return None
 
 

--- a/rialto_airflow/harvest/wos.py
+++ b/rialto_airflow/harvest/wos.py
@@ -20,7 +20,12 @@ from rialto_airflow.schema.harvest import (
     pub_author_association,
 )
 from rialto_airflow.snapshot import Snapshot
-from rialto_airflow.utils import normalize_doi, add_orcid
+from rialto_airflow.utils import (
+    normalize_doi,
+    normalize_pmid,
+    normalize_wos_id,
+    add_orcid,
+)
 
 Params = Dict[str, Union[int, str]]
 
@@ -53,6 +58,8 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
                         break
 
                     doi = get_doi(wos_pub)
+                    wos_id = normalize_wos_id(wos_pub.get("UID"))
+                    pubmed_id = get_pmid(wos_pub)
 
                     with get_session(snapshot.database_name).begin() as insert_session:
                         # if there's a DOI constraint violation we need to update instead of insert
@@ -61,10 +68,14 @@ def harvest(snapshot: Snapshot, limit=None) -> Path:
                             .values(
                                 doi=doi,
                                 wos_json=wos_pub,
+                                wos_id=wos_id,
+                                pubmed_id=pubmed_id,
                             )
                             .on_conflict_do_update(
                                 constraint="publication_doi_key",
-                                set_=dict(wos_json=wos_pub),
+                                set_=dict(
+                                    wos_json=wos_pub, wos_id=wos_id, pubmed_id=pubmed_id
+                                ),
                             )
                             .returning(Publication.id)
                         ).scalar_one()
@@ -107,11 +118,15 @@ def fill_in(snapshot: Snapshot):
                     if doi is None:
                         continue
 
+                    wos_id = normalize_wos_id(wos_pub.get("UID"))
+                    pubmed_id = get_pmid(wos_pub)
                     with get_session(snapshot.database_name).begin() as update_session:
                         update_stmt = (
                             update(Publication)
                             .where(Publication.doi == doi)
-                            .values(wos_json=wos_pub)
+                            .values(
+                                wos_json=wos_pub, wos_id=wos_id, pubmed_id=pubmed_id
+                            )
                         )
                         update_session.execute(update_stmt)
 
@@ -300,6 +315,26 @@ def check_status(resp: requests.Response, should_raise_for_status: bool) -> bool
             return False
 
     return True
+
+
+def get_pmid(pub) -> Optional[str]:
+    """Extract and normalize the PubMed ID from a WOS record's identifiers list."""
+    try:
+        identifiers_field = (
+            pub.get("dynamic_data", {})
+            .get("cluster_related", {})
+            .get("identifiers", {})
+        )
+        if not isinstance(identifiers_field, dict):
+            return None
+        ids = identifiers_field.get("identifier", [])
+        ids = [ids] if isinstance(ids, dict) else ids
+        for id in ids:
+            if id.get("type") == "pmid":
+                return normalize_pmid(str(id["value"]))
+    except AttributeError:
+        pass
+    return None
 
 
 def get_doi(pub) -> Optional[str]:

--- a/rialto_airflow/schema/harvest.py
+++ b/rialto_airflow/schema/harvest.py
@@ -50,6 +50,8 @@ class Publication(HarvestSchemaBase):
     wos_json: Mapped[Optional[dict]] = mapped_column(JSONB(none_as_null=True))
     pubmed_json: Mapped[Optional[dict]] = mapped_column(JSONB(none_as_null=True))
     crossref_json: Mapped[Optional[dict]] = mapped_column(JSONB(none_as_null=True))
+    wos_id: Mapped[Optional[str]] = mapped_column(String)
+    pubmed_id: Mapped[Optional[str]] = mapped_column(String)
     created_at: Mapped[Optional[DateTime]] = mapped_column(
         DateTime, server_default=utcnow()
     )
@@ -76,6 +78,8 @@ class Publication(HarvestSchemaBase):
         Index("idx_wos_id", text("(wos_json->>'UID')")),
         Index("idx_sulpub_id", text("(sulpub_json->>'sulpubid')")),
         Index("idx_dim_id", text("(dim_json->>'id')")),
+        Index("idx_pub_wos_id", "wos_id"),
+        Index("idx_pub_pubmed_id", "pubmed_id"),
     )
 
 

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -146,7 +146,7 @@ def normalize_wos_id(wos_id):
         return None
 
     wos_id = wos_id.strip()
-    if not wos_id:
+    if wos_id == "":
         return None
 
     upper = wos_id.upper()

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -132,6 +132,33 @@ def normalize_pmid(pmid):
     return pmid
 
 
+def normalize_wos_id(wos_id):
+    """
+    Normalize a WOS UID to a bare accession number by stripping the "WOS:" prefix.
+    Returns None for MEDLINE:-prefixed UIDs (those encode PMIDs, not WOS UIDs)
+    and for None/blank inputs.
+    Examples:
+        "WOS:001008232900698" -> "001008232900698"
+        "001008232900698"     -> "001008232900698"
+        "MEDLINE:29780978"    -> None
+    """
+    if wos_id is None:
+        return None
+
+    wos_id = wos_id.strip()
+    if not wos_id:
+        return None
+
+    upper = wos_id.upper()
+    if upper.startswith("MEDLINE:"):
+        return None
+
+    if upper.startswith("WOS:"):
+        return wos_id[4:]
+
+    return wos_id
+
+
 def normalize_orcid(orcid):
     orcid = orcid.strip().lower()
     orcid = orcid.replace("https://orcid.org/", "").replace(

--- a/test/harvest/test_deduplicate.py
+++ b/test/harvest/test_deduplicate.py
@@ -22,6 +22,8 @@ def dataset(test_session, dim_json, openalex_json, wos_json, sulpub_json, pubmed
             wos_json=wos_json,
             sulpub_json=sulpub_json,
             pubmed_json=pubmed_json,
+            wos_id="000123456789",
+            pubmed_id="36857419",
         )
 
         pub2 = Publication(
@@ -35,6 +37,8 @@ def dataset(test_session, dim_json, openalex_json, wos_json, sulpub_json, pubmed
             wos_json=wos_json,
             sulpub_json=sulpub_json,
             pubmed_json=pubmed_json,
+            wos_id="000123456789",
+            pubmed_id="36857419",
         )
 
         author1 = Author(
@@ -124,6 +128,30 @@ def test_openalex_deduplicate(test_session, dataset, snapshot, caplog):
         assert "Deleted 1 publication rows from OpenAlex." in caplog.text
 
 
+def test_pubmed_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that publications with a duplicate pubmed_id are found and merged.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_pubmed_id_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        remaining_pub = (
+            session.query(Publication).where(Publication.pubmed_id == "36857419").one()
+        )
+        assert len(remaining_pub.authors) == 2, "remaining publication has both authors"
+        author2 = session.query(Author).where(Author.orcid == "02980983434").one()
+        assert len(author2.publications) == 1, (
+            "second author exists and is linked to the remaining publication"
+        )
+        assert "Found 1 publications with duplicate pubmed_id." in caplog.text
+        assert "Deleted 1 publication rows with duplicate pubmed_id." in caplog.text
+
+
 def test_sulpub_deduplicate(test_session, dataset, snapshot, caplog):
     """
     Test that the publication with an sulpub duplicate is found and the duplicates removed.
@@ -149,6 +177,46 @@ def test_sulpub_deduplicate(test_session, dataset, snapshot, caplog):
         assert "Deleted 1 publication rows from sulpub." in caplog.text
 
 
+def test_wos_id_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that publications with a duplicate wos_id are found and merged.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_wos_id_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        remaining_pub = (
+            session.query(Publication).where(Publication.wos_id == "000123456789").one()
+        )
+        assert len(remaining_pub.authors) == 2, "remaining publication has both authors"
+        assert "Found 1 publications with duplicate wos_id." in caplog.text
+        assert "Deleted 1 publication rows with duplicate wos_id." in caplog.text
+
+
+def test_pubmed_id_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that publications with a duplicate pubmed_id are found and merged.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_pubmed_id_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        remaining_pub = (
+            session.query(Publication).where(Publication.pubmed_id == "36857419").one()
+        )
+        assert len(remaining_pub.authors) == 2, "remaining publication has both authors"
+        assert "Found 1 publications with duplicate pubmed_id." in caplog.text
+        assert "Deleted 1 publication rows with duplicate pubmed_id." in caplog.text
+
+
 def test_merge_pubs(test_session, dataset):
     """
     Test that merge_pubs merges authors and deletes duplicates.
@@ -172,7 +240,7 @@ def test_merge_pubs(test_session, dataset):
 @pytest.fixture
 def dataset2(test_session, dim_json, openalex_json, wos_json, sulpub_json, pubmed_json):
     """
-    This fixture will create two publications that are duplicates within different platfordmsand lack DOIs.
+    This fixture will create two publications that are duplicates within different platforms and lack DOIs.
     """
     with test_session.begin() as session:
         pub = Publication(

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -38,6 +38,7 @@ def mock_openalex(monkeypatch):
             "doi": "https://doi.org/10.1515/9781503624153",
             "title": "An example title",
             "publication_year": 1891,
+            "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/36857419"},
         }
 
     monkeypatch.setattr(openalex, "orcid_publications", f)
@@ -56,6 +57,7 @@ def test_harvest(snapshot, test_session, mock_authors, mock_openalex):
 
         pub = session.query(Publication).first()
         assert pub.doi == "10.1515/9781503624153", "doi was normalized"
+        assert pub.pubmed_id == "36857419", "pubmed_id populated from ids.pmid"
 
         assert len(pub.authors) == 2, "publication has two authors"
         assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
@@ -78,6 +80,7 @@ def test_harvest_when_doi_exists(
 
         assert pub.openalex_json
         assert pub.openalex_json["title"] == "An example title", "openalex json updated"
+        assert pub.pubmed_id == "36857419", "pubmed_id populated from ids.pmid"
         assert pub.wos_json == {"wos": "data"}, "wos data the same"
         assert pub.pubmed_json is None
 
@@ -107,6 +110,7 @@ def test_harvest_when_author_exists(
 
         assert pub.openalex_json
         assert pub.openalex_json["title"] == "An example title", "openalex json updated"
+        assert pub.pubmed_id == "36857419", "pubmed_id populated from ids.pmid"
         assert pub.wos_json == {"wos": "data"}, "wos data the same"
         assert pub.pubmed_json is None
 
@@ -160,6 +164,7 @@ def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
             "doi": "10.1515/9781503624153",
             "title": "A sample title",
             "publication_year": 1891,
+            "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/36857419"},
         }
     ]
     monkeypatch.setattr(openalex, "Works", lambda: MockWorks(records))
@@ -175,7 +180,9 @@ def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
             "doi": "10.1515/9781503624153",
             "title": "A sample title",
             "publication_year": 1891,
+            "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/36857419"},
         }
+        assert pub.pubmed_id == "36857419", "pubmed_id populated from ids.pmid"
 
     # adds 1 publication to the jsonl file
     assert num_jsonl_objects(snapshot.path / "openalex-fillin.jsonl") == 1

--- a/test/harvest/test_sul_pub.py
+++ b/test/harvest/test_sul_pub.py
@@ -194,3 +194,48 @@ def test_harvest_when_author_exists(
         assert len(pub.authors) == 2, "publication has two authors"
         assert pub.authors[0].cap_profile_id == "12345"
         assert pub.authors[1].cap_profile_id == "123456"
+
+
+def test_extract_wos_uid_from_top_level():
+    pub = {"wos_uid": "WOS:001008232900698"}
+    assert sul_pub.extract_wos_uid(pub) == "001008232900698"
+
+
+def test_extract_wos_uid_from_identifier_wos_uid_type():
+    pub = {"identifier": [{"type": "WosUID", "id": "WOS:001008232900698"}]}
+    assert sul_pub.extract_wos_uid(pub) == "001008232900698"
+
+
+def test_extract_wos_uid_from_identifier_wos_item_id_type():
+    pub = {"identifier": [{"type": "WoSItemID", "id": "001008232900698"}]}
+    assert sul_pub.extract_wos_uid(pub) == "001008232900698"
+
+
+def test_extract_wos_uid_from_identifier_alternate_wos_item_id_type():
+    pub = {"identifier": [{"type": "WosItemID", "id": "001008232900698"}]}
+    assert sul_pub.extract_wos_uid(pub) == "001008232900698"
+
+
+def test_extract_wos_uid_returns_none_when_absent():
+    pub = {"identifier": [{"type": "doi", "id": "10.1000/xyz123"}]}
+    assert sul_pub.extract_wos_uid(pub) is None
+
+
+def test_extract_pmid_from_top_level():
+    pub = {"pmid": 29780978}
+    assert sul_pub.extract_pmid(pub) == "29780978"
+
+
+def test_extract_pmid_from_identifier():
+    pub = {"identifier": [{"type": "pmid", "id": "29780978"}]}
+    assert sul_pub.extract_pmid(pub) == "29780978"
+
+
+def test_extract_pmid_from_identifier_uppercase_type():
+    pub = {"identifier": [{"type": "PMID", "id": "29780978"}]}
+    assert sul_pub.extract_pmid(pub) == "29780978"
+
+
+def test_extract_pmid_returns_none_when_absent():
+    pub = {"identifier": [{"type": "doi", "id": "10.1000/xyz123"}]}
+    assert sul_pub.extract_pmid(pub) is None

--- a/test/harvest/test_wos.py
+++ b/test/harvest/test_wos.py
@@ -539,3 +539,51 @@ def test_check_status_should_raise_false(mock_response_500, mock_response_200, c
     )
 
     assert num_log_record_matches(caplog.records, logging.ERROR, "🤮") == 1
+
+
+def test_get_pmid_from_identifier_list():
+    pub = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {
+                    "identifier": [
+                        {"type": "issn", "value": "1234-5678"},
+                        {"type": "pmid", "value": "29780978"},
+                    ]
+                }
+            }
+        }
+    }
+    assert wos.get_pmid(pub) == "29780978"
+
+
+def test_get_pmid_from_single_identifier_dict():
+    pub = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {"identifier": {"type": "pmid", "value": "29780978"}}
+            }
+        }
+    }
+    assert wos.get_pmid(pub) == "29780978"
+
+
+def test_get_pmid_returns_none_when_no_pmid():
+    pub = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {"identifier": [{"type": "issn", "value": "1234-5678"}]}
+            }
+        }
+    }
+    assert wos.get_pmid(pub) is None
+
+
+def test_get_pmid_returns_none_when_identifiers_not_dict():
+    pub = {"dynamic_data": {"cluster_related": {"identifiers": "some_string"}}}
+    assert wos.get_pmid(pub) is None
+
+
+def test_get_pmid_returns_none_on_attribute_error():
+    pub = {"dynamic_data": {"cluster_related": None}}
+    assert wos.get_pmid(pub) is None

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -128,6 +128,8 @@ def test_create_schema(
                 "sulpub_json",
                 "wos_json",
                 "pubmed_json",
+                "wos_id",
+                "pubmed_id",
                 "created_at",
                 "updated_at",
                 "types",

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -112,3 +112,15 @@ def test_normalize_orcid():
 def test_piped():
     assert utils.piped(["a", "b", "c"]) == "a|b|c"
     assert utils.piped(["a", None, "c", None, "d"]) == "a|c|d"  # type: ignore
+
+
+def test_normalize_wos_id():
+    assert utils.normalize_wos_id(None) is None
+    assert utils.normalize_wos_id("") is None
+    assert utils.normalize_wos_id("   ") is None
+    assert utils.normalize_wos_id("MEDLINE:29780978") is None
+    assert utils.normalize_wos_id("medline:29780978") is None
+    assert utils.normalize_wos_id("WOS:001008232900698") == "001008232900698"
+    assert utils.normalize_wos_id("wos:001008232900698") == "001008232900698"
+    assert utils.normalize_wos_id("001008232900698") == "001008232900698"
+    assert utils.normalize_wos_id("RC:29780978") == "RC:29780978"


### PR DESCRIPTION
**What was changed?**
Fixes #781 to dedupe/merge across platforms where there are duplicate PMIDs or WoS IDs. Follow-on work as described in #823 will handle within-Pubmed duplicates. 

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
Updating the changelog about deduplication algorithm. 
