### PR TITLE
Dedupe by dimensions id

### DIFF
--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -15,17 +15,17 @@ def remove_duplicates(snapshot: Snapshot) -> int:
     logging.debug("Removing duplicate publications from each source.")
     wos_dupes = remove_wos_duplicates(snapshot)
     openalex_dupes = remove_openalex_duplicates(snapshot)
+    dimensions_dupes = remove_dimensions_duplicates(snapshot)
     sulpub_dupes = remove_sulpub_duplicates(snapshot)
     wos_id_dupes = remove_wos_id_duplicates(snapshot)
     pubmed_id_dupes = remove_pubmed_id_duplicates(snapshot)
-    dimensions_dupes = remove_dimensions_duplicates(snapshot)
     total_deleted = (
         wos_dupes
         + openalex_dupes
+        + dimensions_dupes
         + sulpub_dupes
         + wos_id_dupes
         + pubmed_id_dupes
-        + dimensions_dupes
     )
     logging.info(
         f"Deleted a total of {total_deleted} duplicate publication rows from all sources."

--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -18,8 +18,14 @@ def remove_duplicates(snapshot: Snapshot) -> int:
     sulpub_dupes = remove_sulpub_duplicates(snapshot)
     wos_id_dupes = remove_wos_id_duplicates(snapshot)
     pubmed_id_dupes = remove_pubmed_id_duplicates(snapshot)
+    dimensions_dupes = remove_dimensions_duplicates(snapshot)
     total_deleted = (
-        wos_dupes + openalex_dupes + sulpub_dupes + wos_id_dupes + pubmed_id_dupes
+        wos_dupes
+        + openalex_dupes
+        + sulpub_dupes
+        + wos_id_dupes
+        + pubmed_id_dupes
+        + dimensions_dupes
     )
     logging.info(
         f"Deleted a total of {total_deleted} duplicate publication rows from all sources."
@@ -86,6 +92,37 @@ def remove_openalex_duplicates(snapshot: Snapshot) -> int:
             deleted = merge_pubs(pubs=pubs, session=session)
             count_deleted += deleted
         logging.info(f"Deleted {count_deleted} publication rows from OpenAlex.")
+    return num_dupes
+
+
+def remove_dimensions_duplicates(snapshot: Snapshot) -> int:
+    logging.debug("Removing any duplicate Dimensions publications.")
+    with get_session(snapshot.database_name).begin() as session:
+        # Find all duplicate Dimensions publications in the snapshot
+        duplicates = session.execute(
+            select(func.count(), Publication.dim_json["id"])
+            .where(Publication.doi.is_(None))
+            .where(Publication.dim_json["id"].is_not(None))
+            .group_by(Publication.dim_json["id"])
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} Dimensions publications with duplicates.")
+        count_deleted = 0
+        dim_ids = [row[1] for row in duplicates]
+        for dim_id in dim_ids:
+            pubs = (
+                session.execute(
+                    select(Publication).where(
+                        Publication.dim_json["id"].astext == dim_id
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            deleted = merge_pubs(pubs=pubs, session=session)
+            count_deleted += deleted
+        logging.info(f"Deleted {count_deleted} publication rows from Dimensions.")
     return num_dupes
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -170,6 +170,7 @@ def test_reports_session(test_reports_engine, monkeypatch):
 @pytest.fixture
 def dim_json():
     return {
+        "id": "pub.1000000001",
         "type": "article",
         "doi": "10.000/000001",
         "journal": {"title": "Delicious Limes Journal of Science"},

--- a/test/harvest/test_deduplicate.py
+++ b/test/harvest/test_deduplicate.py
@@ -128,6 +128,31 @@ def test_openalex_deduplicate(test_session, dataset, snapshot, caplog):
         assert "Deleted 1 publication rows from OpenAlex." in caplog.text
 
 
+def test_dimensions_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that the publication with a Dimensions duplicate is found and the duplicates removed.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_dimensions_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        pubs = session.query(Publication).where(
+            Publication.dim_json["id"].astext == "pub.1000000001"
+        )
+        assert pubs.count() == 1, "remaining publication has the Dimensions ID"
+        assert len(pubs.one().authors) == 2, "remaining publication has both authors"
+        author2 = session.query(Author).where(Author.orcid == "02980983434").one()
+        assert len(author2.publications) == 1, (
+            "second author exists and is linked to the remaining publication"
+        )
+        assert "Found 1 Dimensions publications with duplicates." in caplog.text
+        assert "Deleted 1 publication rows from Dimensions." in caplog.text
+
+
 def test_pubmed_deduplicate(test_session, dataset, snapshot, caplog):
     """
     Test that publications with a duplicate pubmed_id are found and merged.


### PR DESCRIPTION
**What was changed?**
Closed #504 to dedupe by Dimensions ID when the DOI is null. I considered making a separate non-unique column for dim_json but wasn't sure if that was needed at this point for a within-platform dedupe. Open to adding that, though. 

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
Added note about deduplication. 