### PR TITLE
Prevent long running tasks from being stopped

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -70,7 +70,9 @@ x-airflow-common:
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL: 'http://airflow-apiserver:8080/execution/'
     AIRFLOW__API_AUTH__JWT_SECRET: ${AIRFLOW__API_AUTH__JWT_SECRET:-airflow_jwt_secret}
     AIRFLOW__API_AUTH__JWT_ISSUER: ${AIRFLOW__API_AUTH__JWT_ISSUER:-airflow}
-    AIRFLOW__API_AUTH__JWT_EXPIRATION_TIME: 345600 # 4 days: important for long running tasks
+    # tasks will be killed at 24 hours (default)
+    # see: https://airflow.apache.org/docs/apache-airflow-providers-celery/stable/configurations-ref.html#visibility-timeout
+    AIRFLOW__CELERY_BROKER_TRANSPORT_OPTIONS__VISIBILITY_TIMEOUT: 345600
     AIRFLOW__SMTP__SMTP_USER: ${AIRFLOW__SMTP__SMTP_USER}
     AIRFLOW__SMTP__SMTP_HOST: ${AIRFLOW__SMTP__SMTP_HOST}
     AIRFLOW__SMTP__SMTP_PASSWORD: ''

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -70,6 +70,7 @@ x-airflow-common:
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL: 'http://airflow-apiserver:8080/execution/'
     AIRFLOW__API_AUTH__JWT_SECRET: ${AIRFLOW__API_AUTH__JWT_SECRET:-airflow_jwt_secret}
     AIRFLOW__API_AUTH__JWT_ISSUER: ${AIRFLOW__API_AUTH__JWT_ISSUER:-airflow}
+    AIRFLOW__API_AUTH__JWT_EXPIRATION_TIME: 345600 # 4 days: important for long running tasks
     AIRFLOW__SMTP__SMTP_USER: ${AIRFLOW__SMTP__SMTP_USER}
     AIRFLOW__SMTP__SMTP_HOST: ${AIRFLOW__SMTP__SMTP_HOST}
     AIRFLOW__SMTP__SMTP_PASSWORD: ''

--- a/compose.yaml
+++ b/compose.yaml
@@ -68,7 +68,9 @@ x-airflow-common:
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL: 'http://airflow-apiserver:8080/execution/'
     AIRFLOW__API_AUTH__JWT_SECRET: ${AIRFLOW__API_AUTH__JWT_SECRET:-airflow_jwt_secret}
     AIRFLOW__API_AUTH__JWT_ISSUER: ${AIRFLOW__API_AUTH__JWT_ISSUER:-airflow}
-    AIRFLOW__API_AUTH__JWT_EXPIRATION_TIME: 345600 # 4 days: important for longing running tasks
+    # tasks will be killed at 24 hours (default)
+    # see: https://airflow.apache.org/docs/apache-airflow-providers-celery/stable/configurations-ref.html#visibility-timeout
+    AIRFLOW__CELERY_BROKER_TRANSPORT_OPTIONS__VISIBILITY_TIMEOUT: 345600
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server

--- a/compose.yaml
+++ b/compose.yaml
@@ -68,6 +68,7 @@ x-airflow-common:
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL: 'http://airflow-apiserver:8080/execution/'
     AIRFLOW__API_AUTH__JWT_SECRET: ${AIRFLOW__API_AUTH__JWT_SECRET:-airflow_jwt_secret}
     AIRFLOW__API_AUTH__JWT_ISSUER: ${AIRFLOW__API_AUTH__JWT_ISSUER:-airflow}
+    AIRFLOW__API_AUTH__JWT_EXPIRATION_TIME: 345600 # 4 days: important for longing running tasks
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server


### PR DESCRIPTION
The default visibility timeout for celery tasks is 24 hours which causes tasks that run longer than that to be seen as dead processes which get stopped.

See this Airflow PR for more context: https://github.com/apache/airflow/pull/62869

fixes #834

**The `harvest_dimensions` task ran successfully for more than 24 hours in production with this branch deployed**
