### PR TITLE
Remove initial WOS deduping in favor of cross-platform deduping

### DIFF
--- a/rialto_airflow/harvest/deduplicate.py
+++ b/rialto_airflow/harvest/deduplicate.py
@@ -13,15 +13,20 @@ def remove_duplicates(snapshot: Snapshot) -> int:
     Returns the number of duplicates found (not the number of rows deleted).
     """
     logging.debug("Removing duplicate publications from each source.")
-    wos_dupes = remove_wos_duplicates(snapshot)
     openalex_dupes = remove_openalex_duplicates(snapshot)
     dimensions_dupes = remove_dimensions_duplicates(snapshot)
     sulpub_dupes = remove_sulpub_duplicates(snapshot)
     wos_id_dupes = remove_wos_id_duplicates(snapshot)
     pubmed_id_dupes = remove_pubmed_id_duplicates(snapshot)
     total_deleted = (
-        wos_dupes
-        + openalex_dupes
+        openalex_dupes
+        + dimensions_dupes
+        + sulpub_dupes
+        + wos_id_dupes
+        + pubmed_id_dupes
+    )
+    total_deleted = (
+        openalex_dupes
         + dimensions_dupes
         + sulpub_dupes
         + wos_id_dupes
@@ -31,37 +36,6 @@ def remove_duplicates(snapshot: Snapshot) -> int:
         f"Deleted a total of {total_deleted} duplicate publication rows from all sources."
     )
     return total_deleted
-
-
-def remove_wos_duplicates(snapshot: Snapshot) -> int:
-    logging.debug("Removing any duplicate WOS publications.")
-    with get_session(snapshot.database_name).begin() as session:
-        # Find all duplicate WOS publications in the snapshot
-        duplicates = session.execute(
-            select(func.count(), Publication.wos_json["UID"])
-            .where(Publication.doi.is_(None))
-            .where(Publication.wos_json["UID"].is_not(None))
-            .group_by(Publication.wos_json["UID"])
-            .having(func.count() > 1)
-        ).all()
-        num_dupes = len(duplicates)
-        logging.info(f"Found {num_dupes} WOS publications with duplicates.")
-        count_deleted = 0
-        wos_uids = [row[1] for row in duplicates]
-        for wos_uid in wos_uids:
-            pubs = (
-                session.execute(
-                    select(Publication).where(
-                        Publication.wos_json["UID"].astext == wos_uid
-                    )
-                )
-                .scalars()
-                .all()
-            )
-            deleted = merge_pubs(pubs=pubs, session=session)
-            count_deleted += deleted
-        logging.info(f"Deleted {count_deleted} publication rows from WOS.")
-    return num_dupes
 
 
 def remove_openalex_duplicates(snapshot: Snapshot) -> int:

--- a/test/harvest/test_deduplicate.py
+++ b/test/harvest/test_deduplicate.py
@@ -80,29 +80,6 @@ def dataset(test_session, dim_json, openalex_json, wos_json, sulpub_json, pubmed
         session.add(pub2)
 
 
-def test_wos_deduplicate(test_session, dataset, snapshot, caplog):
-    """
-    Test that the publication with a duplicate is found and the duplicates removed.
-    Authors should be moved to the remaining record.
-    """
-    caplog.set_level(logging.INFO)
-    dupes = deduplicate.remove_wos_duplicates(snapshot)
-    assert dupes == 1
-    with test_session.begin() as session:
-        # only one publication remains and dupe has been deleted
-        assert session.query(Publication).count() == 1
-        pubs = session.query(Publication).where(
-            Publication.wos_json["UID"].astext == "WOS:000123456789"
-        )
-        assert pubs.count() == 1
-        assert len(pubs.one().authors) == 2
-        # the second author remains and is linked to one publication
-        author2 = session.query(Author).where(Author.orcid == "02980983434").one()
-        assert len(author2.publications) == 1
-        assert "Found 1 WOS publications with duplicates." in caplog.text
-        assert "Deleted 1 publication rows from WOS." in caplog.text
-
-
 def test_openalex_deduplicate(test_session, dataset, snapshot, caplog):
     """
     Test that the publication with an OpenAlex duplicate is found and the duplicates removed.


### PR DESCRIPTION
**What was changed?**
No need to dedupe within-platform and cross-platform for WOS IDs. 

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
N/A