### PR TITLE
Set up incremental harvest DAG as copy of harvest

### DIFF
--- a/rialto_airflow/dags/harvest_incremental.py
+++ b/rialto_airflow/dags/harvest_incremental.py
@@ -1,0 +1,210 @@
+import datetime
+import logging
+from pathlib import Path
+import shutil
+
+from airflow.sdk import dag, task, task_group
+from airflow.models import Variable
+
+from rialto_airflow import funders
+from rialto_airflow.harvest_incremental import (
+    authors,
+    crossref,
+    dimensions,
+    openalex,
+    sul_pub,
+    wos,
+    pubmed,
+    distill,
+    deduplicate,
+)
+from rialto_airflow.database import create_database, create_schema
+from rialto_airflow.schema.harvest import HarvestSchemaBase
+from rialto_airflow.snapshot import Snapshot
+from rialto_airflow.utils import rialto_authors_file
+from rialto_airflow.honeybadger import default_args
+
+data_dir = Path(Variable.get("data_dir"))
+sul_pub_host = Variable.get("sul_pub_host")
+sul_pub_key = Variable.get("sul_pub_key")
+
+# to artificially limit the API activity in development
+harvest_limit = None
+try:
+    harvest_limit = int(Variable.get("harvest_limit", default_var=None))
+except TypeError:
+    pass
+except ValueError:
+    pass
+
+if harvest_limit:
+    logging.warning(
+        f"⚠️ harvest_limit is set to {harvest_limit}, running harvest will stop at the limit number of publications per source"
+    )
+else:
+    logging.debug(
+        "‼️ no harvest_limit is set, running harvest will attempt to retrieve all results"
+    )
+
+
+@dag(
+    schedule="@weekly",
+    max_active_runs=1,
+    start_date=datetime.datetime(2024, 1, 1),
+    catchup=False,
+    default_args=default_args(),
+)
+def harvest_incremental():
+    @task()
+    def setup():
+        """
+        Set up the snapshot directory and database.
+        """
+        snapshot = Snapshot.create(data_dir)
+        shutil.copyfile(Path(rialto_authors_file(data_dir)), snapshot.authors_csv)
+        create_database(snapshot.database_name)
+        create_schema(snapshot.database_name, HarvestSchemaBase)
+
+        return snapshot
+
+    @task()
+    def load_authors(snapshot):
+        """
+        Load the authors data from the authors CSV into the database.
+        """
+        authors.load_authors_table(snapshot)
+
+    @task()
+    def dimensions_harvest(snapshot):
+        """
+        Fetch the data by ORCID from Dimensions.
+        """
+        dimensions.harvest(snapshot, limit=harvest_limit)
+
+    @task()
+    def openalex_harvest(snapshot):
+        """
+        Fetch the data by ORCID from OpenAlex.
+        """
+        openalex.harvest(snapshot, limit=harvest_limit)
+
+    @task()
+    def wos_harvest(snapshot):
+        """
+        Fetch the data by ORCID from Web of Science.
+        """
+        wos.harvest(snapshot, limit=harvest_limit)
+
+    @task()
+    def sulpub_harvest(snapshot):
+        """
+        Harvest data from SUL-Pub.
+        """
+        sul_pub.harvest(snapshot, sul_pub_host, sul_pub_key, limit=harvest_limit)
+
+    @task()
+    def pubmed_harvest(snapshot):
+        """
+        Fetch the data by ORCID from Pubmed.
+        """
+        pubmed.harvest(snapshot, limit=harvest_limit)
+
+    @task_group()
+    def harvest_pubs(snapshot):
+        dimensions_harvest(snapshot)
+        openalex_harvest(snapshot)
+        wos_harvest(snapshot)
+        sulpub_harvest(snapshot)
+        pubmed_harvest(snapshot)
+
+    @task()
+    def fill_in_openalex(snapshot):
+        """
+        Fill in OpenAlex data for DOIs from other publication sources.
+        """
+        openalex.fill_in(snapshot)
+
+    @task()
+    def fill_in_dimensions(snapshot):
+        """
+        Fill in Dimensions data for DOIs from other publication sources.
+        """
+        dimensions.fill_in(snapshot)
+
+    @task()
+    def fill_in_wos(snapshot):
+        """
+        Fill in WebOfScience data for DOIs from other publication sources.
+        """
+        wos.fill_in(snapshot)
+
+    @task()
+    def fill_in_pubmed(snapshot):
+        """
+        Fill in Pubmed data for DOIs from other publication sources.
+        """
+        pubmed.fill_in(snapshot)
+
+    @task()
+    def fill_in_crossref(snapshot):
+        """
+        Fill in Crossref data for DOIs from other publication sources.
+        """
+        crossref.fill_in(snapshot)
+
+    @task_group()
+    def fill_in(snapshot):
+        fill_in_openalex(snapshot)
+        fill_in_dimensions(snapshot)
+        fill_in_wos(snapshot)
+        fill_in_crossref(snapshot)
+        fill_in_pubmed(snapshot)
+
+    @task()
+    def remove_duplicates(snapshot):
+        """
+        Remove duplicates. This task is run *before* the distill_publications
+        task because we want to fold together any duplicates prior to extracting
+        values from metadata.
+        """
+        deduplicate.remove_duplicates(snapshot)
+
+    @task()
+    def distill_publications(snapshot):
+        """
+        Distill the publication metadata into publication table columns.
+        """
+        distill.distill(snapshot)
+
+    @task()
+    def link_funders(snapshot):
+        """
+        Link all the publications to funders.
+        """
+        funders.link_publications(snapshot)
+
+    @task_group()
+    def post_process(snapshot):
+        dedupe = remove_duplicates(snapshot)
+        distill = distill_publications(snapshot)
+        link = link_funders(snapshot)
+        dedupe >> [distill, link]
+
+    @task()
+    def complete(snapshot):
+        snapshot.complete()
+
+    # link up dag tasks and task groups
+
+    snapshot = setup()
+
+    (
+        load_authors(snapshot)
+        >> harvest_pubs(snapshot)
+        >> fill_in(snapshot)
+        >> post_process(snapshot)
+        >> complete(snapshot)
+    )
+
+
+harvest_incremental()

--- a/rialto_airflow/dags/harvest_incremental.py
+++ b/rialto_airflow/dags/harvest_incremental.py
@@ -48,7 +48,7 @@ else:
 
 
 @dag(
-    schedule="@weekly",
+    # schedule="@weekly",
     max_active_runs=1,
     start_date=datetime.datetime(2024, 1, 1),
     catchup=False,

--- a/rialto_airflow/harvest_incremental/authors.py
+++ b/rialto_airflow/harvest_incremental/authors.py
@@ -1,0 +1,96 @@
+import csv
+import logging
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from rialto_airflow.database import get_engine
+from rialto_airflow.schema.harvest import Author
+from rialto_airflow.utils import rialto_authors_file
+
+
+def load_authors_table(snapshot) -> None:
+    """
+    Load the authors data from the authors CSV into the database
+    """
+    engine = get_engine(snapshot.database_name)
+    Session = sessionmaker(engine)
+
+    authors_file = rialto_authors_file(snapshot.path)
+    check_headers(authors_file)
+
+    logging.debug(
+        f"Loading authors from {authors_file} into database {snapshot.database_name}"
+    )
+    with open(authors_file, "r") as file:
+        errors = []
+        csv_reader = csv.DictReader(file)
+        for row in csv_reader:
+            try:
+                with Session.begin() as session:
+                    author = Author(
+                        sunet=row["sunetid"],
+                        cap_profile_id=row["cap_profile_id"] or None,
+                        orcid=row["orcidid"] or None,
+                        first_name=row["first_name"],
+                        last_name=row["last_name"],
+                        status=to_boolean(row["active"]),
+                        academic_council=to_boolean(row["academic_council"]),
+                        role=row["role"],
+                        schools=to_array(row["all_schools"]),
+                        departments=to_array(row["all_departments"]),
+                        primary_school=row["primary_school"],
+                        primary_dept=row["primary_department"],
+                        primary_division=row["primary_division"],
+                    )
+                    session.add(author)
+            except IntegrityError as e:
+                message = f"Skipping author: {row['sunetid'], row['orcidid']}: {e}"
+                logging.debug(
+                    message
+                )  # this is debug level so we can watch as it goes if need be, but errors are logged in aggregate at warning level at end
+                errors.append(message)
+                continue
+            finally:
+                session.close()
+
+    logging.info(f"Loaded {session.query(Author).count()} authors")
+    if errors:
+        # show all errors at the end of the log
+        logging.warning(f"Errors with {len(errors)} authors: {errors}")
+
+
+def check_headers(authors_file: str) -> None:
+    with open(authors_file, "r") as file:
+        csv_reader = csv.reader(file)
+        headers = next(csv_reader)
+        required_headers = [
+            "sunetid",
+            "first_name",
+            "last_name",
+            "orcidid",
+            "role",
+            "academic_council",
+            "primary_school",
+            "primary_department",
+            "primary_division",
+            "all_schools",
+            "all_departments",
+            "active",
+        ]
+        if not set(required_headers).issubset(set(headers)):
+            raise ValueError(
+                f"Headers in {authors_file} are {headers}, expected to include {required_headers}"
+            )
+        logging.debug(f"Headers in {authors_file}: {headers}")
+
+
+def to_boolean(value: str) -> bool:
+    bool_map = {"true": True, "false": False}
+
+    # will raise KeyError if unexpected value
+    return bool_map[value.strip().lower()]
+
+
+def to_array(value: str) -> list:
+    return value.split("|") if value else []

--- a/rialto_airflow/harvest_incremental/crossref.py
+++ b/rialto_airflow/harvest_incremental/crossref.py
@@ -1,0 +1,126 @@
+import json
+import logging
+import os
+import re
+import time
+from collections.abc import Iterable
+from itertools import batched
+from pathlib import Path
+from typing import Dict
+
+import requests
+from sqlalchemy import select, update
+
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.harvest import Publication
+from rialto_airflow.snapshot import Snapshot
+from rialto_airflow.utils import normalize_doi
+
+RIALTO_EMAIL = os.environ.get("AIRFLOW_VAR_CROSSREF_EMAIL")
+
+
+def fill_in(snapshot: Snapshot) -> Path:
+    """Harvest Crossref data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "crossref-fillin.jsonl"
+    count = 0
+    with jsonl_file.open("a") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            stmt = (
+                select(Publication.doi)
+                .where(Publication.doi.is_not(None))
+                .where(Publication.crossref_json.is_(None))
+                .execution_options(yield_per=1000)
+            )
+
+            for rows in select_session.execute(stmt).partitions():
+                dois = [normalize_doi(row.doi) for row in rows]
+                for crossref_pub in get_dois(dois):
+                    doi = normalize_doi(crossref_pub.get("DOI"))
+
+                    with get_session(snapshot.database_name).begin() as update_session:
+                        update_stmt = (
+                            update(Publication)
+                            .where(Publication.doi == doi)
+                            .values(crossref_json=crossref_pub)
+                        )
+                        update_session.execute(update_stmt)
+
+                    count += 1
+                    jsonl_output.write(json.dumps(crossref_pub) + "\n")
+
+    logging.info(f"filled in {count} publications")
+
+    return jsonl_file
+
+
+def get_dois(dois: Iterable[str], tries=5) -> Iterable[dict]:
+    # the API only allows looking up 49 DOIs at a time in a batch
+    for doi_batch in batched(dois, 40):
+        prefixed_dois = []
+        ignored_dois = []
+        for doi in doi_batch:
+            doi = doi.replace(",", "")  # commas are used to join DOIs in the filter
+
+            # DOIs need to have a prefix in the API works filter call, but we don't store them that way
+            if not doi.startswith("doi:"):
+                doi = f"doi:{doi}"
+
+            # According to Crossref API error messages the DOI must be of the form:
+            # doi:10.prefix/suffix where prefix is 4 or more digits and suffix is a string
+            # the string must not contain whitespace
+            if m := re.match(r"^doi:10\.(\d+)/\S+$", doi):
+                if len(m.group(1)) >= 4:
+                    prefixed_dois.append(doi)
+                else:
+                    ignored_dois.append(doi)
+            else:
+                ignored_dois.append(doi)
+
+        if len(ignored_dois) > 0:
+            logging.debug(
+                f"ignored DOIs for invalid prefix code or invalid format: {ignored_dois}"
+            )
+
+        if len(prefixed_dois) == 0:
+            logging.warning(f"No valid DOIs to look up in {dois}")
+            return
+
+        logging.debug(f"Looking up DOIS {prefixed_dois}")
+
+        params: Dict[str, str | int | None] = {
+            "filter": ",".join(prefixed_dois),
+            "rows": len(prefixed_dois),
+            "mailto": RIALTO_EMAIL,
+        }
+
+        # prevent us getting ban from public use
+        time.sleep(1)
+
+        resp = requests.get(
+            "https://api.crossref.org/works/",
+            params=params,
+            headers={
+                "User-Agent": "Stanford RIALTO: https://github.com/sul-dlss/rialto-airflow"
+            },
+        )
+
+        # the API seems to occasionally throw 500 errors, which then work when retried?
+        if resp.status_code == 500:
+            if tries > 1:
+                logging.debug("caught 500 error, retrying")
+                yield from get_dois(doi_batch, tries - 1)
+            else:
+                logging.error(
+                    "caught 500 error, giving up since there are no more tries left!"
+                )
+                return
+
+        else:
+            # be noisy if we don't get a 200 OK
+            resp.raise_for_status()
+
+            results = resp.json()
+            if "message" in results and "items" in results.get("message", {}):
+                yield from results["message"]["items"]
+            else:
+                logging.warning(f"Unexpected JSON response {results}")

--- a/rialto_airflow/harvest_incremental/deduplicate.py
+++ b/rialto_airflow/harvest_incremental/deduplicate.py
@@ -1,0 +1,210 @@
+import logging
+from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert
+
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.harvest import Publication, pub_author_association
+from rialto_airflow.snapshot import Snapshot
+
+
+def remove_duplicates(snapshot: Snapshot) -> int:
+    """
+    Remove duplicate publications from the database.
+    Returns the number of duplicates found (not the number of rows deleted).
+    """
+    logging.debug("Removing duplicate publications from each source.")
+    openalex_dupes = remove_openalex_duplicates(snapshot)
+    dimensions_dupes = remove_dimensions_duplicates(snapshot)
+    sulpub_dupes = remove_sulpub_duplicates(snapshot)
+    wos_id_dupes = remove_wos_id_duplicates(snapshot)
+    pubmed_id_dupes = remove_pubmed_id_duplicates(snapshot)
+    total_deleted = (
+        openalex_dupes
+        + dimensions_dupes
+        + sulpub_dupes
+        + wos_id_dupes
+        + pubmed_id_dupes
+    )
+    total_deleted = (
+        openalex_dupes
+        + dimensions_dupes
+        + sulpub_dupes
+        + wos_id_dupes
+        + pubmed_id_dupes
+    )
+    logging.info(
+        f"Deleted a total of {total_deleted} duplicate publication rows from all sources."
+    )
+    return total_deleted
+
+
+def remove_openalex_duplicates(snapshot: Snapshot) -> int:
+    logging.debug("Removing any duplicate OpenAlex publications.")
+    with get_session(snapshot.database_name).begin() as session:
+        # Find all duplicate OpenAlex publications in the snapshot
+        duplicates = session.execute(
+            select(func.count(), Publication.openalex_json["id"])
+            .where(Publication.doi.is_(None))
+            .where(Publication.openalex_json["id"].is_not(None))
+            .group_by(Publication.openalex_json["id"])
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} OpenAlex publications with duplicates.")
+        count_deleted = 0
+        openalex_ids = [row[1] for row in duplicates]
+        for openalex_id in openalex_ids:
+            pubs = (
+                session.execute(
+                    select(Publication).where(
+                        Publication.openalex_json["id"].astext == openalex_id
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            deleted = merge_pubs(pubs=pubs, session=session)
+            count_deleted += deleted
+        logging.info(f"Deleted {count_deleted} publication rows from OpenAlex.")
+    return num_dupes
+
+
+def remove_dimensions_duplicates(snapshot: Snapshot) -> int:
+    logging.debug("Removing any duplicate Dimensions publications.")
+    with get_session(snapshot.database_name).begin() as session:
+        # Find all duplicate Dimensions publications in the snapshot
+        duplicates = session.execute(
+            select(func.count(), Publication.dim_json["id"])
+            .where(Publication.doi.is_(None))
+            .where(Publication.dim_json["id"].is_not(None))
+            .group_by(Publication.dim_json["id"])
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} Dimensions publications with duplicates.")
+        count_deleted = 0
+        dim_ids = [row[1] for row in duplicates]
+        for dim_id in dim_ids:
+            pubs = (
+                session.execute(
+                    select(Publication).where(
+                        Publication.dim_json["id"].astext == dim_id
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            deleted = merge_pubs(pubs=pubs, session=session)
+            count_deleted += deleted
+        logging.info(f"Deleted {count_deleted} publication rows from Dimensions.")
+    return num_dupes
+
+
+def remove_sulpub_duplicates(snapshot: Snapshot) -> int:
+    logging.debug("Removing any duplicate sulpub publications.")
+    with get_session(snapshot.database_name).begin() as session:
+        # Find all duplicate sulpub publications in the snapshot
+        duplicates = session.execute(
+            select(func.count(), Publication.sulpub_json["sulpubid"])
+            .where(Publication.doi.is_(None))
+            .where(Publication.sulpub_json["sulpubid"].is_not(None))
+            .group_by(Publication.sulpub_json["sulpubid"])
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} sulpub publications with duplicates.")
+        count_deleted = 0
+        sulpub_ids = [row[1] for row in duplicates]
+        for sulpub_id in sulpub_ids:
+            pubs = (
+                session.execute(
+                    select(Publication).where(
+                        Publication.sulpub_json["sulpubid"].astext == sulpub_id
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            deleted = merge_pubs(pubs=pubs, session=session)
+            count_deleted += deleted
+        logging.info(f"Deleted {count_deleted} publication rows from sulpub.")
+    return num_dupes
+
+
+def remove_wos_id_duplicates(snapshot: Snapshot) -> int:
+    logging.debug("Removing any publications with duplicate wos_id.")
+    with get_session(snapshot.database_name).begin() as session:
+        duplicates = session.execute(
+            select(func.count(), Publication.wos_id)
+            .where(Publication.doi.is_(None))
+            .where(Publication.wos_id.is_not(None))
+            .group_by(Publication.wos_id)
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} publications with duplicate wos_id.")
+        count_deleted = 0
+        wos_ids = [row[1] for row in duplicates]
+        for wos_id in wos_ids:
+            pubs = (
+                session.execute(select(Publication).where(Publication.wos_id == wos_id))
+                .scalars()
+                .all()
+            )
+            deleted = merge_pubs(pubs=pubs, session=session)
+            count_deleted += deleted
+        logging.info(f"Deleted {count_deleted} publication rows with duplicate wos_id.")
+    return num_dupes
+
+
+def remove_pubmed_id_duplicates(snapshot: Snapshot) -> int:
+    logging.debug("Removing any publications with duplicate pubmed_id.")
+    with get_session(snapshot.database_name).begin() as session:
+        duplicates = session.execute(
+            select(func.count(), Publication.pubmed_id)
+            .where(Publication.doi.is_(None))
+            .where(Publication.pubmed_id.is_not(None))
+            .group_by(Publication.pubmed_id)
+            .having(func.count() > 1)
+        ).all()
+        num_dupes = len(duplicates)
+        logging.info(f"Found {num_dupes} publications with duplicate pubmed_id.")
+        count_deleted = 0
+        pubmed_ids = [row[1] for row in duplicates]
+        for pubmed_id in pubmed_ids:
+            pubs = (
+                session.execute(
+                    select(Publication).where(Publication.pubmed_id == pubmed_id)
+                )
+                .scalars()
+                .all()
+            )
+            deleted = merge_pubs(pubs=pubs, session=session)
+            count_deleted += deleted
+        logging.info(
+            f"Deleted {count_deleted} publication rows with duplicate pubmed_id."
+        )
+    return num_dupes
+
+
+def merge_pubs(*, pubs, session) -> int:
+    """
+    Given a set of publications that are duplicates, merge them into one,
+    moving author relationships to the first instance and deleting the duplicates.
+    Returns the number of deleted publications.
+    """
+    count_deleted = 0
+    main_pub = pubs[0].id
+    for pub in pubs[1:]:
+        # Move author relationships to the first instance
+        for author in pub.authors:
+            session.execute(
+                insert(pub_author_association)
+                .values(publication_id=main_pub, author_id=author.id)
+                .on_conflict_do_nothing()
+            )
+
+        # Delete the duplicate
+        session.execute(delete(Publication).where(Publication.id == pub.id))
+        count_deleted += 1
+    return count_deleted

--- a/rialto_airflow/harvest_incremental/dimensions.py
+++ b/rialto_airflow/harvest_incremental/dimensions.py
@@ -1,0 +1,298 @@
+import json
+import logging
+import os
+import time
+from functools import cache
+from pathlib import Path
+
+import dimcli
+import requests
+from more_itertools import batched
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert
+
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.harvest import (
+    Author,
+    Publication,
+    pub_author_association,
+)
+from rialto_airflow.snapshot import Snapshot
+from rialto_airflow.utils import (
+    normalize_doi,
+    normalize_orcid,
+    normalize_pmid,
+    add_orcid,
+)
+
+
+def harvest(snapshot: Snapshot, limit: None | int = None) -> Path:
+    """
+    Walk through all the Author ORCIDs and generate publications for them.
+    """
+    jsonl_file = snapshot.path / "dimensions.jsonl"
+    count = 0
+    stop = False
+
+    with jsonl_file.open("w") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            # get all authors that have an ORCID
+            for author in (
+                select_session.query(Author).where(Author.orcid.is_not(None)).all()
+            ):
+                if stop is True:
+                    logging.warning(f"Reached limit of {limit} publications stopping")
+                    break
+
+                for dimensions_pub_json in publications_from_orcid(author.orcid):
+                    count += 1
+                    if limit is not None and count > limit:
+                        stop = True
+                        break
+
+                    doi = normalize_doi(dimensions_pub_json.get("doi", None))
+                    pubmed_id = (
+                        normalize_pmid(dimensions_pub_json.get("pmid"))
+                        if dimensions_pub_json.get("pmid") is not None
+                        else None
+                    )
+                    with get_session(snapshot.database_name).begin() as insert_session:
+                        # if there's a DOI constraint violation, update the existing row's JSON
+                        pub_id = insert_session.execute(
+                            insert(Publication)
+                            .values(
+                                doi=doi,
+                                dim_json=dimensions_pub_json,
+                                pubmed_id=pubmed_id,
+                            )
+                            .on_conflict_do_update(
+                                constraint="publication_doi_key",
+                                set_=dict(
+                                    dim_json=dimensions_pub_json, pubmed_id=pubmed_id
+                                ),
+                            )
+                            .returning(Publication.id)
+                        ).scalar_one()
+
+                        # a constraint violation here means we already know the
+                        # publication is by the author
+                        insert_session.execute(
+                            insert(pub_author_association)
+                            .values(publication_id=pub_id, author_id=author.id)
+                            .on_conflict_do_nothing()
+                        )
+
+                        jsonl_output.write(
+                            json.dumps(add_orcid(dimensions_pub_json, author.orcid))
+                            + "\n"
+                        )
+
+    return jsonl_file
+
+
+def publications_from_dois(dois: list, batch_size=200):
+    """
+    Get the publications metadata for the provided list of DOIs.
+    """
+    fields = " + ".join(publication_fields())
+    for doi_batch in batched(dois, batch_size):
+        doi_list = ",".join(['"{}"'.format(doi) for doi in doi_batch])
+        logging.debug(f"looking up: {doi_list}")
+
+        q = f"""
+            search publications where doi in [{doi_list}]
+            return publications [{fields}]
+            """
+
+        result = query_with_retry(q, retry=5)
+        for pub in result["publications"]:
+            yield normalize_publication(pub)
+
+
+def publications_from_orcid(orcid: str, batch_size=200):
+    """
+    Get the publications metadata for a given ORCID.
+    """
+    orcid = normalize_orcid(orcid)
+    logging.debug(f"looking up publications for orcid {orcid}")
+    fields = " + ".join(publication_fields())
+    q = f"""
+        search publications where researchers.orcid_id = "{orcid}"
+        return publications[{fields}]
+        """
+
+    result = query_with_retry(q, retry=5)
+    for pub in result["publications"]:
+        yield normalize_publication(pub)
+
+
+def publication_fields():
+    # See Dimensions docs for a description of what is included in the basics and book fieldsets:
+    # https://docs.dimensions.ai/dsl/datasource-publications.html#publications-fieldsets
+    return [
+        "basics",
+        "book",
+        "altmetric",
+        "date",
+        "doi",
+        "funders",
+        "open_access",
+        "pmcid",
+        "pmid",
+        "times_cited",
+        "abstract",
+        "altmetric_id",
+        "issn",
+        "isbn",
+        "publisher",
+        "recent_citations",
+        "supporting_grant_ids",
+        "concepts",
+    ]
+
+
+def unpacked_pub_fields():
+    # Response will include fields unpacked from the basics and book fieldsets requested.
+    return [
+        # basics
+        "authors",
+        "id",
+        "issue",
+        "journal",
+        "pages",
+        "title",
+        "type",
+        "volume",
+        "year",
+        # book
+        "book_doi",
+        "book_series_title",
+        "book_title",
+        # specific fields
+        "altmetric",
+        "concepts",
+        "date",
+        "doi",
+        "funders",
+        "open_access",
+        "pmcid",
+        "pmid",
+        "times_cited",
+        "abstract",
+        "altmetric_id",
+        "issn",
+        "isbn",
+        "publisher",
+        "recent_citations",
+        "supporting_grant_ids",
+    ]
+
+
+def normalize_publication(pub) -> dict:
+    for field in unpacked_pub_fields():
+        if field not in pub:
+            pub[field] = None
+
+    return pub
+
+
+@cache
+def login():
+    """
+    Login to Dimensions API and cache the result.
+    """
+    logging.info("logging in to Dimensions API")
+    dimcli.login(
+        key=os.environ.get("AIRFLOW_VAR_DIMENSIONS_API_KEY"),
+        endpoint="https://app.dimensions.ai/api/dsl/v2",
+    )
+
+
+def dsl():
+    """
+    Get the Dimensions DSL for querying.
+    """
+    login()
+    return dimcli.Dsl(verbose=False)
+
+
+def query_with_retry(q, retry=5):
+    # Catch all request exceptions since dimcli currently only catches HTTP exceptions
+    # see: https://github.com/digital-science/dimcli/issues/88
+    try_count = 0
+    while True:
+        try_count += 1
+
+        # dimcli will retry HTTP level errors, but not ones involving the connection
+        try:
+            # use query_iterative which will page responses, 1 request per second, but aggregate them
+            # into a complete result set. The maximum number of results is 50,000.
+            # Using a limit param set to 25 rather than the default of 1,000 to avoid 408 errors about the size
+            # of a response. Consider raising or removing the limit if the issue is resolved and
+            # removing the force param to view errors.
+            return dsl().query_iterative(
+                q, show_results=False, limit=25, force=True, retry=5
+            )
+        except requests.exceptions.RequestException as e:
+            if try_count > retry:
+                logging.error(
+                    "Dimensions API call %s resulted in error: %s", try_count, e
+                )
+                raise e
+            else:
+                if (
+                    e.response is not None and e.response.status_code == 401
+                ):  # Response could be None
+                    # Likely the token expired, clear cache. login() will be retried on next dsl() call
+                    login.cache_clear()
+                logging.warning(
+                    "Dimensions query error retry %s of %s: %s", try_count, retry, e
+                )
+                time.sleep(try_count * 10)
+
+
+def fill_in(snapshot: Snapshot):
+    """Harvest Dimensions data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "dimensions-fillin.jsonl"
+    count = 0
+    with jsonl_file.open("a") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            stmt = (
+                select(Publication.doi)
+                .where(Publication.doi.is_not(None))
+                .where(Publication.dim_json.is_(None))
+                .execution_options(yield_per=100)
+            )
+
+            for rows in select_session.execute(stmt).partitions():
+                dois = [row.doi for row in rows]
+
+                # note: we could potentially adjust batch_size upwards if we
+                # want to look up more DOIs at a time
+                for dimensions_pub in publications_from_dois(dois, batch_size=100):
+                    doi = dimensions_pub.get("doi")
+                    if doi is None:
+                        logging.warning(
+                            f"unable to determine what DOI to update from {dimensions_pub}"
+                        )
+                        continue
+
+                    with get_session(snapshot.database_name).begin() as update_session:
+                        pubmed_id = (
+                            normalize_pmid(str(dimensions_pub["pmid"]))
+                            if dimensions_pub.get("pmid") is not None
+                            else None
+                        )
+                        update_stmt = (
+                            update(Publication)
+                            .where(Publication.doi == doi)
+                            .values(dim_json=dimensions_pub, pubmed_id=pubmed_id)
+                        )
+                        update_session.execute(update_stmt)
+
+                    count += 1
+                    jsonl_output.write(json.dumps(dimensions_pub) + "\n")
+
+    logging.info(f"filled in {count} publications")
+
+    return jsonl_file

--- a/rialto_airflow/harvest_incremental/distill.py
+++ b/rialto_airflow/harvest_incremental/distill.py
@@ -1,0 +1,80 @@
+import logging
+from typing import Optional
+
+from sqlalchemy import select, update
+
+from rialto_airflow.database import get_session
+from rialto_airflow.distiller import (
+    title,
+    pub_year,
+    open_access,
+    types,
+    publisher,
+    journal_name,
+    apc,
+)
+from rialto_airflow.schema.harvest import Publication
+from rialto_airflow.snapshot import Snapshot
+
+
+def distill(snapshot: Snapshot) -> int:
+    """
+    Walk through all publications in the database and set the title, pub_year,
+    open_access columns using the harvested metadata.
+    """
+    with get_session(snapshot.database_name).begin() as select_session:
+        # iterate through publictions 100 at a time
+        count = 0
+        stmt = select(Publication).execution_options(yield_per=100)
+
+        for row in select_session.execute(stmt):
+            count += 1
+            if count % 50000 == 0:
+                logging.debug(f"processed {count} publications")
+
+            pub = row[0]
+
+            # populate new publication columns
+            cols = {
+                "title": title(pub),
+                "pub_year": pub_year(pub),
+                "open_access": open_access(pub),
+                "types": types(pub),
+                "publisher": publisher(pub),
+                "journal_name": journal_name(pub),
+                "academic_council_authored": _academic_council(pub),
+                "faculty_authored": _faculty_authored(pub),
+            }
+
+            # pub_year and open_access in cols is needed to determine the apc
+            cols["apc"] = apc(pub, cols)
+
+            # update the publication with the new columns
+            with get_session(snapshot.database_name).begin() as update_session:
+                update_stmt = (
+                    update(Publication).where(Publication.id == pub.id).values(cols)
+                )
+                update_session.execute(update_stmt)
+
+    return count
+
+
+# these helper functions aren't in the rialto_airflow.distiller modules because
+# they simply look at the database models and not the JSON publication metadata
+
+
+def _academic_council(pub) -> Optional[bool]:
+    """
+    Get the academic_council value for all authors and return True if any are academic_council
+    """
+    authors = pub.authors
+
+    for author in authors:
+        if author.academic_council:
+            return True
+
+    return False
+
+
+def _faculty_authored(pub) -> Optional[bool]:
+    return any(author.role == "faculty" for author in pub.authors)

--- a/rialto_airflow/harvest_incremental/openalex.py
+++ b/rialto_airflow/harvest_incremental/openalex.py
@@ -1,0 +1,230 @@
+from functools import cache
+import json
+import logging
+import os
+from pathlib import Path
+
+from pyalex import Authors, Sources, Works, config
+import requests
+from typing import Generator
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert
+
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.harvest import (
+    Author,
+    Publication,
+    pub_author_association,
+)
+from rialto_airflow.snapshot import Snapshot
+from rialto_airflow.utils import normalize_doi, normalize_pmid, add_orcid
+
+config.max_retries = 5
+config.retry_backoff_factor = 0.1
+config.retry_http_codes = [429, 500, 503, 520]
+config.api_key = os.environ.get("AIRFLOW_VAR_OPENALEX_API_KEY")
+
+
+def harvest(snapshot: Snapshot, limit=None) -> Path:
+    """
+    Walk through all the Author ORCIDs and generate publications for them.
+    """
+    jsonl_file = snapshot.path / "openalex.jsonl"
+    count = 0
+    stop = False
+
+    with jsonl_file.open("w") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            # get all authors that have an ORCID
+            # TODO: should we just pull the relevant bits back into memory since
+            # that's what's going on with our client-side buffering connection
+            # and there aren't that many of them?
+            for author in (
+                select_session.query(Author).where(Author.orcid.is_not(None)).all()
+            ):
+                if stop is True:
+                    logging.warning(f"Reached limit of {limit} publications stopping")
+                    break
+
+                for openalex_pub in orcid_publications(author.orcid):
+                    count += 1
+                    if limit is not None and count > limit:
+                        stop = True
+                        break
+
+                    doi = normalize_doi(openalex_pub.get("doi", None))
+
+                    pubmed_id = normalize_pmid(openalex_pub.get("ids", {}).get("pmid"))
+
+                    with get_session(snapshot.database_name).begin() as insert_session:
+                        # if there's a DOI constraint violation we need to update instead of insert
+                        pub_id = insert_session.execute(
+                            insert(Publication)
+                            .values(
+                                doi=doi,
+                                openalex_json=openalex_pub,
+                                pubmed_id=pubmed_id,
+                            )
+                            .on_conflict_do_update(
+                                constraint="publication_doi_key",
+                                set_=dict(
+                                    openalex_json=openalex_pub,
+                                    pubmed_id=pubmed_id,
+                                ),
+                            )
+                            .returning(Publication.id)
+                        ).scalar_one()
+
+                        # a constraint violation is ok here, since it means we
+                        # already know that the publication is by the author
+                        insert_session.execute(
+                            insert(pub_author_association)
+                            .values(publication_id=pub_id, author_id=author.id)
+                            .on_conflict_do_nothing()
+                        )
+
+                        jsonl_output.write(
+                            json.dumps(add_orcid(openalex_pub, author.orcid)) + "\n"
+                        )
+
+    return jsonl_file
+
+
+def orcid_publications(orcid: str) -> Generator[dict, None, None]:
+    """
+    Pass in the ORCID ID and get an iterator for publications by that author.
+    """
+    # TODO: I think we can maybe have this function take a list of orcids and
+    # batch process them since we can filter by multiple orcids in one request?
+    logging.debug(f"looking up publications for orcid {orcid}")
+
+    # get the first (and hopefully only) openalex id for the orcid
+    authors = Authors().filter(orcid=orcid).get()
+    if len(authors) == 0:
+        return
+    elif len(authors) > 1:
+        logging.warning(f"found more than one openalex author id for {orcid}")
+    author_id = authors[0]["id"]
+
+    # get all the works for the openalex author id
+    for page in Works().filter(author={"id": author_id}).paginate(per_page=200):
+        yield from page
+
+
+def fill_in(snapshot) -> Path:
+    """Harvest OpenAlex data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "openalex-fillin.jsonl"
+    count = 0
+    with jsonl_file.open("a") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            stmt = (
+                select(Publication.doi)
+                .where(Publication.doi.is_not(None))
+                .where(Publication.openalex_json.is_(None))
+                .execution_options(yield_per=50)
+            )
+
+            for rows in select_session.execute(stmt).partitions():
+                # since the query uses yield_per=50 we will be looking up 50 DOIs at a time
+                dois = [normalize_doi(row.doi) for row in rows]
+
+                # drop dois that are problematic for the openalex api
+                dois_filtered = _clean_dois_for_query(dois)
+
+                # looking up multiple DOIs is supported by pipe separating them
+                dois_joined = "|".join(dois_filtered)
+
+                logging.debug(f"looking up DOIs {dois_joined}")
+                for openalex_pub in Works().filter(doi=dois_joined).get():
+                    doi = normalize_doi(openalex_pub.get("doi"))
+                    if doi is None:
+                        logging.warning(
+                            f"unable to determine what DOI to update for {openalex_pub}"
+                        )
+                        continue
+
+                    pubmed_id = normalize_pmid(openalex_pub.get("ids", {}).get("pmid"))
+
+                    with get_session(snapshot.database_name).begin() as update_session:
+                        update_stmt = (
+                            update(Publication)
+                            .where(Publication.doi == doi)
+                            .values(
+                                openalex_json=openalex_pub,
+                                pubmed_id=pubmed_id,
+                            )
+                        )
+                        update_session.execute(update_stmt)
+
+                    count += 1
+                    jsonl_output.write(json.dumps(openalex_pub) + "\n")
+
+    logging.info(f"filled in {count} publications")
+
+    return jsonl_file
+
+
+def _clean_dois_for_query(dois: list[str]) -> list[str]:
+    """
+    Commas are a reserved character in openalex filter queries, so until there is
+    a way to escape them we will need to drop them
+    https://docs.openalex.org/how-to-use-the-api/get-lists-of-entities/filter-entity-lists#intersection-and
+
+    If a DOI starts with 'doi:' that confuses the OpenAlex API because it interprets
+    it as trying to do an OR query with multiple fields.
+
+    If the DOI contains a field name prefix and a colon that needs to be ignored,
+    or else OpenAlex thinks it is a OR query.
+
+    For example:
+
+    doi: 10.1093/noajnl/vdad070.013 pmcid: pmc10402389
+    """
+
+    clean_dois: list[str] = []
+    unqueryable_dois: list[str] = []
+
+    for doi in dois:
+        if "," in doi:
+            unqueryable_dois.append(doi)
+            _doi_log_message(doi)
+            continue
+        elif doi.startswith("doi:"):
+            unqueryable_dois.append(doi)
+            _doi_log_message(doi)
+            continue
+        elif "pmcid:" in doi:
+            unqueryable_dois.append(doi)
+            _doi_log_message(doi)
+            continue
+        else:
+            clean_dois.append(doi)
+
+    if len(unqueryable_dois) > 0:
+        logging.warning(
+            f"dropped {len(unqueryable_dois)} DOIs from openalex lookup: {unqueryable_dois}"
+        )
+
+    return clean_dois
+
+
+def _doi_log_message(doi: str):
+    logging.warning(f"dropping {doi} from openalex lookup")
+
+
+@cache
+def source_by_issn(issn: str) -> dict | None:
+    """
+    Given an ISSN, return the first OpenAlex Source entity
+    """
+    try:
+        sources = Sources().filter(issn=issn).get()
+    except requests.exceptions.JSONDecodeError as e:
+        logging.error(f"Error decoding JSON for ISSN {issn}: {e}")
+        sources = None
+
+    if not sources:
+        logging.info(f"No OpenAlex Source found for issn: {issn}")
+        return None
+
+    return sources[0]

--- a/rialto_airflow/harvest_incremental/pubmed.py
+++ b/rialto_airflow/harvest_incremental/pubmed.py
@@ -1,0 +1,316 @@
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Optional
+from urllib3.util import Retry
+
+import requests
+import xmltodict
+from requests.adapters import HTTPAdapter
+from requests.exceptions import ChunkedEncodingError
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert
+from xml.parsers.expat import ExpatError
+
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.harvest import (
+    Author,
+    Publication,
+    pub_author_association,
+)
+from rialto_airflow.snapshot import Snapshot
+from rialto_airflow.utils import add_orcid, normalize_doi, normalize_pmid
+
+
+PUBMED_KEY = os.environ.get("AIRFLOW_VAR_PUBMED_KEY")
+BASE_URL = "https://eutils.ncbi.nlm.nih.gov"
+
+BASE_PARAMS = {
+    "db": "pubmed",
+    "retmax": 1000,
+    "api_key": PUBMED_KEY,
+}
+
+HEADERS = {"User-Agent": "stanford-library-rialto", "Accept": "application/json"}
+
+SEARCH_URL = f"{BASE_URL}/entrez/eutils/esearch.fcgi"
+FETCH_URL = f"{BASE_URL}/entrez/eutils/efetch.fcgi"
+
+# create an http session that will retry any 429 statuses to stay within rate limits
+# will retry ten times, backing off with each requests, the last of which is 102.4 seconds
+# see: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html
+
+http = requests.Session()
+http.mount(
+    "https://",
+    HTTPAdapter(
+        max_retries=Retry(
+            status=10,
+            status_forcelist=[429, 500],
+            backoff_factor=0.1,
+            backoff_jitter=2,
+            allowed_methods=["GET", "POST"],
+        )
+    ),
+)
+
+
+def harvest(snapshot: Snapshot, limit=None) -> Path:
+    """
+    Walk through all the Author ORCIDs and generate publications for them from pubmed.
+    """
+    jsonl_file = snapshot.path / "pubmed.jsonl"
+    count = 0
+    stop = False
+
+    with jsonl_file.open("w") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            # get all authors that have an ORCID
+            for author in (
+                select_session.query(Author).where(Author.orcid.is_not(None)).all()
+            ):
+                if stop is True:
+                    logging.warning(f"Reached limit of {limit} publications stopping")
+                    break
+
+                pmids = pmids_from_orcid(author.orcid)
+                if not pmids:
+                    logging.debug(f"No publications found for {author.orcid}")
+                    continue
+
+                for pubmed_pub in publications_from_pmids(pmids):
+                    count += 1
+                    if limit is not None and count > limit:
+                        stop = True
+                        break
+
+                    doi = normalize_doi(get_doi(pubmed_pub))
+                    pubmed_id = normalize_pmid(get_identifier(pubmed_pub, "pubmed"))
+
+                    with get_session(snapshot.database_name).begin() as insert_session:
+                        # if there's a DOI constraint violation we need to update instead of insert
+                        pub_id = insert_session.execute(
+                            insert(Publication)
+                            .values(
+                                doi=doi,
+                                pubmed_json=pubmed_pub,
+                                pubmed_id=pubmed_id,
+                            )
+                            .on_conflict_do_update(
+                                constraint="publication_doi_key",
+                                set_=dict(pubmed_json=pubmed_pub, pubmed_id=pubmed_id),
+                            )
+                            .returning(Publication.id)
+                        ).scalar_one()
+
+                        # a constraint violation is ok here, since it means we
+                        # already know that the publication is by the author
+                        insert_session.execute(
+                            insert(pub_author_association)
+                            .values(publication_id=pub_id, author_id=author.id)
+                            .on_conflict_do_nothing()
+                        )
+
+                        jsonl_output.write(
+                            json.dumps(add_orcid(pubmed_pub, author.orcid)) + "\n"
+                        )
+
+    return jsonl_file
+
+
+def fill_in(snapshot: Snapshot):
+    """Harvest Pubmed data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "pubmed-fillin.jsonl"
+    count = 0
+    with jsonl_file.open("a") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            stmt = (
+                select(Publication.doi)
+                .where(Publication.doi.is_not(None))
+                .where(Publication.pubmed_json.is_(None))
+                .execution_options(yield_per=50)
+            )
+
+            for rows in select_session.execute(stmt).partitions():
+                # use a batch size of 50 DOIs at a time
+                dois = [normalize_doi(row.doi) for row in rows]
+
+                logging.debug(f"looking up DOIs {dois}")
+
+                # find PMIDs for the DOIs, and then get full records
+                # note that there are likely not as many PMIDs returned as DOIs that were queried
+                # and the ordering may be different than the queried DOIs
+                # but this doesn't matter, because we will get the full pubmed record for each PMID returned
+                # and then find the DOI in the full pubmed record to figure out which publication to update
+                # in the database
+                pmids = pmids_from_dois(dois)
+                pubmed_pubs = publications_from_pmids(pmids)
+
+                for pubmed_pub in pubmed_pubs:
+                    doi = normalize_doi(get_doi(pubmed_pub))
+                    if doi is None:
+                        logging.warning(
+                            f"unable to determine what DOI to update for {pubmed_pub}"
+                        )
+                        continue
+
+                    with get_session(snapshot.database_name).begin() as update_session:
+                        pubmed_id = normalize_pmid(get_identifier(pubmed_pub, "pubmed"))
+                        update_stmt = (
+                            update(Publication)
+                            .where(Publication.doi == doi)
+                            .values(pubmed_json=pubmed_pub, pubmed_id=pubmed_id)
+                        )
+                        update_session.execute(update_stmt)
+
+                    count += 1
+                    jsonl_output.write(json.dumps(pubmed_pub) + "\n")
+
+    logging.info(f"filled in {count} publications")
+
+    return snapshot.path
+
+
+def pmids_from_orcid(orcid: str) -> list[str]:
+    """
+    Returns PMIDs associated with a given ORCID.
+    """
+    # Pubmed doesn't want the full ORCID URIs which are stored in User table
+    if m := re.match(r"^https?://orcid.org/(.+)$", orcid):
+        orcid = m.group(1)
+
+    return _pubmed_search_api(f"{orcid}[auid]")
+
+
+# NOTE: You will get a list of PMIDs that may be shorter than the list of DOIs if not all are found
+# You cannot assume the ordering is the same as input list of DOIs
+def pmids_from_dois(dois: list[str]) -> list[str]:
+    """
+    Returns PMIDs associated with given list of DOIs.
+    """
+    if not dois:
+        return []
+
+    # Build a batch query using OR operator to search for multiple DOIs at once
+    # Format: (doi1[doi] OR doi2[doi] OR doi3[doi])
+    doi_terms = [f'"{doi}"[doi]' for doi in dois]
+    batch_query = "(" + " OR ".join(doi_terms) + ")"
+
+    # Get all PMIDs for the batch query
+    return _pubmed_search_api(batch_query)
+
+
+def publications_from_pmids(pmids: list[str], retries=10) -> list[dict[Any, Any]]:
+    """
+    Returns full pubmed records given a list of PMIDs. The retries behavior
+    controls how many times to retry if we get back bad XML (XML that won't
+    parse).
+    """
+    if len(pmids) == 0:
+        return []
+
+    logging.debug(f"fetching full records from pubmed for {pmids}")
+
+    data = {
+        **BASE_PARAMS,
+        "id": pmids,
+        "retmode": "xml",
+    }
+
+    try:
+        response = http.post(FETCH_URL, data=data, headers=HEADERS)
+        response.raise_for_status()
+        xml_results = response.content
+        json_results = xmltodict.parse(xml_results)
+    except (ExpatError, ChunkedEncodingError) as e:
+        time.sleep(1)
+
+        if retries > 0:
+            logging.warning(f"retrying after error: {type(e)} {e}")
+            return publications_from_pmids(pmids, retries=retries - 1)
+        else:
+            logging.warning(f"too many retries: {type(e)} {e}")
+            raise e
+
+    pubs = json_results.get("PubmedArticleSet", {}).get("PubmedArticle")
+
+    if pubs is None:
+        return []
+    if not isinstance(pubs, list):
+        # if there is only one record, it will not be in a list, but we want to be in one so we can iterate over it
+        return [pubs]
+    else:
+        return pubs
+
+
+def _pubmed_search_api(query) -> list:
+    """
+    Return a list of pmids given a general search query.
+    """
+
+    params = {**BASE_PARAMS, "retmode": "json", "term": query}
+    logging.debug(f"searching pubmed with {params}")
+
+    response = http.get(SEARCH_URL, params=params, headers=HEADERS)
+    response.raise_for_status()
+    results = response.json()
+
+    if "error" in results:
+        logging.error(f"Error in results found for {query}: {results['error']}")
+        return []
+    elif results.get("esearchresult", {}).get("count") is None:
+        logging.debug(f"No esearchresult or count found for {query}")
+        return []
+    elif int(results["esearchresult"]["count"]) == 0:
+        logging.debug(f"No results found for {query}")
+        return []
+    else:
+        return results["esearchresult"]["idlist"]  # return a list of pmids
+
+
+# get the DOI from the pubmed record
+def get_doi(pub) -> Optional[str]:
+    # this is the primary way to get the DOI from the pubmed record
+    doi = get_identifier(pub, "doi")
+    if doi:
+        return doi
+
+    # this is a fallback if the DOI is not in the expected place
+    try:
+        ids = pub.get("MedlineCitation", {}).get("Article", {}).get("ELocationID")
+        if ids is None:
+            return None
+        # if there is only one identifier, it is not a list, so make it a list so we can iterate over it
+        if not isinstance(ids, list):
+            ids = [ids]
+
+        for identifier in ids:
+            if "@EIdType" in identifier and identifier["@EIdType"] == "doi":
+                return identifier["#text"]
+    except KeyError:
+        return None
+
+    return None
+
+
+def get_identifier(pub, identifier_name) -> Optional[str]:
+    # look through the list of identifiers in the pubmed record
+    try:
+        ids = pub.get("PubmedData", {}).get("ArticleIdList", {}).get("ArticleId")
+        if ids is None:
+            return None
+        # if there is only one identifier, it is not a list, so make it a list so we can iterate over it
+        if not isinstance(ids, list):
+            ids = [ids]
+
+        for identifier in ids:
+            if "@IdType" in identifier and identifier["@IdType"] == identifier_name:
+                return identifier["#text"]
+    except KeyError:
+        logging.info(f"No identifiers found in pubmed record for {pub}")
+        return None
+
+    return None

--- a/rialto_airflow/harvest_incremental/sul_pub.py
+++ b/rialto_airflow/harvest_incremental/sul_pub.py
@@ -1,0 +1,169 @@
+import json
+import logging
+
+import requests
+from requests.adapters import HTTPAdapter
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from urllib3.util import Retry
+
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.harvest import (
+    Author,
+    Publication,
+    pub_author_association,
+)
+from rialto_airflow.utils import normalize_doi, normalize_pmid, normalize_wos_id
+
+
+def harvest(snapshot, host, key, per_page=1000, limit=None):
+    # create a jsonl file to write to
+    jsonl_file = snapshot.path / "sulpub.jsonl"
+
+    with jsonl_file.open("w") as jsonl_output:
+        for sulpub_pub in publications(host, key, per_page, limit):
+            with get_session(snapshot.database_name).begin() as session:
+                doi = extract_doi(sulpub_pub)
+
+                # only write approved publications to the database
+                if approved(sulpub_pub):
+                    wos_id = extract_wos_uid(sulpub_pub)
+                    pubmed_id = extract_pmid(sulpub_pub)
+                    # if when inserting the row we get a constraint violation
+                    # on the DOI then we have to do an update
+                    pub_id = session.execute(
+                        insert(Publication)
+                        .values(
+                            doi=doi,
+                            sulpub_json=sulpub_pub,
+                            wos_id=wos_id,
+                            pubmed_id=pubmed_id,
+                        )
+                        .on_conflict_do_update(
+                            constraint="publication_doi_key",
+                            set_=dict(
+                                sulpub_json=sulpub_pub,
+                                wos_id=wos_id,
+                                pubmed_id=pubmed_id,
+                            ),
+                        )
+                        .returning(Publication.id)
+                    ).scalar_one()
+
+                    # get a list of approved cap_ids for the publication
+                    # the cap_profile_id needs to be a string for the database
+                    cap_ids = [
+                        str(a["cap_profile_id"])
+                        for a in sulpub_pub["authorship"]
+                        if a["status"] == "approved"
+                    ]
+
+                    # if the row is already there we could get a constraint
+                    # violation, but we can safely ignore that
+                    session.execute(
+                        insert(pub_author_association)
+                        .from_select(
+                            ["publication_id", "author_id"],
+                            select(pub_id, Author.id).where(
+                                Author.cap_profile_id.in_(cap_ids)
+                            ),
+                        )
+                        .on_conflict_do_nothing()
+                    )
+
+                jsonl_output.write(json.dumps(sulpub_pub) + "\n")
+
+    return jsonl_file
+
+
+def publications(host, key, per_page=1000, limit=None):
+    url = f"https://{host}/publications.json"
+
+    http_headers = {"CAPKEY": key}
+    params = {"per": per_page}
+
+    page = 0
+    record_count = 0
+    more = True
+
+    # catch and back off from temporary errors from sulpub
+    # https://docs.python-requests.org/en/latest/user/advanced/#example-automatic-retries
+
+    http = requests.Session()
+    retries = Retry(connect=5, read=5)
+    http.mount("https://", HTTPAdapter(max_retries=retries))
+
+    while more:
+        page += 1
+        params["page"] = page
+
+        logging.debug(f"fetching sul_pub results {url} {params}")
+        resp = http.get(url, params=params, headers=http_headers)
+        resp.raise_for_status()
+
+        records = resp.json()["records"]
+        if len(records) == 0:
+            more = False
+
+        for record in records:
+            record_count += 1
+            if limit is not None and record_count > limit:
+                logging.warning(f"stopping with limit={limit}")
+                more = False
+                break
+
+            yield record
+
+
+def extract_doi(pub):
+    if pub.get("doi"):
+        return normalize_doi(pub["doi"])
+
+    for id in pub.get("identifier"):
+        if id.get("type") == "doi" and "id" in id:
+            logging.debug(
+                f"doi was not available in top level for sulpub id {pub.get('sulpubid')} but found in identifier block"
+            )
+            return normalize_doi(id["id"])
+    return None
+
+
+def extract_wos_uid(pub) -> str | None:
+    """
+    Extract and normalize the WOS UID from a sulpub record.
+    Checks top-level 'wos_uid' first, then the identifier list for type 'WosUID',
+    'WoSItemID', or 'WosItemID'.
+    """
+    if pub.get("wos_uid"):
+        return normalize_wos_id(pub["wos_uid"])
+
+    for id in pub.get("identifier", []):
+        id_type = id.get("type", "")
+        if id_type in ("WoSItemID", "WosItemID", "WosUID"):
+            # These are bare accession numbers without the WOS: prefix
+            return normalize_wos_id(id.get("id"))
+    return None
+
+
+def extract_pmid(pub) -> str | None:
+    """
+    Extract and normalize the PubMed ID from a sulpub record.
+    Checks top-level 'pmid' first, then the identifier list for type 'pmid' or 'PMID'.
+    """
+    if pub.get("pmid"):
+        return normalize_pmid(str(pub["pmid"]))
+
+    for id in pub.get("identifier", []):
+        if id.get("type", "").lower() == "pmid":
+            return normalize_pmid(id.get("id"))
+    return None
+
+
+def approved(pub):
+    """
+    Returns True if at least one author has approved the publication, and False if not.
+    """
+    for authorship in pub["authorship"]:
+        if authorship["status"] == "approved":
+            return True
+    return False

--- a/rialto_airflow/harvest_incremental/wos.py
+++ b/rialto_airflow/harvest_incremental/wos.py
@@ -1,0 +1,366 @@
+import json
+import logging
+import os
+import re
+from itertools import batched
+from pathlib import Path
+from time import sleep
+
+import requests
+from requests.adapters import HTTPAdapter
+from typing import Generator, Optional, Dict, Union
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert
+from urllib3.util import Retry
+
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.harvest import (
+    Author,
+    Publication,
+    pub_author_association,
+)
+from rialto_airflow.snapshot import Snapshot
+from rialto_airflow.utils import (
+    normalize_doi,
+    normalize_pmid,
+    normalize_wos_id,
+    add_orcid,
+)
+
+Params = Dict[str, Union[int, str]]
+
+
+def harvest(snapshot: Snapshot, limit=None) -> Path:
+    """
+    Walk through all the Author ORCIDs and generate publications for them.
+    """
+    jsonl_file = snapshot.path / "wos.jsonl"
+    count = 0
+    stop = False
+
+    with jsonl_file.open("w") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            # get all authors that have an ORCID
+            # TODO: should we just pull the relevant bits back into memory since
+            # that's what's going on with our client-side buffering connection
+            # and there aren't that many of them?
+            for author in (
+                select_session.query(Author).where(Author.orcid.is_not(None)).all()
+            ):
+                if stop is True:
+                    logging.warning(f"Reached limit of {limit} publications stopping")
+                    break
+
+                for wos_pub in orcid_publications(author.orcid):
+                    count += 1
+                    if limit is not None and count > limit:
+                        stop = True
+                        break
+
+                    doi = get_doi(wos_pub)
+                    wos_id = normalize_wos_id(wos_pub.get("UID"))
+                    pubmed_id = get_pmid(wos_pub)
+
+                    with get_session(snapshot.database_name).begin() as insert_session:
+                        # if there's a DOI constraint violation we need to update instead of insert
+                        pub_id = insert_session.execute(
+                            insert(Publication)
+                            .values(
+                                doi=doi,
+                                wos_json=wos_pub,
+                                wos_id=wos_id,
+                                pubmed_id=pubmed_id,
+                            )
+                            .on_conflict_do_update(
+                                constraint="publication_doi_key",
+                                set_=dict(
+                                    wos_json=wos_pub, wos_id=wos_id, pubmed_id=pubmed_id
+                                ),
+                            )
+                            .returning(Publication.id)
+                        ).scalar_one()
+
+                        # a constraint violation is ok here, since it means we
+                        # already know that the publication is by the author
+                        insert_session.execute(
+                            insert(pub_author_association)
+                            .values(publication_id=pub_id, author_id=author.id)
+                            .on_conflict_do_nothing()
+                        )
+
+                        jsonl_output.write(
+                            json.dumps(add_orcid(wos_pub, author.orcid)) + "\n"
+                        )
+
+    return jsonl_file
+
+
+def fill_in(snapshot: Snapshot):
+    """Harvest WebOfScience data for DOIs from other publication sources."""
+    jsonl_file = snapshot.path / "wos-fillin.jsonl"
+    count = 0
+    with jsonl_file.open("a") as jsonl_output:
+        with get_session(snapshot.database_name).begin() as select_session:
+            stmt = (
+                select(Publication.doi)
+                .where(Publication.doi.is_not(None))
+                .where(Publication.wos_json.is_(None))
+                .execution_options(yield_per=50)
+            )
+
+            for rows in select_session.execute(stmt).partitions():
+                # since the query uses yield_per=50 we will be looking up 50 DOIs at a time
+                dois = [row.doi for row in rows]
+
+                logging.debug(f"looking up DOIs {dois}")
+                for wos_pub in publications_from_dois(dois):
+                    doi = normalize_doi(get_doi(wos_pub))
+                    if doi is None:
+                        continue
+
+                    wos_id = normalize_wos_id(wos_pub.get("UID"))
+                    pubmed_id = get_pmid(wos_pub)
+                    with get_session(snapshot.database_name).begin() as update_session:
+                        update_stmt = (
+                            update(Publication)
+                            .where(Publication.doi == doi)
+                            .values(
+                                wos_json=wos_pub, wos_id=wos_id, pubmed_id=pubmed_id
+                            )
+                        )
+                        update_session.execute(update_stmt)
+
+                    count += 1
+                    jsonl_output.write(json.dumps(wos_pub) + "\n")
+
+    logging.info(f"filled in {count} publications")
+
+    return jsonl_file
+
+
+def orcid_publications(orcid) -> Generator[dict, None, None]:
+    """
+    A generator that returns publications associated with a given ORCID.
+    """
+    # WoS doesn't recognize ORCID URIs which are stored in User table
+    if m := re.match(r"^https?://orcid.org/(.+)$", orcid):
+        orcid = m.group(1)
+
+    yield from _wos_api(f"AI={orcid}")
+
+
+def publications_from_dois(dois: list[str]) -> Generator[dict, None, None]:
+    """
+    A generator that returns publications associated a list of DOIs.
+
+    It will first try to lookup the DOIs in batches.  If a batch fails it will
+    try to look up each DOI in the batch individually, because we've seen batches
+    fail due to a single DOI within it, where many of the others might lookup successfully.
+    See https://github.com/sul-dlss/rialto-airflow/issues/680
+
+    A wordy note on timeouts in the API calls below (first value is
+    connection timeout, second is read):
+    * per the docs -- https://requests.readthedocs.io/en/stable/user/advanced/#timeouts
+    "It’s a good practice to set connect timeouts to slightly larger than a
+    multiple of 3, which is the default TCP packet retransmission window."
+    * The initial lookup read timeout is longer, a minute, but not too long, because responses should
+    be relatively quick, and we have a lot of batches to get through.  The read timeout for individual
+    lookups is much more aggressive at 15 seconds, because we switched to batches due to long runs
+    as a result of individual DOI lookups.
+    """
+    for doi_batch in batched(dois, n=50):
+        try:
+            yield from _wos_api(
+                f"DO=({' '.join(f'"{doi}"' for doi in doi_batch)})",
+                should_raise_for_status=True,
+                timeout=(6.05, 60),
+            )
+        except Exception as e:
+            logging.error(
+                f"Unexpected error querying for DOIs in DOI batch, trying one at a time.  doi_batch={doi_batch} -- error={e}"
+            )
+            for doi in doi_batch:
+                try:
+                    yield from _wos_api(f'DO=("{doi}")', timeout=(6.05, 15))
+                except Exception as e:
+                    logging.error(
+                        f'Unexpected error querying for single DOI from larger batch.  DOI="{doi}" -- error={e}'
+                    )
+
+
+def _wos_api_retry() -> Retry:
+    # Retry on HTTP 429.  We want to make sure we really back off, since status code 429
+    # indicates we're being rate limited.
+    # Retry up to 10 times on status code errors.
+    #
+    # For each try the time to sleep will be set using:
+    # {backoff_factor} * (2 ** ({number of previous retries})) + random.uniform(0, {backoff_jitter})
+    return Retry(
+        status=10, status_forcelist=[429], backoff_factor=0.3, backoff_jitter=5
+    )
+
+
+def _wos_api(
+    query,
+    should_raise_for_status: bool = False,
+    timeout: int | tuple[float, float] | None = None,
+) -> Generator[dict, None, None]:
+    """
+    A generator that returns publications associated a list of DOIs.
+    """
+
+    # For API details see: https://api.clarivate.com/swagger-ui/?apikey=none&url=https%3A%2F%2Fdeveloper.clarivate.com%2Fapis%2Fwos%2Fswagger
+
+    wos_key = os.environ.get("AIRFLOW_VAR_WOS_KEY")
+    base_url = "https://wos-api.clarivate.com/api/wos"
+    headers = {"Accept": "application/json", "X-ApiKey": wos_key}
+
+    # the number of records to get in each request (100 is max)
+    count = 100
+
+    params: Params = {
+        "databaseId": "WOK",
+        "usrQuery": query,
+        "count": count,
+        "firstRecord": 1,
+        "optionView": "SR",  # SR = Short Records, which gives us the most basic info about the publication, skipping authors, to keep
+    }
+
+    # retry any 429 statuses and stay within rate limits
+    http = requests.Session()
+    http.mount("https://", HTTPAdapter(max_retries=_wos_api_retry()))
+
+    # get the initial set of results, which also gives us a Query ID to fetch
+    # subsequent pages of results if there are any
+    logging.debug(f"fetching {base_url} with {params}")
+    resp: requests.Response = http.get(
+        base_url, params=params, headers=headers, timeout=timeout
+    )
+    if not check_status(resp, should_raise_for_status):
+        return
+
+    results = get_json(resp)
+    if results is None:
+        return
+
+    if results["QueryResult"]["RecordsFound"] == 0:
+        logging.debug(f"No results found for {query}")
+        return
+
+    yield from results["Data"]["Records"]["records"]["REC"]
+
+    # get subsequent results using the Query ID
+
+    query_id = results["QueryResult"]["QueryID"]
+    records_found = results["QueryResult"]["RecordsFound"]
+    first_record = count + 1  # since the initial set included 100
+
+    # if there aren't any more results to fetch this loop will never be entered
+
+    logging.debug(f"{records_found} records found")
+    while first_record < records_found:
+        sleep(0.5)
+        page_params: Params = {"firstRecord": first_record, "count": count}
+        logging.debug(f"fetching {base_url}/query/{query_id} with {page_params}")
+
+        # retry any 429 errors and stay within rate limits
+        http = requests.Session()
+        http.mount("https://", HTTPAdapter(max_retries=_wos_api_retry()))
+        resp = http.get(
+            f"{base_url}/query/{query_id}",
+            params=page_params,
+            headers=headers,
+            timeout=timeout,
+        )
+        if not check_status(resp, should_raise_for_status):
+            return
+
+        records = get_json(resp)
+        if records is None:
+            break
+
+        yield from records["Records"]["records"]["REC"]
+
+        # move the offset along in the results list
+        first_record += count
+
+
+def get_json(resp: requests.Response) -> Optional[dict]:
+    try:
+        return resp.json()
+    except requests.exceptions.JSONDecodeError as e:
+        # see https://github.com/sul-dlss/rialto-airflow/issues/207 for why
+        if resp.text == "":
+            logging.error(
+                f"got empty string instead of JSON when looking up {resp.url}"
+            )
+            return None
+        else:
+            logging.error(f"uhoh, instead of JSON we got: {resp.text}")
+            raise e
+
+
+def check_status(resp: requests.Response, should_raise_for_status: bool) -> bool:
+    try:
+        # try raise_for_status() is pretty much what requests.Response.ok() does. But
+        # doing similar, instead of a conditional on the ok() result, allows us to leverage
+        # the error message building that raise_for_status() already does, before re-raising
+        # the appropriate HTTPError.
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        logging.error(f"{e} -- {resp.text}")
+        if should_raise_for_status:
+            raise
+        else:
+            return False
+
+    return True
+
+
+def get_pmid(pub) -> Optional[str]:
+    """Extract and normalize the PubMed ID from a WOS record's identifiers list."""
+    try:
+        identifiers_field = (
+            pub.get("dynamic_data", {})
+            .get("cluster_related", {})
+            .get("identifiers", {})
+        )
+        if not isinstance(identifiers_field, dict):
+            return None
+        ids = identifiers_field.get("identifier", [])
+        ids = [ids] if isinstance(ids, dict) else ids
+        for id in ids:
+            if id.get("type") == "pmid":
+                return normalize_pmid(str(id["value"]))
+    except AttributeError:
+        pass
+    return None
+
+
+def get_doi(pub) -> Optional[str]:
+    try:
+        identifiers_field = (
+            pub.get("dynamic_data", {})
+            .get("cluster_related", {})
+            .get("identifiers", {})
+        )
+
+        if isinstance(identifiers_field, dict):
+            # The "identifier" field (from "identifiers" above) is usually a list. But sometimes
+            # there is just one string value instead. (as an examle, see record for WOS:000299597104419)
+            ids = identifiers_field.get("identifier", [])
+            ids = [ids] if isinstance(ids, dict) else ids
+
+            for id in ids:
+                if id["type"] == "doi":
+                    return normalize_doi(id["value"])
+        elif isinstance(identifiers_field, str):
+            # We have seen at least one publication, WOS:000089165000013, where the "identifiers" field is
+            # a str instead of a dict, albeit an empty string in that case. Normalize empty string to None.
+            return identifiers_field or None
+    except AttributeError as e:
+        logging.warning(f"error {e} trying to parse identifiers from {pub}")
+        return None
+
+    logging.warning(f"unable to determine what DOI to update: {pub}")
+    return None

--- a/test/harvest_incremental/test_authors.py
+++ b/test/harvest_incremental/test_authors.py
@@ -1,0 +1,213 @@
+import csv
+import logging
+import pytest
+from rialto_airflow.schema.harvest import Author
+from rialto_airflow.harvest.authors import load_authors_table
+from test.utils import num_log_record_matches
+
+
+@pytest.fixture
+def author(test_session):
+    with test_session.begin() as session:
+        session.add(
+            Author(
+                sunet="janes",
+                cap_profile_id="12345",
+                orcid="https://orcid.org/0000-0000-0000-0001",
+                first_name="Jane",
+                last_name="Stanford",
+                status=True,
+            )
+        )
+
+
+def test_author_fixture(test_session, author):
+    with test_session.begin() as session:
+        assert session.query(Author).where(Author.sunet == "janes").count() == 1
+
+
+@pytest.fixture
+def authors_csv(snapshot):
+    # Create a fixture authors CSV file
+    fixture_file = snapshot.path / "authors.csv"
+    with open(fixture_file, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(
+            [
+                "sunetid",
+                "first_name",
+                "last_name",
+                "full_name",
+                "orcidid",
+                "orcid_update_scope",
+                "cap_profile_id",
+                "role",
+                "academic_council",
+                "primary_affiliation",
+                "primary_school",
+                "primary_department",
+                "primary_division",
+                "all_schools",
+                "all_departments",
+                "all_divisions",
+                "active",
+            ]
+        )
+        writer.writerow(
+            [
+                "janes",
+                "Jane",
+                "Stanford",
+                "Jane Stanford",
+                "https://orcid.org/0000-0000-0000-0001",
+                "true",
+                "12345",
+                "staff",
+                "false",
+                "Engineering",
+                "School of Engineering",
+                "Computer Science",
+                "Philanthropy Division",
+                "Independent Labs, Institutes, and Centers (Dean of Research)|School of Humanities and Sciences",
+                "Computer Science|Horticulture",
+                "Philanthropy Division|Other Division",
+                "true",
+            ]
+        )
+    return fixture_file
+
+
+def test_load_authors_table(test_session, tmp_path, caplog, authors_csv, snapshot):
+    load_authors_table(snapshot)
+
+    with test_session.begin() as session:
+        assert session.query(Author).count() == 1
+
+        author = session.query(Author).where(Author.sunet == "janes").one()
+        assert author.cap_profile_id == "12345"
+        assert author.first_name == "Jane"
+        assert author.last_name == "Stanford"
+        assert author.orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert author.status
+        assert not author.academic_council
+        assert author.role == "staff"
+        assert author.primary_school == "School of Engineering"
+        assert author.primary_dept == "Computer Science"
+        assert author.primary_division == "Philanthropy Division"
+        assert author.schools == [
+            "Independent Labs, Institutes, and Centers (Dean of Research)",
+            "School of Humanities and Sciences",
+        ]
+        assert author.departments == ["Computer Science", "Horticulture"]
+        assert author.created_at is not None
+    assert "Errors:" not in caplog.text
+
+
+def test_load_dupe_orcid(test_session, tmp_path, caplog, authors_csv, snapshot):
+    caplog.set_level(logging.DEBUG)
+    # add a row with a duplicate ORCID to the CSV
+    with open(authors_csv, "a", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(
+            [
+                "lelands",
+                "Leland",
+                "Stanford, Jr.",
+                "Leland Stanford, Jr.",
+                "https://orcid.org/0000-0000-0000-0001",
+                "true",
+                "67890",
+                "faculty",
+                "true",
+                "Humanities",
+                "School of Humanities and Sciences",
+                "History",
+                "History Division",
+                "School of Humanities and Sciences",
+                "History",
+                "History Division",
+                "true",
+            ]
+        )
+
+    load_authors_table(snapshot)
+
+    with test_session.begin() as session:
+        assert session.query(Author).count() == 1
+        assert session.query(Author).where(Author.sunet == "janes").count() == 1
+        assert session.query(Author).where(Author.sunet == "lelands").count() == 0
+
+    assert (
+        len([record for record in caplog.records if record.levelname == "WARNING"]) == 1
+    )
+    assert (
+        "Skipping author: ('lelands', 'https://orcid.org/0000-0000-0000-0001')"
+        in caplog.text
+    )
+    assert num_log_record_matches(
+        caplog.records, logging.WARNING, "Errors with 1 authors: "
+    )
+
+
+def test_load_null_cap_id(test_session, tmp_path, caplog, authors_csv, snapshot):
+    # add row with null cap_profile_id
+    with open(authors_csv, "a", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerows(
+            [
+                [
+                    "lelands",
+                    "Leland",
+                    "Stanford, Jr.",
+                    "Leland Stanford, Jr.",
+                    "https://orcid.org/0000-0000-0000-0002",
+                    "true",
+                    None,
+                    "faculty",
+                    "true",
+                    "Humanities",
+                    "School of Humanities and Sciences",
+                    "History",
+                    "History Division",
+                    "School of Humanities and Sciences",
+                    "History",
+                    "History Division",
+                    "true",
+                ],
+                [
+                    "rsmith",
+                    "Robert",
+                    "Smith",
+                    "Robert Smith",
+                    "https://orcid.org/0000-0000-0000-0003",
+                    "true",
+                    None,
+                    "faculty",
+                    "true",
+                    "Humanities",
+                    "School of Humanities and Sciences",
+                    "History",
+                    "History Division",
+                    "School of Humanities and Sciences",
+                    "History",
+                    "History Division",
+                    "true",
+                ],
+            ]
+        )
+
+    load_authors_table(snapshot)
+
+    with test_session.begin() as session:
+        assert session.query(Author).count() == 3
+        assert (
+            session.query(Author)
+            .where(Author.sunet == "lelands")
+            .first()
+            .cap_profile_id
+            is None
+        )
+        assert (
+            session.query(Author).where(Author.sunet == "rsmith").first().cap_profile_id
+            is None
+        )

--- a/test/harvest_incremental/test_crossref.py
+++ b/test/harvest_incremental/test_crossref.py
@@ -1,0 +1,204 @@
+import logging
+import re
+
+import dotenv
+import pandas
+
+from rialto_airflow.schema.harvest import Publication
+from rialto_airflow.harvest_incremental import crossref
+from test.utils import num_jsonl_objects, num_log_record_matches
+
+dotenv.load_dotenv()
+
+
+def test_get_dois():
+    """
+    Test Crossref API lookups by DOI. 40 can be requested at a time.
+    """
+    # get 25 DOIs
+    df = pandas.read_csv("test/data/dois.csv")
+    dois = list(df.doi[0:100])
+
+    # look them up
+    results = list(crossref.get_dois(dois))
+
+    assert len(results) > 40, "paging worked (some dois are invalid)"
+    assert len(set([r["DOI"] for r in results])) == len(results), "DOIs are unique"
+
+
+def test_get_dois_missing():
+    """
+    Test that things work when looking up bogus DOIs.
+    """
+    df = pandas.read_csv("test/data/dois.csv")
+    dois = [f"{doi}-naw" for doi in df.doi[0:25]]
+
+    results = crossref.get_dois(dois)
+    assert len(list(results)) == 0
+
+
+def test_invalid_doi_prefix(caplog):
+    """
+    Test lookup with invalid DOI format. According to the API docs a DOI must
+    match doi:10.prefix/suffix where prefix is of length 4 or more.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    results = crossref.get_dois(["10.123/abcdef"])
+    assert len(list(results)) == 0, ".123 prefix is too short"
+    assert (
+        num_log_record_matches(
+            caplog.records,
+            logging.DEBUG,
+            "ignored DOIs for invalid prefix code or invalid format: ['doi:10.123/abcdef']",
+        )
+        == 1
+    )
+    assert (
+        num_log_record_matches(
+            caplog.records,
+            logging.WARNING,
+            "No valid DOIs to look up in ['10.123/abcdef']",
+        )
+        == 1
+    )
+
+
+def test_non_numeric_prefix(caplog):
+    """
+    The DOI prefix must be a number.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    results = crossref.get_dois(["10.123a/abcdef"])
+    assert len(list(results)) == 0, "ignore dois with non-numeric prefix"
+    assert (
+        num_log_record_matches(
+            caplog.records,
+            logging.DEBUG,
+            "ignored DOIs for invalid prefix code or invalid format: ['doi:10.123a/abcdef']",
+        )
+        == 1
+    )
+
+
+def test_doi_missing_10(caplog):
+    """
+    DOI must start with "10."
+    """
+    caplog.set_level(logging.DEBUG)
+
+    assert len(list(crossref.get_dois(["1234/abcdef"]))) == 0, "missing 10."
+    assert (
+        num_log_record_matches(
+            caplog.records,
+            logging.DEBUG,
+            "ignored DOIs for invalid prefix code or invalid format: ['doi:1234/abcdef']",
+        )
+        == 1
+    )
+
+
+def test_doi_missing_suffix(caplog):
+    """
+    DOIs must have a "/" followed by a string.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    assert len(list(crossref.get_dois(["10.2345"]))) == 0, "missing /suffix"
+    assert (
+        num_log_record_matches(
+            caplog.records,
+            logging.DEBUG,
+            "ignored DOIs for invalid prefix code or invalid format: ['doi:10.2345']",
+        )
+        == 1
+    )
+
+
+def test_doi_with_space(caplog):
+    """
+    The API requires that DOIs not include spaces.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    assert len(list(crossref.get_dois(["10.1234/ abcdef"]))) == 0, (
+        "doi can't include space"
+    )
+    assert (
+        num_log_record_matches(
+            caplog.records,
+            logging.DEBUG,
+            "ignored DOIs for invalid prefix code or invalid format: ['doi:10.1234/ abcdef']",
+        )
+        == 1
+    )
+
+
+def test_http_500(caplog, requests_mock):
+    """
+    Crossref API sometimes throws random 500 errors, which work when retried. We
+    try five times and then give up.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.get(re.compile(r"https://api.crossref.org/works.*"), status_code=500)
+    assert len(list(crossref.get_dois(["10.2345/abcdef"]))) == 0, "catches 500 errors"
+    assert (
+        num_log_record_matches(
+            caplog.records, logging.DEBUG, "caught 500 error, retrying"
+        )
+        == 4
+    )
+    assert (
+        num_log_record_matches(
+            caplog.records,
+            logging.ERROR,
+            "caught 500 error, giving up since there are no more tries left!",
+        )
+        == 1
+    )
+
+
+def test_unexpected_json(caplog, requests_mock):
+    """
+    This checks that we don't thow an exception when encountering JSON that
+    doesn't look like what we are expecting.
+    """
+    requests_mock.get(
+        re.compile(r"https://api.crossref.org/works.*"), json={"foo": "bar"}
+    )
+    assert len(list(crossref.get_dois(["10.2345/abcdef"]))) == 0, "catches JSON errors"
+    assert "Unexpected JSON response {'foo': 'bar'}" in caplog.text
+
+
+def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+
+    # setup Works to return a list of one record
+    records = [
+        {
+            "DOI": "10.1515/9781503624153",
+            "title": "A sample title",
+            "publication_year": 1891,
+        }
+    ]
+    monkeypatch.setattr(crossref, "get_dois", lambda _: records)
+
+    crossref.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.crossref_json == {
+            "DOI": "10.1515/9781503624153",
+            "title": "A sample title",
+            "publication_year": 1891,
+        }
+
+    # adds 1 publication to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "crossref-fillin.jsonl") == 1
+    assert "filled in 1 publications" in caplog.text

--- a/test/harvest_incremental/test_deduplicate.py
+++ b/test/harvest_incremental/test_deduplicate.py
@@ -1,0 +1,333 @@
+import logging
+import pytest
+
+from rialto_airflow.schema.harvest import Author, Publication
+from rialto_airflow.harvest_incremental import deduplicate
+
+
+@pytest.fixture
+def dataset(test_session, dim_json, openalex_json, wos_json, sulpub_json, pubmed_json):
+    """
+    This fixture will create two publications that are duplicates and lack DOIs.
+    """
+    with test_session.begin() as session:
+        pub = Publication(
+            doi=None,
+            title="My Life",
+            apc=123,
+            open_access="green",
+            pub_year=2024,
+            dim_json=dim_json,
+            openalex_json=openalex_json,
+            wos_json=wos_json,
+            sulpub_json=sulpub_json,
+            pubmed_json=pubmed_json,
+            wos_id="000123456789",
+            pubmed_id="36857419",
+        )
+
+        pub2 = Publication(
+            doi=None,
+            title="My Life",
+            apc=123,
+            open_access="green",
+            pub_year=2024,
+            dim_json=dim_json,
+            openalex_json=openalex_json,
+            wos_json=wos_json,
+            sulpub_json=sulpub_json,
+            pubmed_json=pubmed_json,
+            wos_id="000123456789",
+            pubmed_id="36857419",
+        )
+
+        author1 = Author(
+            first_name="Jane",
+            last_name="Stanford",
+            sunet="janes",
+            cap_profile_id="1234",
+            orcid="0298098343",
+            primary_school="School of Humanities and Sciences",
+            primary_dept="Social Sciences",
+            role="faculty",
+            schools=[
+                "Vice Provost for Undergraduate Education",
+                "School of Humanities and Sciences",
+            ],
+            departments=["Inter-Departmental Programs", "Social Sciences"],
+            academic_council=True,
+        )
+
+        author2 = Author(
+            first_name="Leland",
+            last_name="Stanford",
+            sunet="lelands",
+            cap_profile_id="12345",
+            orcid="02980983434",
+            primary_school="School of Humanities and Sciences",
+            primary_dept="Social Sciences",
+            role="staff",
+            schools=[
+                "School of Humanities and Sciences",
+            ],
+            departments=["Social Sciences"],
+            academic_council=False,
+        )
+
+        pub.authors.append(author1)
+        pub2.authors.append(author2)
+        session.add(pub)
+        session.add(pub2)
+
+
+def test_openalex_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that the publication with an OpenAlex duplicate is found and the duplicates removed.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_openalex_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        pubs = session.query(Publication).where(
+            Publication.openalex_json["id"].astext == "https://openalex.org/W123456789"
+        )
+        assert pubs.count() == 1, "remaining publication has the OpenAlex ID"
+        assert len(pubs.one().authors) == 2, "remaining publication has both authors"
+        author2 = session.query(Author).where(Author.orcid == "02980983434").one()
+        assert len(author2.publications) == 1, (
+            "second author exists and is linked to the remaining publication"
+        )
+        assert "Found 1 OpenAlex publications with duplicates." in caplog.text
+        assert "Deleted 1 publication rows from OpenAlex." in caplog.text
+
+
+def test_dimensions_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that the publication with a Dimensions duplicate is found and the duplicates removed.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_dimensions_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        pubs = session.query(Publication).where(
+            Publication.dim_json["id"].astext == "pub.1000000001"
+        )
+        assert pubs.count() == 1, "remaining publication has the Dimensions ID"
+        assert len(pubs.one().authors) == 2, "remaining publication has both authors"
+        author2 = session.query(Author).where(Author.orcid == "02980983434").one()
+        assert len(author2.publications) == 1, (
+            "second author exists and is linked to the remaining publication"
+        )
+        assert "Found 1 Dimensions publications with duplicates." in caplog.text
+        assert "Deleted 1 publication rows from Dimensions." in caplog.text
+
+
+def test_pubmed_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that publications with a duplicate pubmed_id are found and merged.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_pubmed_id_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        remaining_pub = (
+            session.query(Publication).where(Publication.pubmed_id == "36857419").one()
+        )
+        assert len(remaining_pub.authors) == 2, "remaining publication has both authors"
+        author2 = session.query(Author).where(Author.orcid == "02980983434").one()
+        assert len(author2.publications) == 1, (
+            "second author exists and is linked to the remaining publication"
+        )
+        assert "Found 1 publications with duplicate pubmed_id." in caplog.text
+        assert "Deleted 1 publication rows with duplicate pubmed_id." in caplog.text
+
+
+def test_sulpub_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that the publication with an sulpub duplicate is found and the duplicates removed.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_sulpub_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        pubs = session.query(Publication).where(
+            Publication.sulpub_json["sulpubid"].astext == "123456"
+        )
+        assert pubs.count() == 1, "remaining publication has the sulpub ID"
+        assert len(pubs.one().authors) == 2, "remaining publication has both authors"
+        author2 = session.query(Author).where(Author.orcid == "02980983434").one()
+        assert len(author2.publications) == 1, (
+            "second author exists and is linked to the remaining publication"
+        )
+        assert "Found 1 sulpub publications with duplicates." in caplog.text
+        assert "Deleted 1 publication rows from sulpub." in caplog.text
+
+
+def test_wos_id_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that publications with a duplicate wos_id are found and merged.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_wos_id_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        remaining_pub = (
+            session.query(Publication).where(Publication.wos_id == "000123456789").one()
+        )
+        assert len(remaining_pub.authors) == 2, "remaining publication has both authors"
+        assert "Found 1 publications with duplicate wos_id." in caplog.text
+        assert "Deleted 1 publication rows with duplicate wos_id." in caplog.text
+
+
+def test_pubmed_id_deduplicate(test_session, dataset, snapshot, caplog):
+    """
+    Test that publications with a duplicate pubmed_id are found and merged.
+    Authors should be moved to the remaining record.
+    """
+    caplog.set_level(logging.INFO)
+    dupes = deduplicate.remove_pubmed_id_duplicates(snapshot)
+    assert dupes == 1
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, (
+            "only one publication remains in table"
+        )
+        remaining_pub = (
+            session.query(Publication).where(Publication.pubmed_id == "36857419").one()
+        )
+        assert len(remaining_pub.authors) == 2, "remaining publication has both authors"
+        assert "Found 1 publications with duplicate pubmed_id." in caplog.text
+        assert "Deleted 1 publication rows with duplicate pubmed_id." in caplog.text
+
+
+def test_merge_pubs(test_session, dataset):
+    """
+    Test that merge_pubs merges authors and deletes duplicates.
+    """
+    with test_session.begin() as session:
+        pubs = session.query(Publication).all()
+        assert len(pubs) == 2, "two pubs exist before merging"
+        deleted = deduplicate.merge_pubs(pubs=pubs, session=session)
+        assert deleted == 1, "function counts one deletion"
+        assert session.query(Publication).count() == 1, "one pub remains"
+        remaining_pub = session.query(Publication).one()
+        assert len(remaining_pub.authors) == 2, (
+            "both authors are linked to the remaining publication"
+        )
+        author2 = session.query(Author).where(Author.orcid == "02980983434").one()
+        assert len(author2.publications) == 1, (
+            "second author exists and is linked to the remaining publication"
+        )
+
+
+@pytest.fixture
+def dataset2(test_session, dim_json, openalex_json, wos_json, sulpub_json, pubmed_json):
+    """
+    This fixture will create two publications that are duplicates within different platforms and lack DOIs.
+    """
+    with test_session.begin() as session:
+        pub = Publication(
+            doi=None,
+            title="My Life",
+            apc=123,
+            open_access="green",
+            pub_year=2024,
+            dim_json=dim_json,
+            openalex_json=openalex_json,
+            wos_json=wos_json,
+            sulpub_json=sulpub_json,
+            pubmed_json=pubmed_json,
+        )
+
+        pub2 = Publication(
+            doi=None,
+            title="My Life",
+            apc=123,
+            open_access="green",
+            pub_year=2024,
+            dim_json=dim_json,
+            openalex_json=None,
+            wos_json=wos_json,
+            sulpub_json=sulpub_json,
+            pubmed_json=pubmed_json,
+        )
+
+        pub3 = Publication(
+            doi=None,
+            title="My Life",
+            apc=123,
+            open_access="green",
+            pub_year=2024,
+            dim_json=dim_json,
+            openalex_json=openalex_json,
+            wos_json=None,
+            sulpub_json=sulpub_json,
+            pubmed_json=pubmed_json,
+        )
+
+        author1 = Author(
+            first_name="Jane",
+            last_name="Stanford",
+            sunet="janes",
+            cap_profile_id="1234",
+            orcid="0298098343",
+            primary_school="School of Humanities and Sciences",
+            primary_dept="Social Sciences",
+            role="faculty",
+            schools=[
+                "Vice Provost for Undergraduate Education",
+                "School of Humanities and Sciences",
+            ],
+            departments=["Inter-Departmental Programs", "Social Sciences"],
+            academic_council=True,
+        )
+
+        author2 = Author(
+            first_name="Leland",
+            last_name="Stanford",
+            sunet="lelands",
+            cap_profile_id="12345",
+            orcid="02980983434",
+            primary_school="School of Humanities and Sciences",
+            primary_dept="Social Sciences",
+            role="staff",
+            schools=[
+                "School of Humanities and Sciences",
+            ],
+            departments=["Social Sciences"],
+            academic_council=False,
+        )
+
+        pub.authors.append(author1)
+        pub2.authors.append(author2)
+        pub3.authors.append(author2)
+        session.add(pub)
+        session.add(pub2)
+        session.add(pub3)
+
+
+def test_remove_duplicates(test_session, dataset2, snapshot):
+    """
+    Test that remove_duplicates returns the total number of duplicates removed.
+    """
+    total_dupes = deduplicate.remove_duplicates(snapshot)
+    assert total_dupes == 2, "two duplicates have been removed"

--- a/test/harvest_incremental/test_dimensions.py
+++ b/test/harvest_incremental/test_dimensions.py
@@ -1,0 +1,399 @@
+import logging
+import os
+import pytest
+import requests
+
+import dotenv
+import dimcli
+
+from rialto_airflow.harvest_incremental import dimensions
+from rialto_airflow.schema.harvest import Publication
+
+from test.utils import num_jsonl_objects, num_log_record_matches
+
+dotenv.load_dotenv()
+
+
+def test_publications_from_dois():
+    # use batch_size=1 to test paging for two DOIs
+    pubs = list(
+        dimensions.publications_from_dois(
+            ["10.48550/arxiv.1706.03762", "10.1145/3442188.3445922"], batch_size=1
+        )
+    )
+    assert len(pubs) == 2
+    assert pubs[0]["doi"] == "10.48550/arxiv.1706.03762"
+    assert len(pubs[0].keys()) == 28, "first publication has 28 columns"
+    assert "book_title" in pubs[0].keys()
+    assert len(pubs[1].keys()) == 28, "second publication has 28 columns"
+
+
+def test_publication_fields():
+    fields = dimensions.publication_fields()
+    assert len(fields) == 18
+    assert "basics" in fields
+    assert "book" in fields
+
+
+def test_publications_from_orcid():
+    pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
+    assert len(pubs) == 17
+    assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
+
+
+@pytest.fixture
+def mock_dimensions_dsl_query_error(monkeypatch):
+    """
+    Mock our function for fetching publications by orcid from Dimensions
+    such that the first call results in a retriable error.
+    """
+
+    patched_dsl = dimensions.dsl()  # Dimensions dimcli.Dsl instance lets you query
+    original_query_iterative = (
+        patched_dsl.query_iterative
+    )  # a ref to the real query_iterative function
+
+    # for the first call to query_iterative that does an orcid query on publications,
+    # raise a request exception.  for the rest, just call the real query function.
+    req_count = 0
+
+    def query_iterative_raise_sometimes_fn(*args, **kwargs):
+        nonlocal req_count
+        if "search publications where researchers.orcid_id = " not in args[0]:
+            return original_query_iterative(*args, **kwargs)
+
+        req_count += 1
+        if req_count > 1:
+            return original_query_iterative(*args, **kwargs)
+        else:
+            exception = dimensions.requests.exceptions.RequestException(
+                "transient error"
+            )
+            response = requests.Response()
+            response.status_code = 429
+            exception.response = response
+            raise exception
+
+    monkeypatch.setattr(
+        patched_dsl, "query_iterative", query_iterative_raise_sometimes_fn
+    )
+    monkeypatch.setattr(
+        dimensions, "dsl", lambda: patched_dsl
+    )  # wrapped in a lambda because dimensions.dsl is a fn that returns a dimcli.Dsl instance
+
+
+def test_query_with_retry(mock_dimensions_dsl_query_error, caplog):
+    pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
+    assert len(pubs) == 17
+    assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
+    assert num_log_record_matches(
+        caplog.records,
+        logging.WARNING,
+        "Dimensions query error retry 1 of 5: transient error",
+    )
+
+
+@pytest.fixture
+def mock_dimensions_dsl_query_login_error(monkeypatch):
+    """
+    Mock our function for fetching publications by orcid from Dimensions
+    such that the first call results in an authentication error.
+    """
+
+    patched_dsl = dimensions.dsl()  # Dimensions dimcli.Dsl instance lets you query
+    original_query_iterative = (
+        patched_dsl.query_iterative
+    )  # a ref to the real query_iterative function
+
+    # for the first call to query_iterative that does an orcid query on publications,
+    # raise a request exception. For the rest, just call the real query function.
+    req_count = 0
+
+    def query_iterative_raise_sometimes_fn(*args, **kwargs):
+        nonlocal req_count
+        if "search publications where researchers.orcid_id = " not in args[0]:
+            return original_query_iterative(*args, **kwargs)
+
+        req_count += 1
+        if req_count > 1:
+            return original_query_iterative(*args, **kwargs)
+        else:
+            exception = dimensions.requests.exceptions.RequestException("login error")
+            response = requests.Response()
+            response.status_code = 401
+            exception.response = response
+            raise exception
+
+    monkeypatch.setattr(
+        patched_dsl, "query_iterative", query_iterative_raise_sometimes_fn
+    )
+    monkeypatch.setattr(
+        dimensions, "dsl", lambda: patched_dsl
+    )  # wrapped in a lambda because dimensions.dsl is a fn that returns a dimcli.Dsl instance
+
+
+def test_query_with_login_retry(mock_dimensions_dsl_query_login_error, caplog):
+    pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
+    assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
+    assert num_log_record_matches(
+        caplog.records,
+        logging.WARNING,
+        "Dimensions query error retry 1 of 5: login error",
+    )
+
+
+@pytest.fixture
+def mock_dimensions(monkeypatch):
+    """
+    Mock our function for fetching publications by orcid from Dimensions.
+    """
+
+    def f(*args, **kwargs):
+        yield {
+            "doi": "https://doi.org/10.1515/9781503624153",
+            "title": "An example title",
+            "type": "article",
+            "publication_year": 1891,
+        }
+
+    monkeypatch.setattr(dimensions, "publications_from_orcid", f)
+
+
+def test_harvest(snapshot, test_session, mock_authors, mock_dimensions):
+    # harvest from dimensions
+    dimensions.harvest(snapshot)
+
+    # the mocked openalex api returns the same publication for both authors
+    assert num_jsonl_objects(snapshot.path / "dimensions.jsonl") == 2
+
+    # make sure a publication is in the database and linked to the author
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publication loaded"
+
+        pub = session.query(Publication).first()
+        assert pub.doi == "10.1515/9781503624153", "doi was normalized"
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_harvest_when_doi_exists(
+    snapshot, test_session, mock_publication, mock_authors, mock_dimensions
+):
+    # harvest from dimensions
+    dimensions.harvest(snapshot)
+
+    # jsonl file is there and has two lines (one for each author)
+    assert num_jsonl_objects(snapshot.path / "dimensions.jsonl") == 2
+
+    # ensure that the existing publication for the DOI was updated
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publication loaded"
+        pub = session.query(Publication).first()
+
+        assert pub.dim_json
+        assert pub.dim_json["title"] == "An example title", "dimensions json updated"
+        assert pub.sulpub_json == {"sulpub": "data"}, "sulpub data the same"
+        assert pub.openalex_json is None
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_harvest_when_pub_author_association_exists(
+    snapshot,
+    test_session,
+    mock_publication,
+    mock_authors,
+    mock_association,
+    mock_dimensions,
+):
+    # harvest from dimensions
+    dimensions.harvest(snapshot)
+
+    # jsonl file is there and has two lines (one for each author)
+    assert num_jsonl_objects(snapshot.path / "dimensions.jsonl") == 2
+
+    # ensure that the existing publication for the DOI was updated
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publication loaded"
+        pub = session.query(Publication).first()
+
+        assert pub.dim_json
+        assert pub.dim_json["title"] == "An example title", "dimensions json updated"
+        assert pub.wos_json == {"wos": "data"}, "wos data the same"
+        assert pub.pubmed_json is None
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+@pytest.fixture
+def mock_many_dimensions(monkeypatch):
+    """
+    Mock our function for fetching publications by orcid from OpenAlex.
+    """
+
+    def f(*args, **kwargs):
+        for n in range(1, 1000):
+            yield {
+                "doi": f"https://doi.org/10.1515/{n}",
+                "title": "An example title",
+                "publication_year": 1891,
+            }
+
+    monkeypatch.setattr(dimensions, "publications_from_orcid", f)
+
+
+def test_log_message(snapshot, mock_authors, mock_many_dimensions, caplog):
+    caplog.set_level(logging.INFO)
+    dimensions.harvest(snapshot, limit=50)
+    assert "Reached limit of 50 publications stopping" in caplog.text
+
+
+@pytest.fixture
+def mock_no_dim_publication(test_session):
+    with test_session.begin() as session:
+        pub = Publication(
+            doi="10.1515/9781503624199",
+            sulpub_json={"sulpub": "data"},
+            wos_json={"wos": "data"},
+        )
+        session.add(pub)
+        return pub
+
+
+@pytest.fixture
+def mock_dimensions_doi(monkeypatch):
+    """
+    Mock our function for fetching publications by DOI from Dimensions.
+    """
+
+    def f(*args, **kwargs):
+        yield {
+            "doi": "10.1515/9781503624199",
+            "title": "An example title",
+            "type": "article",
+            "publication_year": 1891,
+        }
+
+    monkeypatch.setattr(dimensions, "publications_from_dois", f)
+
+
+def test_fill_in(
+    snapshot, test_session, mock_no_dim_publication, mock_dimensions_doi, caplog
+):
+    caplog.set_level(logging.INFO)
+    dimensions.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624199")
+            .first()
+        )
+        assert pub.dim_json == {
+            "doi": "10.1515/9781503624199",
+            "title": "An example title",
+            "type": "article",
+            "publication_year": 1891,
+        }
+
+    # adds 1 publication to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "dimensions-fillin.jsonl") == 1
+    assert "filled in 1 publications" in caplog.text
+
+
+def test_fill_in_no_dimensions(
+    snapshot,
+    test_session,
+    mock_publication,
+    mock_no_dim_publication,
+    caplog,
+    monkeypatch,
+):
+    caplog.set_level(logging.INFO)
+
+    # make it look like Dimensions returns no publications by DOI
+    monkeypatch.setattr(
+        dimensions, "publications_from_dois", lambda *args, **kwargs: []
+    )
+
+    dimensions.fill_in(snapshot)
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624199")
+            .first()
+        )
+        assert pub.dim_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "dimensions-fillin.jsonl") == 0
+    assert "filled in 0 publications" in caplog.text
+
+
+@pytest.mark.skip(reason="this test appears to be inconsistent")
+def test_researchers_error():
+    """
+    The Dimensions API can intermittently throw Service Unavailable errors when we include
+    "researchers" in the list of fields that we want to return.
+
+    If this test starts to fail that should be a flag that we can consider adding
+    "researchers" back to the list of fields that we query Dimensions for.
+
+    See: https://github.com/digital-science/dimcli/issues/90
+    """
+    dimcli.login(
+        key=os.environ.get("AIRFLOW_VAR_DIMENSIONS_API_KEY"),
+        endpoint="https://app.dimensions.ai/api/dsl/v2",
+    )
+
+    dsl = dimcli.Dsl()
+
+    q = """
+    search publications where doi in ["10.3847/1538-4357/ad9749","10.1103/physrevd.111.042005","10.3847/1538-4357/ad8de0","10.1364/fio.2024.jtu4a.2","10.3847/1538-4357/ad65ce","10.1364/cleo_si.2024.sm1d.3","10.1103/physrevd.110.042001","10.3847/1538-4357/ad3e83","10.3847/2041-8213/ad5beb"]
+    return publications [researchers]
+    limit 1000
+    """
+
+    results = dsl.query(q)
+    assert results.errors["query"]["header"] == "Service unavailable"
+
+
+def test_fill_in_no_doi(
+    snapshot,
+    test_session,
+    mock_no_dim_publication,
+    caplog,
+    monkeypatch,
+):
+    """
+    Test that a publication coming back from Dimensions without DOI doesn't
+    cause an exception.
+    """
+
+    monkeypatch.setattr(
+        dimensions,
+        "publications_from_dois",
+        lambda *args, **kwargs: [{"title": "Example"}],
+    )
+
+    caplog.set_level(logging.INFO)
+    dimensions.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624199")
+            .first()
+        )
+        assert pub.dim_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "dimensions-fillin.jsonl") == 0
+    assert "unable to determine what DOI to update" in caplog.text
+    assert "filled in 0 publications" in caplog.text

--- a/test/harvest_incremental/test_distill.py
+++ b/test/harvest_incremental/test_distill.py
@@ -1,0 +1,26 @@
+from rialto_airflow.harvest_incremental.distill import distill
+from rialto_airflow.schema.harvest import Publication
+
+# This simply tests that the distill function is working. For the detailed testing of distill rules see
+# the test/distill directory.
+
+
+def test_distill(test_session, dataset, snapshot):
+    with test_session.begin() as session:
+        distill(snapshot)
+
+        pub = (
+            session.query(Publication).where(Publication.doi == "10.000/000001").first()
+        )
+        assert pub.title == "Sometimes limes are ok"
+        assert pub.pub_year == 2023
+        assert pub.apc == 123
+        assert pub.open_access == "gold"
+        assert pub.types == ["Article"]
+        assert pub.publisher == "Science Publisher Inc."
+        assert (
+            pub.journal_name
+            == "Proceedings of the National Academy of Sciences of the United States of America"
+        )
+        assert pub.academic_council_authored is True
+        assert pub.faculty_authored is True

--- a/test/harvest_incremental/test_openalex.py
+++ b/test/harvest_incremental/test_openalex.py
@@ -1,0 +1,334 @@
+import dotenv
+import logging
+import pytest
+
+import pyalex
+import requests
+from rialto_airflow.harvest_incremental import openalex
+from rialto_airflow.schema.harvest import Publication
+
+from test.utils import num_jsonl_objects, num_log_record_matches
+
+dotenv.load_dotenv()
+
+
+def test_orcid_publications():
+    """
+    This is a live test of OpenAlex API, to make sure paging works properly.
+    """
+    count = 0
+    for pub in openalex.orcid_publications("https://orcid.org/0000-0002-8030-5327"):
+        assert pub
+
+        count += 1
+        if count >= 400:
+            break
+
+    assert count == 400, "found 100 publications"
+
+
+@pytest.fixture
+def mock_openalex(monkeypatch):
+    """
+    Mock our function for fetching publications by orcid from OpenAlex.
+    """
+
+    def f(*args, **kwargs):
+        yield {
+            "doi": "https://doi.org/10.1515/9781503624153",
+            "title": "An example title",
+            "publication_year": 1891,
+            "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/36857419"},
+        }
+
+    monkeypatch.setattr(openalex, "orcid_publications", f)
+
+
+def test_harvest(snapshot, test_session, mock_authors, mock_openalex):
+    # harvest from openalex
+    openalex.harvest(snapshot)
+
+    # the mocked openalex api returns the same publication for both authors
+    assert num_jsonl_objects(snapshot.path / "openalex.jsonl") == 2
+
+    # make sure a publication is in the database and linked to the author
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publication loaded"
+
+        pub = session.query(Publication).first()
+        assert pub.doi == "10.1515/9781503624153", "doi was normalized"
+        assert pub.pubmed_id == "36857419", "pubmed_id populated from ids.pmid"
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_harvest_when_doi_exists(
+    snapshot, test_session, mock_publication, mock_authors, mock_openalex
+):
+    # harvest from openalex
+    openalex.harvest(snapshot)
+
+    # jsonl file is there and has two lines (one for each author)
+    assert num_jsonl_objects(snapshot.path / "openalex.jsonl") == 2
+
+    # ensure that the existing publication for the DOI was updated
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publication loaded"
+        pub = session.query(Publication).first()
+
+        assert pub.openalex_json
+        assert pub.openalex_json["title"] == "An example title", "openalex json updated"
+        assert pub.pubmed_id == "36857419", "pubmed_id populated from ids.pmid"
+        assert pub.wos_json == {"wos": "data"}, "wos data the same"
+        assert pub.pubmed_json is None
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_harvest_when_author_exists(
+    snapshot,
+    test_session,
+    mock_publication,
+    mock_authors,
+    mock_association,
+    mock_openalex,
+):
+    # harvest from openalex
+    openalex.harvest(snapshot)
+
+    # jsonl file is there and has two lines (one for each author)
+    assert num_jsonl_objects(snapshot.path / "openalex.jsonl") == 2
+
+    # ensure that the existing publication for the DOI was updated
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publication loaded"
+        pub = session.query(Publication).first()
+
+        assert pub.openalex_json
+        assert pub.openalex_json["title"] == "An example title", "openalex json updated"
+        assert pub.pubmed_id == "36857419", "pubmed_id populated from ids.pmid"
+        assert pub.wos_json == {"wos": "data"}, "wos data the same"
+        assert pub.pubmed_json is None
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+@pytest.fixture
+def mock_many_openalex(monkeypatch):
+    """
+    Mock our function for fetching publications by orcid from OpenAlex.
+    """
+
+    def f(*args, **kwargs):
+        for n in range(1, 1000):
+            yield {
+                "doi": f"https://doi.org/10.1515/{n}",
+                "title": "An example title",
+                "publication_year": 1891,
+            }
+
+    monkeypatch.setattr(openalex, "orcid_publications", f)
+
+
+def test_log_message(snapshot, mock_authors, mock_many_openalex, caplog):
+    caplog.set_level(logging.INFO)
+    openalex.harvest(snapshot, limit=50)
+    assert "Reached limit of 50 publications stopping" in caplog.text
+
+
+class MockWorks:
+    def __init__(self, records):
+        # create a
+        self.records = records
+
+    def filter(self, *args, **kwargs):
+        # filter is a no-op when called
+        return self
+
+    def get(self):
+        return self.records
+
+
+def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+
+    # setup Works to return a list of one record
+    records = [
+        {
+            "doi": "10.1515/9781503624153",
+            "title": "A sample title",
+            "publication_year": 1891,
+            "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/36857419"},
+        }
+    ]
+    monkeypatch.setattr(openalex, "Works", lambda: MockWorks(records))
+    openalex.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.openalex_json == {
+            "doi": "10.1515/9781503624153",
+            "title": "A sample title",
+            "publication_year": 1891,
+            "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/36857419"},
+        }
+        assert pub.pubmed_id == "36857419", "pubmed_id populated from ids.pmid"
+
+    # adds 1 publication to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "openalex-fillin.jsonl") == 1
+    assert "filled in 1 publications" in caplog.text
+
+
+def test_fill_in_no_openalex(
+    test_session, mock_publication, snapshot, caplog, monkeypatch
+):
+    caplog.set_level(logging.INFO)
+
+    # set up Works to return no records
+    monkeypatch.setattr(openalex, "Works", lambda: MockWorks([]))
+    openalex.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.openalex_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "openalex-fillin.jsonl") == 0
+    assert "filled in 0 publications" in caplog.text
+
+
+def test_fill_in_no_doi(test_session, mock_publication, snapshot, caplog, monkeypatch):
+    """
+    Test that Dimensions publication metadata lacking a DOI doesn't cause an
+    exception during fill-in.
+    """
+    caplog.set_level(logging.INFO)
+
+    # set up Works to return no records
+    monkeypatch.setattr(openalex, "Works", lambda: MockWorks([{"title": "example"}]))
+    openalex.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.openalex_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "openalex-fillin.jsonl") == 0
+    assert "unable to determine what DOI to update" in caplog.text
+    assert "filled in 0 publications" in caplog.text
+
+
+def test_comma():
+    """
+    The OpenAlex API doesn't allow you to look up DOIs with commas in them. If
+    this starts working again we can stop ignoring them when looking them up by
+    DOI when doing the fill-in process.
+    """
+    with pytest.raises(pyalex.api.QueryError, match="Invalid query parameter"):
+        dois = "10.1103/physrevd.72,031101"
+        pyalex.Works().filter(doi=dois).get()
+
+
+def test_colon():
+    """
+    The OpenAlex API doesn't allow you to look up multiple DOIs if they contain
+    a name prefix like 'doi:' since it confuses their query syntax into thinking you are trying to
+    filter using an OR boolean. If this test starts passing we can consider
+    stopping ignoring them.
+    """
+    with pytest.raises(
+        pyalex.api.QueryError, match="It looks like you're trying to do an OR query"
+    ):
+        dois = "abc123|doi:abc123"
+        pyalex.Works().filter(doi=dois).get()
+
+
+def test_clean_dois_for_query(caplog):
+    assert openalex._clean_dois_for_query(
+        [
+            "doi:123",
+            "abc/123,45",
+            "aaa/111",
+            "123/abc pmcid:123",
+            "abc/123",
+            "10.1093/noajnl/vdad070.013pmcid:pmc10402389",
+        ]
+    ) == ["aaa/111", "abc/123"]
+
+    assert num_log_record_matches(
+        caplog.records,
+        logging.WARNING,
+        "dropped 4 DOIs from openalex lookup: ['doi:123', 'abc/123,45', '123/abc pmcid:123', '10.1093/noajnl/vdad070.013pmcid:pmc10402389']",
+    )
+
+
+class MockSources:
+    def __init__(self, records):
+        self.records = records
+
+    def filter(self, *args, **kwargs):
+        # filter is a no-op when called
+        return self
+
+    def get(self):
+        return self.records
+
+
+def test_source_by_issn(monkeypatch):
+    records = [
+        {
+            "id": "https://openalex.org/S137773608",
+            "issn_l": "0028-0836",
+            "issn": ["0028-0836", "1476-4687"],
+            "display_name": "Nature",
+            "host_organization": "https://openalex.org/P4310319908",
+            "host_organization_name": "Nature Portfolio",
+            "works_count": 431710,
+            "cited_by_count": 25659865,
+        }
+    ]
+    monkeypatch.setattr(openalex, "Sources", lambda: MockSources(records))
+
+    source = openalex.source_by_issn("0028-0836")
+    assert source is not None
+    assert source.get("display_name") == "Nature"
+    assert source.get("host_organization_name") == "Nature Portfolio"
+
+
+class MockSourcesError:
+    def __init__(self, records):
+        self.records = records
+
+    def filter(self, *args, **kwargs):
+        # filter is a no-op when called
+        return self
+
+    def get(self):
+        raise requests.exceptions.JSONDecodeError("Expecting value", "", 0)
+
+
+def test_source_by_issn_jsonerror(monkeypatch, caplog):
+    records = "Not JSON"
+    monkeypatch.setattr(openalex, "Sources", lambda: MockSourcesError(records))
+
+    source = openalex.source_by_issn("XXXX-0836")
+    assert source is None
+    assert "Error decoding JSON for ISSN XXXX-0836" in caplog.text

--- a/test/harvest_incremental/test_pubmed.py
+++ b/test/harvest_incremental/test_pubmed.py
@@ -1,0 +1,727 @@
+import logging
+import re
+
+import pytest
+from xml.parsers.expat import ExpatError
+
+from rialto_airflow.harvest_incremental import pubmed
+from rialto_airflow.schema.harvest import Publication
+from test.utils import load_jsonl_file, num_jsonl_objects, num_log_record_matches
+
+
+@pytest.fixture
+def mock_pubmed_fetch(monkeypatch):
+    """
+    Mock our function for fetching publications from a list of PMIDs from Pubmed.
+    """
+
+    def f(*args, **kwargs):
+        return load_jsonl_file("test/data/pubmed.jsonl")
+
+    monkeypatch.setattr(pubmed, "publications_from_pmids", f)
+
+
+@pytest.fixture
+def mock_pubmed_search(monkeypatch):
+    """
+    Mock our function for searching for PMIDs given an ORCID
+    """
+
+    def f(*args, **kwargs):
+        return ["36857419", "36108252"]
+
+    monkeypatch.setattr(pubmed, "pmids_from_orcid", f)
+
+
+@pytest.fixture
+def mock_pubmed_search_no_results(monkeypatch):
+    """
+    Mock our function for searching for PMIDs given an ORCID
+    """
+
+    def f(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(pubmed, "pmids_from_orcid", f)
+
+
+@pytest.fixture
+def existing_publication(test_session):
+    with test_session.begin() as session:
+        pub = Publication(
+            doi="10.1182/bloodadvances.2022008893",
+            sulpub_json={"sulpub": "data"},
+        )
+        session.add(pub)
+        return pub
+
+
+@pytest.fixture
+def pubmed_book_xml():
+    return """<?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2025//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_250101.dtd">
+        <PubmedArticleSet>
+            <PubmedBookArticle>
+                <BookDocument>
+                    <PMID Version="1">38478703</PMID>
+                    <ArticleIdList><ArticleId IdType="bookaccession">NBK601514</ArticleId><ArticleId IdType="doi">10.25302/01.2021.ME.150731469</ArticleId></ArticleIdList>
+                    <Book>
+                    <Publisher><PublisherName>Patient-Centered Outcomes Research Institute (PCORI)</PublisherName><PublisherLocation>Washington (DC)</PublisherLocation></Publisher>
+                    <BookTitle book="pcori12021me15073146">Comparing Preferences for Depression and Diabetes Treatment among Adults of Different Racial and Ethnic Groups Who Reported Discrimination in Health Care</BookTitle>
+                    <PubDate><Year>2021</Year><Month>01</Month></PubDate>
+                    <CollectionTitle book="pcoricollect">PCORI Final Research Reports</CollectionTitle>
+                    <ELocationID EIdType="doi">10.25302/01.2021.ME.150731469</ELocationID>
+                    <PublicationType UI="D016454">Review</PublicationType>
+                    <Abstract><AbstractText Label="BACKGROUND">The abstract.</AbstractText></Abstract>
+                    </Book>
+                </BookDocument>
+                <PubmedBookData>
+                    <ArticleIdList>
+                        <ArticleId IdType="pubmed">38478703</ArticleId>
+                    </ArticleIdList>
+                </PubmedBookData>
+            </PubmedBookArticle>
+        </PubmedArticleSet>
+        """
+
+
+def pubmed_json():
+    """
+    A partial Pubmed JSON object with a DOI and some other IDs.
+    """
+    return {
+        "MedlineCitation": {
+            "Article": {
+                "ELocationID": [
+                    {
+                        "@EIdType": "doi",
+                        "@ValidYN": "Y",
+                        "#text": "10.1021/ac1028984",
+                    }
+                ],
+                "ArticleTitle": "Another Article Title",
+            },
+        },
+        "PubmedData": {
+            "ArticleIdList": {
+                "ArticleId": [
+                    {"@IdType": "pubmed", "#text": "36857419"},
+                    {"@IdType": "pmc", "#text": "PMC10275701"},
+                    {"@IdType": "doi", "#text": "10.1182/bloodadvances.2022008893"},
+                    {"@IdType": "pii", "#text": "494746"},
+                ]
+            },
+        },
+    }
+
+
+def pubmed_json_no_doi():
+    """
+    A partial Pubmed JSON object without a DOI.
+    """
+    return {
+        "MedlineCitation": {
+            "Article": {
+                "ArticleTitle": "Another Article Title",
+            },
+        },
+        "PubmedData": {
+            "ArticleIdList": {
+                "ArticleId": [
+                    {"@IdType": "pubmed", "#text": "36857419"},
+                    {"@IdType": "pmc", "#text": "PMC10275701"},
+                    {"@IdType": "pii", "#text": "494746"},
+                ]
+            },
+        },
+    }
+
+
+def pubmed_json_fill_in_doi():
+    """
+    A partial Pubmed JSON object with a DOI.
+    """
+    return {
+        "MedlineCitation": {
+            "Article": {
+                "ArticleTitle": "Another Article Title To Be Filled In",
+            },
+        },
+        "PubmedData": {
+            "ArticleIdList": {
+                "ArticleId": [
+                    {"@IdType": "pubmed", "#text": "12345"},
+                    {"@IdType": "doi", "#text": "10.1515/9781503624153"},
+                ]
+            },
+        },
+    }
+
+
+def test_pubmed_search_no_results(requests_mock, caplog):
+    """
+    This is a test of the Pubmed Search API to ensure we are parsing the mocked response correctly with no results.
+    """
+    caplog.set_level(logging.INFO)
+
+    requests_mock.get(
+        re.compile(".*"),
+        json={
+            "header": {"type": "esearch", "version": "0.3"},
+            "esearchresult": {"count": "0"},
+        },
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert pubmed.pmids_from_orcid("nope") == []
+
+
+def test_pubmed_search_error(requests_mock, caplog):
+    """
+    This is a test of the Pubmed Search API to ensure we are parsing the mocked response correctly when an error.
+    """
+    caplog.set_level(logging.INFO)
+
+    requests_mock.get(
+        re.compile(".*"),
+        json={"error": "no good"},
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert pubmed.pmids_from_orcid("nope") == []
+    assert "Error in results found for nope[auid]: no good" in caplog.text
+
+
+def test_pubmed_search_unexpected_response(requests_mock, caplog):
+    """
+    This is a test of the Pubmed Search API to ensure we are parsing the mocked response correctly when there is an unexpected response.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.get(
+        re.compile(".*"),
+        json={"header": {"type": "esearch", "version": "0.3"}},
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert pubmed.pmids_from_orcid("nope") == []
+    assert (
+        num_log_record_matches(
+            caplog.records,
+            logging.DEBUG,
+            "No esearchresult or count found for nope[auid]",
+        )
+        == 1
+    )
+
+
+def test_pubmed_search_orcid_found_publications():
+    """
+    This is a live test of the Pubmed Search API to ensure we can get PMIDs back given an ORCID.
+    """
+    # The ORCID that is tested should return more at least two PMIDs
+    orcid = "https://orcid.org/0000-0002-5286-7795"
+    pmids = pubmed.pmids_from_orcid(orcid)
+    assert len(pmids) >= 2, "found at least 2 publications"
+    assert "29035265" in pmids, "found an expected publication for this author"
+
+
+def test_pubmed_search_orcid_no_publications():
+    """
+    This is a live test of the Pubmed Search API to ensure no results are returned for an ORCID with no publications.
+    """
+    # No publications should be found for this ORCID
+    orcid = "5555-5555-5555-5555"
+    pmids = pubmed.pmids_from_orcid(orcid)
+    assert len(pmids) == 0, "found no publications"
+
+
+def test_pubmed_search_dois_found_publications():
+    """
+    This is a live test of the Pubmed Search API to ensure we can get PMIDs back given two DOIs.
+    """
+    # The first DOIs should both return PMIDs, the last will return nothing
+    dois = ["10.1118/1.598623", "10.3899/jrheum.220960", "bogus"]
+    pmids = pubmed.pmids_from_dois(dois)
+    assert set(pmids) == {"10435530", "36243410"}, (
+        "found both publications"
+    )  # ordering is not important
+
+
+def test_pubmed_search_dois_found_one_publication():
+    """
+    This is a live test of the Pubmed Search API to ensure we can get PMIDs back a single DOIs.
+    """
+    # These DOIs should both return PMIDs
+    dois = ["10.1021/ac1028984"]
+    pmids = pubmed.pmids_from_dois(dois)
+    assert pmids == ["21302935"], "found single publication"
+
+
+def test_pubmed_search_dois_no_publications():
+    """
+    This is a live test of the Pubmed Search API to ensure no results are returned for DOIs with no publications.
+    """
+    # No publications should be found for these dois
+    dois = ["bogus-doi-1", "bogus-doi-2"]
+    pmids = pubmed.pmids_from_dois(dois)
+    assert len(pmids) == 0, "found no publications"
+
+
+def test_pubmed_fetch_publications():
+    """
+    This is a live test of the Pubmed Fetch API to ensure we can get publication data back given a list of PMIDs.
+    """
+    # Both of these publications should be found
+    pmids = ["29035265", "29035260"]
+    pubs = pubmed.publications_from_pmids(pmids)
+    assert len(pubs) == 2, "found both publications"
+    assert isinstance(pubs[0], dict), (
+        "first publication is json"
+    )  # check that we got a dict back
+    assert isinstance(pubs[1], dict), (
+        "second publication is json"
+    )  # check that we got a dict back
+    assert "PubmedData" in pubs[0], "found the PubmedData key in the first publication"
+    assert "PubmedData" in pubs[1], "found the PubmedData key in the second publication"
+
+
+def test_pubmed_fetch_missing_publications():
+    """
+    This is a live test of the Pubmed Fetch API to ensure we can get a list back even for one publication
+    """
+    # This publication should be found
+    pmids = ["29035265"]
+    pubs = pubmed.publications_from_pmids(pmids)
+
+    assert len(pubs) == 1, "found publication as a list of one element"
+    assert isinstance(pubs[0], dict), (
+        "first publication is json"
+    )  # check that we got a dict back
+    assert "PubmedData" in pubs[0], "found the PubmedData key in the first publication"
+
+
+def test_pubmed_fetch_publications_expects_list():
+    pubs = pubmed.publications_from_pmids([])
+
+    assert pubs == [], "no publications returned because we passed an empty list"
+
+
+def test_harvest(
+    snapshot, test_session, mock_authors, mock_pubmed_fetch, mock_pubmed_search
+):
+    """
+    With some authors loaded and a mocked Pubmed API, make sure that
+    publications are matched up to the authors using the ORCID.
+    """
+    # harvest from Pubmed
+    pubmed.harvest(snapshot)
+
+    # the mocked Pubmed api returns the same two publications for both authors
+    assert num_jsonl_objects(snapshot.path / "pubmed.jsonl") == 4
+
+    # make sure a publication is in the database and linked to the author
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 2, "two publications loaded"
+
+        pubs = session.query(Publication).all()
+        assert pubs[0].doi == "10.1182/bloodadvances.2022008893", "doi was added"
+        assert pubs[1].doi == "10.1200/jco.22.01076", "doi was normalized"
+
+        assert len(pubs[0].authors) == 2, "publication has two authors"
+        assert pubs[0].authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pubs[0].authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_harvest_limit(
+    snapshot, test_session, mock_authors, mock_pubmed_fetch, mock_pubmed_search, caplog
+):
+    """
+    With some authors loaded and a mocked Pubmed API and an artificially low
+    harvest limit, confirm that processing stops as expected and logs appropriately.
+    """
+    # harvest from Pubmed with a limit of one publication
+    pubmed.harvest(snapshot, 1)
+
+    # the mocked Pubmed api returns the same two publications for both authors, but we
+    # only process the first
+    assert num_jsonl_objects(snapshot.path / "pubmed.jsonl") == 1
+
+    # make sure a publication is in the database and linked to the author
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "only one publication loaded"
+
+        pubs = session.query(Publication).all()
+        assert pubs[0].doi == "10.1182/bloodadvances.2022008893", "doi was added"
+
+        assert len(pubs[0].authors) == 1, (
+            "publication has one author because limit is reached before second is processed"
+        )
+        assert pubs[0].authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+
+        assert (
+            num_log_record_matches(
+                caplog.records,
+                logging.WARNING,
+                "Reached limit of 1 publications stopping",
+            )
+            == 1
+        )
+
+
+def test_harvest_no_pubmed_results(
+    snapshot,
+    test_session,
+    mock_authors,
+    mock_pubmed_fetch,
+    mock_pubmed_search_no_results,
+    caplog,
+):
+    """
+    With some authors loaded and a Pubmed API mocked to never find anything, confirm that we
+    log the unsuccessful searches appropriately.
+    """
+    caplog.set_level(logging.DEBUG)
+    pubmed.harvest(snapshot)
+    assert num_jsonl_objects(snapshot.path / "pubmed.jsonl") == 0
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 0, (
+            "no publications loaded because none found"
+        )
+        assert (
+            num_log_record_matches(
+                caplog.records,
+                logging.DEBUG,
+                "No publications found for https://orcid.org/0000-0000-0000-0001",
+            )
+            == 1
+        )
+        assert (
+            num_log_record_matches(
+                caplog.records,
+                logging.DEBUG,
+                "No publications found for https://orcid.org/0000-0000-0000-0002",
+            )
+            == 1
+        )
+
+
+def test_harvest_when_doi_exists(
+    snapshot,
+    test_session,
+    existing_publication,
+    mock_authors,
+    mock_pubmed_fetch,
+    mock_pubmed_search,
+):
+    """
+    When a publication and its authors already exist in the database make sure that the pubmed_json is updated.
+    """
+    # harvest from Pubmed
+    pubmed.harvest(snapshot)
+
+    # jsonl file is there and has four lines (two pubs for each author)
+    assert num_jsonl_objects(snapshot.path / "pubmed.jsonl") == 4
+
+    # ensure that the existing publication for the DOI was updated
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 2, "two publications loaded"
+        pub = session.query(Publication).first()
+
+        assert pub.wos_json is None
+        assert pub.sulpub_json == {"sulpub": "data"}, "sulpub data the same"
+        assert pub.pubmed_json
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_fill_in(snapshot, test_session, mock_publication, caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+
+    # mock pubmed api to return a PMID for the fake DOI
+    monkeypatch.setattr(pubmed, "pmids_from_dois", lambda *args, **kwargs: ["12345"])
+
+    # mock pubmed api to return a record for this PMID
+    monkeypatch.setattr(
+        pubmed,
+        "publications_from_pmids",
+        lambda *args, **kwargs: [pubmed_json_fill_in_doi()],
+    )
+    pubmed.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.pubmed_json == pubmed_json_fill_in_doi()
+
+    # adds 1 publication to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "pubmed-fillin.jsonl") == 1
+    assert "filled in 1 publications" in caplog.text
+
+
+def test_fill_in_no_pubmed(
+    test_session, mock_publication, snapshot, caplog, monkeypatch
+):
+    caplog.set_level(logging.INFO)
+
+    # mock pubmed api to return no records for the doi
+    monkeypatch.setattr(pubmed, "pmids_from_dois", lambda *args, **kwargs: [])
+    pubmed.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.pubmed_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "pubmed-fillin.jsonl") == 0
+    assert "filled in 0 publications" in caplog.text
+
+
+def test_fill_in_no_doi(test_session, mock_publication, snapshot, caplog, monkeypatch):
+    """
+    Test that a publication coming back from Pubmed without DOI doesn't
+    cause an exception.
+    """
+
+    # mock pubmed api to return a PMID for the fake DOI
+    monkeypatch.setattr(pubmed, "pmids_from_dois", lambda *args, **kwargs: ["12345"])
+
+    # mock pubmed api to return a record for this PMID, but without a DOI
+    monkeypatch.setattr(
+        pubmed,
+        "publications_from_pmids",
+        lambda *args, **kwargs: [pubmed_json_no_doi()],
+    )
+
+    caplog.set_level(logging.INFO)
+    pubmed.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624153")
+            .first()
+        )
+        assert pub.pubmed_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "pubmed-fillin.jsonl") == 0
+    assert "unable to determine what DOI to update" in caplog.text
+    assert "filled in 0 publications" in caplog.text
+
+
+def test_get_doi():
+    assert pubmed.get_doi(pubmed_json()) == "10.1182/bloodadvances.2022008893"
+
+    pubmed_json_single_id = {
+        "PubmedData": {
+            "ArticleIdList": {
+                "ArticleId": {
+                    "@IdType": "doi",
+                    "#text": "10.1182/bloodadvances.2022008893",
+                },
+            },
+        }
+    }
+    assert pubmed.get_doi(pubmed_json_single_id) == "10.1182/bloodadvances.2022008893"
+
+    assert pubmed.get_doi(pubmed_json_no_doi()) is None
+
+    pubmed_json_no_ids = {
+        "PubmedData": {
+            "PublicationStatus": "ppublish",
+        }
+    }
+    assert pubmed.get_doi(pubmed_json_no_ids) is None
+
+    pubmed_json_alt_doi = {
+        "MedlineCitation": {
+            "Article": {
+                "ELocationID": [
+                    {
+                        "@EIdType": "doi",
+                        "@ValidYN": "Y",
+                        "#text": "10.1182/bloodadvances.2022008893",
+                    }
+                ]
+            },
+        }
+    }
+    assert pubmed.get_doi(pubmed_json_alt_doi) == "10.1182/bloodadvances.2022008893"
+
+    pubmed_json_alt_single_id = {
+        "MedlineCitation": {
+            "Article": {
+                "ELocationID": {
+                    "@EIdType": "doi",
+                    "@ValidYN": "Y",
+                    "#text": "10.1182/only-one",
+                }
+            },
+        }
+    }
+    assert pubmed.get_doi(pubmed_json_alt_single_id) == "10.1182/only-one"
+
+
+def test_get_identifier():
+    assert (
+        pubmed.get_identifier(pubmed_json(), "doi")
+        == "10.1182/bloodadvances.2022008893"
+    )
+    assert pubmed.get_identifier(pubmed_json(), "pubmed") == "36857419"
+    assert pubmed.get_identifier(pubmed_json(), "pmc") == "PMC10275701"
+    assert pubmed.get_identifier(pubmed_json(), "pii") == "494746"
+    assert pubmed.get_identifier(pubmed_json(), "invalid") is None
+
+
+def test_pubs_from_pmids_no_articles(requests_mock, pubmed_book_xml):
+    """
+    Test that an empty list is returned when no articles are found for a PMIDs
+    """
+    requests_mock.post(
+        re.compile(".*"),
+        text=pubmed_book_xml,
+        status_code=200,
+        headers={"Content-Type": "application/xml"},
+    )
+    pubs = pubmed.publications_from_pmids(["00000000"])
+    assert pubs == []
+
+
+def test_http_session_retries():
+    """
+    Verify the http session is configured to retry 429 responses on both GET and POST
+    requests. requests_mock bypasses urllib3 entirely so cannot exercise this, but we
+    can inspect the adapter's Retry configuration directly.
+
+    get_adapter() returns BaseAdapter in the type stubs, but at runtime it returns
+    HTTPAdapter which does have max_retries.
+    """
+    adapter = pubmed.http.get_adapter("https://")
+    retry = adapter.max_retries  # type: ignore
+    assert 429 in retry.status_forcelist
+    assert 500 in retry.status_forcelist
+    assert "POST" in retry.allowed_methods
+    assert "GET" in retry.allowed_methods
+
+
+def test_retry_bad_xml(requests_mock, caplog, pubmed_book_xml):
+    """
+    PubMed API can sometimes return invalid XML, which then works on retry. This
+    tests that these get retried.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.register_uri(
+        "POST",
+        pubmed.FETCH_URL,
+        # a list of mocked http responses: first returns bad xml, second returns good xml
+        [
+            {"status_code": 200, "text": "this ain't xml"},
+            {
+                "status_code": 200,
+                "text": pubmed_book_xml,
+            },
+        ],
+    )
+
+    assert pubmed.publications_from_pmids(["123456"]) == []
+    assert (
+        "retrying after error: <class 'xml.parsers.expat.ExpatError'> syntax error: line 1, column 0"
+        in caplog.text
+    )
+
+
+def test_too_many_bad_xml(requests_mock, caplog, pubmed_book_xml):
+    """
+    PubMed API can sometimes return invalid XML, which then works on retry. This
+    tests that these get retried, and that we give up after 10 retries.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.register_uri(
+        "POST",
+        pubmed.FETCH_URL,
+        # 10 failures in a row should cause publications_from_pmids to fail
+        [
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+            {"status_code": 200, "text": "this ain't xml"},
+        ],
+    )
+
+    with pytest.raises(ExpatError):
+        pubmed.publications_from_pmids(["123456"]) == []
+
+    assert (
+        "too many retries: <class 'xml.parsers.expat.ExpatError'> syntax error: line 1, column 0"
+        in caplog.text
+    )
+
+
+def test_retry_chunked_encoding_error(requests_mock, caplog, pubmed_book_xml):
+    """
+    PubMed API can sometimes drop the connection mid-response. This tests
+    that ChunkedEncodingError is retried.
+    """
+    from requests.exceptions import ChunkedEncodingError
+
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.register_uri(
+        "POST",
+        pubmed.FETCH_URL,
+        [
+            {"exc": ChunkedEncodingError()},
+            {"status_code": 200, "text": pubmed_book_xml},
+        ],
+    )
+
+    assert pubmed.publications_from_pmids(["123456"]) == []
+    assert (
+        "retrying after error: <class 'requests.exceptions.ChunkedEncodingError'>"
+        in caplog.text
+    )
+
+
+def test_too_many_chunked_encoding_errors(requests_mock, caplog):
+    """
+    If ChunkedEncodingError persists beyond the retry limit, the exception is raised.
+    """
+    from requests.exceptions import ChunkedEncodingError
+
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.register_uri(
+        "POST",
+        pubmed.FETCH_URL,
+        [{"exc": ChunkedEncodingError()}] * 11,
+    )
+
+    with pytest.raises(ChunkedEncodingError):
+        pubmed.publications_from_pmids(["123456"])
+
+    assert (
+        "too many retries: <class 'requests.exceptions.ChunkedEncodingError'>"
+        in caplog.text
+    )

--- a/test/harvest_incremental/test_sul_pub.py
+++ b/test/harvest_incremental/test_sul_pub.py
@@ -1,0 +1,241 @@
+import os
+import logging
+
+import dotenv
+
+from rialto_airflow.schema.harvest import Publication
+from rialto_airflow.harvest_incremental import sul_pub
+from rialto_airflow.snapshot import Snapshot
+
+from test.utils import num_jsonl_objects, num_log_record_matches
+
+dotenv.load_dotenv()
+
+sul_pub_host = os.environ.get("AIRFLOW_VAR_SUL_PUB_HOST")
+sul_pub_key = os.environ.get("AIRFLOW_VAR_SUL_PUB_KEY")
+
+no_auth = not (sul_pub_host and sul_pub_key)
+
+
+response = {
+    "records": [
+        {
+            "title": "An example title with DOI in top level only",
+            "doi": "https://doi.org/10.1515/9781503624153",
+            "authorship": [
+                {"status": "approved", "cap_profile_id": "12345"},
+                {"status": "approved", "cap_profile_id": "123456"},
+            ],
+        },
+        {
+            "title": "Another title with no approved authors - will be ignored",
+            "sulpubid": "456012",
+            "identifier": [
+                {"type": "doi", "id": "https://doi.org/10.1215/0961754X-9809305"}
+            ],
+            "authorship": [
+                {"status": "unknown", "cap_profile_id": "12345"},
+                {"status": "unknown", "cap_profile_id": "123456"},
+            ],
+        },
+        {
+            "title": "Another title that will be harvested with DOI in identifier field only",
+            "sulpubid": "123789",
+            "identifier": [
+                {"type": "doi", "id": "https://doi.org/10.9999/0161754X-9809305"}
+            ],
+            "authorship": [
+                {"status": "approved", "cap_profile_id": "12345"},
+            ],
+        },
+    ]
+}
+
+
+def test_harvest(tmp_path, test_session, mock_authors, caplog, requests_mock):
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.get("/publications.json", json=response)
+    requests_mock.get("/publications.json?page=2", json={"records": []})
+
+    # harvest from sulpub
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    sul_pub.harvest(snapshot, sul_pub_host, sul_pub_key)
+
+    # make sure the jsonl file looks good
+    assert num_jsonl_objects(snapshot.path / "sulpub.jsonl") == 3
+
+    # make sure there are publications in the database
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 2, "two publications loaded"
+
+        # Fetch all publications in a deterministic order
+        pubs = session.query(Publication).order_by(Publication.id).all()
+
+        pub = pubs[0]
+        assert pub.doi == "10.1515/9781503624153", "first DOI present"
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].cap_profile_id == "12345"
+        assert pub.authors[1].cap_profile_id == "123456"
+
+        pub2 = pubs[1]
+        assert pub2.doi == "10.9999/0161754x-9809305", "second DOI present"
+        assert len(pub2.authors) == 1, "publication has one author"
+        assert pub2.authors[0].cap_profile_id == "12345"
+        assert (
+            num_log_record_matches(
+                caplog.records,
+                logging.DEBUG,
+                "doi was not available in top level for sulpub id 456012 but found in identifier block",
+            )
+            == 1
+        )
+
+
+def test_harvest_limit(tmp_path, test_session, mock_authors, caplog, requests_mock):
+    """
+    Confirm that the harvest limit we use in test envs is observed, and that a warning is
+    logged when the limit is hit.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    requests_mock.get("/publications.json", json=response)
+    requests_mock.get("/publications.json?page=2", json={"records": []})
+
+    # harvest from sulpub with a limit of one publication
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    sul_pub.harvest(snapshot, sul_pub_host, sul_pub_key, limit=1)
+
+    # make sure the jsonl file looks good
+    assert num_jsonl_objects(snapshot.path / "sulpub.jsonl") == 1
+
+    # make sure a publication is in the database and linked to the authors
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publications loaded"
+
+        pubs = session.query(Publication).all()
+        assert pubs[0].doi == "10.1515/9781503624153", "doi was added"
+
+        assert len(pubs[0].authors) == 2, (
+            "publication has two authors because limit is only placed on publication processing"
+        )
+        assert pubs[0].authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+
+        assert (
+            num_log_record_matches(
+                caplog.records,
+                logging.WARNING,
+                "stopping with limit=1",
+            )
+            == 1
+        )
+
+
+def test_harvest_when_doi_exists(
+    tmp_path, test_session, mock_publication, mock_authors, requests_mock
+):
+    requests_mock.get("/publications.json", json=response)
+    requests_mock.get("/publications.json?page=2", json={"records": []})
+
+    # harvest from sulpub
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    sul_pub.harvest(snapshot, sul_pub_host, sul_pub_key)
+
+    # jsonl file is there and ok
+    assert num_jsonl_objects(snapshot.path / "sulpub.jsonl") == 3
+
+    # ensure that the existing publication for the DOI was updated
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 2, "two publications loaded"
+        pub = session.query(Publication).order_by(Publication.id).first()
+
+        assert pub.sulpub_json
+        assert (
+            pub.sulpub_json["title"] == "An example title with DOI in top level only"
+        ), "sulpub json updated"
+        assert pub.wos_json == {"wos": "data"}, "wos data the same"
+        assert pub.pubmed_json is None
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].cap_profile_id == "12345"
+        assert pub.authors[1].cap_profile_id == "123456"
+
+
+def test_harvest_when_author_exists(
+    tmp_path,
+    test_session,
+    mock_publication,
+    mock_authors,
+    mock_association,
+    requests_mock,
+):
+    requests_mock.get("/publications.json", json=response)
+    requests_mock.get("/publications.json?page=2", json={"records": []})
+
+    # harvest from sulpub
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    sul_pub.harvest(snapshot, sul_pub_host, sul_pub_key)
+
+    # jsonl file is there and ok
+    assert num_jsonl_objects(snapshot.path / "sulpub.jsonl") == 3
+
+    # ensure that the existing publication for the DOI was updated
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 2, "two publications loaded"
+        pub = session.query(Publication).order_by(Publication.id).first()
+
+        assert pub.sulpub_json
+        assert (
+            pub.sulpub_json["title"] == "An example title with DOI in top level only"
+        ), "sulpub json updated"
+        assert pub.wos_json == {"wos": "data"}, "wos data the same"
+        assert pub.pubmed_json is None
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].cap_profile_id == "12345"
+        assert pub.authors[1].cap_profile_id == "123456"
+
+
+def test_extract_wos_uid_from_top_level():
+    pub = {"wos_uid": "WOS:001008232900698"}
+    assert sul_pub.extract_wos_uid(pub) == "001008232900698"
+
+
+def test_extract_wos_uid_from_identifier_wos_uid_type():
+    pub = {"identifier": [{"type": "WosUID", "id": "WOS:001008232900698"}]}
+    assert sul_pub.extract_wos_uid(pub) == "001008232900698"
+
+
+def test_extract_wos_uid_from_identifier_wos_item_id_type():
+    pub = {"identifier": [{"type": "WoSItemID", "id": "001008232900698"}]}
+    assert sul_pub.extract_wos_uid(pub) == "001008232900698"
+
+
+def test_extract_wos_uid_from_identifier_alternate_wos_item_id_type():
+    pub = {"identifier": [{"type": "WosItemID", "id": "001008232900698"}]}
+    assert sul_pub.extract_wos_uid(pub) == "001008232900698"
+
+
+def test_extract_wos_uid_returns_none_when_absent():
+    pub = {"identifier": [{"type": "doi", "id": "10.1000/xyz123"}]}
+    assert sul_pub.extract_wos_uid(pub) is None
+
+
+def test_extract_pmid_from_top_level():
+    pub = {"pmid": 29780978}
+    assert sul_pub.extract_pmid(pub) == "29780978"
+
+
+def test_extract_pmid_from_identifier():
+    pub = {"identifier": [{"type": "pmid", "id": "29780978"}]}
+    assert sul_pub.extract_pmid(pub) == "29780978"
+
+
+def test_extract_pmid_from_identifier_uppercase_type():
+    pub = {"identifier": [{"type": "PMID", "id": "29780978"}]}
+    assert sul_pub.extract_pmid(pub) == "29780978"
+
+
+def test_extract_pmid_returns_none_when_absent():
+    pub = {"identifier": [{"type": "doi", "id": "10.1000/xyz123"}]}
+    assert sul_pub.extract_pmid(pub) is None

--- a/test/harvest_incremental/test_wos.py
+++ b/test/harvest_incremental/test_wos.py
@@ -1,0 +1,589 @@
+import logging
+import os
+import re
+
+import dotenv
+import pandas
+import pytest
+import requests
+
+from rialto_airflow.schema.harvest import Publication
+from rialto_airflow.harvest_incremental import wos
+from rialto_airflow.snapshot import Snapshot
+from test.utils import num_jsonl_objects, num_log_record_matches
+
+dotenv.load_dotenv()
+
+
+wos_key = os.environ.get("AIRFLOW_VAR_WOS_KEY")
+
+
+@pytest.fixture
+def mock_wos(monkeypatch):
+    """
+    Mock our function for fetching publications by orcid from Web of Science.
+    """
+
+    def f(*args, **kwargs):
+        yield {
+            "static_data": {
+                "summary": {
+                    "titles": {
+                        "title": [{"type": "source", "content": "An example title"}]
+                    }
+                }
+            },
+            "dynamic_data": {
+                "cluster_related": {
+                    "identifiers": {
+                        "identifier": [
+                            {"type": "issn", "value": "2211-9124"},
+                            {
+                                "type": "doi",
+                                "value": "https://doi.org/10.1515/9781503624153",
+                            },
+                        ]
+                    }
+                }
+            },
+        }
+
+    monkeypatch.setattr(wos, "orcid_publications", f)
+
+
+@pytest.fixture
+def mock_many_wos(monkeypatch):
+    """
+    A fixture for that returns 1000 fake documents from Web of Science.
+    """
+
+    def f(*args, **kwargs):
+        for n in range(1, 1000):
+            yield {"UID": f"mock:{n}"}
+
+    monkeypatch.setattr(wos, "orcid_publications", f)
+
+
+@pytest.fixture
+def existing_publication(test_session):
+    with test_session.begin() as session:
+        pub = Publication(
+            doi="10.1515/9781503624153",
+            sulpub_json={"sulpub": "data"},
+        )
+        session.add(pub)
+        return pub
+
+
+@pytest.fixture
+def mock_no_wos_publication(test_session):
+    with test_session.begin() as session:
+        pub = Publication(
+            doi="10.1515/9781503624199",
+            sulpub_json={"sulpub": "data"},
+            dim_json={"dim": "data"},
+        )
+        session.add(pub)
+        return pub
+
+
+@pytest.fixture
+def mock_wos_doi(monkeypatch):
+    """
+    Mock our function for fetching publications by DOI from Web of Science.
+    """
+
+    def f(*args, **kwargs):
+        yield {
+            "title": "An example title",
+            "type": "article",
+            "publication_year": 1891,
+            "dynamic_data": {
+                "cluster_related": {
+                    "identifiers": {
+                        "identifier": [
+                            {"type": "doi", "value": "10.1515/9781503624199"}
+                        ]
+                    }
+                }
+            },
+        }
+
+    monkeypatch.setattr(wos, "publications_from_dois", f)
+
+
+@pytest.mark.skipif(wos_key is None, reason="no Web of Science key")
+def test_orcid_publications_with_paging():
+    """
+    This is a live test of WoS API to ensure paging works properly.
+    """
+
+    # https://www-webofscience-com.stanford.idm.oclc.org/wos/alldb/advanced-search
+    # The ORCID that is tested should return more than 200 results to exercise paging
+    orcid = "https://orcid.org/0000-0002-0673-5257"
+
+    uids = set()
+    for pub in wos.orcid_publications(orcid):
+        assert pub
+        assert pub["UID"] not in uids, "haven't seen publication before"
+        uids.add(pub["UID"])
+
+    assert len(uids) > 200, "found more than 200 publications"
+
+
+@pytest.mark.skipif(wos_key is None, reason="no Web of Science key")
+def test_orcid_publications_with_bad_orcid():
+    """
+    This is a live test of the WoS API to ensure that a search for an invalid ORCID yields no results.
+    """
+    assert (
+        len(list(wos.orcid_publications("https://orcid.org/0000-0003-0784-7987-XXX")))
+        == 0
+    )
+
+
+def test_harvest(tmp_path, test_session, mock_authors, mock_wos):
+    """
+    With some authors loaded and a mocked WoS API make sure that a
+    publication is matched up to the authors using the ORCID.
+    """
+    # harvest from Web of Science
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    wos.harvest(snapshot)
+
+    # the mocked Web of Science api returns the same publication for both authors
+    assert num_jsonl_objects(snapshot.path / "wos.jsonl") == 2
+
+    # make sure a publication is in the database and linked to the author
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publication loaded"
+
+        pub = session.query(Publication).first()
+        assert pub.doi == "10.1515/9781503624153", "doi was normalized"
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_harvest_when_doi_exists(
+    tmp_path, test_session, existing_publication, mock_authors, mock_wos
+):
+    """
+    When a publication and its authors already exist in the database make sure that the wos_json is updated.
+    """
+    # harvest from web of science
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    wos.harvest(snapshot)
+
+    # jsonl file is there and has two lines (one for each author)
+    assert num_jsonl_objects(snapshot.path / "wos.jsonl") == 2
+
+    # ensure that the existing publication for the DOI was updated
+    with test_session.begin() as session:
+        assert session.query(Publication).count() == 1, "one publication loaded"
+        pub = session.query(Publication).first()
+
+        assert pub.wos_json
+        assert pub.sulpub_json == {"sulpub": "data"}, "sulpub data the same"
+        assert pub.pubmed_json is None
+
+        assert len(pub.authors) == 2, "publication has two authors"
+        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def test_log_message(tmp_path, mock_authors, mock_many_wos, caplog):
+    caplog.set_level(logging.INFO)
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    wos.harvest(snapshot, limit=50)
+    assert "Reached limit of 50 publications stopping" in caplog.text
+
+
+def test_customization_error(
+    test_session, tmp_path, caplog, mock_authors, requests_mock
+):
+    """
+    A 500 error (with a specific JSON error payload) we've seen from WoS.
+    Now handled like any other 500 error, but confirm that we get the error
+    message on the same log line as the HTTP error code.
+    """
+    requests_mock.get(
+        re.compile(".*"),
+        json={"message": "Customization error"},
+        status_code=500,
+        headers={"Content-Type": "application/json"},
+    )
+
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    wos.harvest(snapshot, limit=50)
+    assert test_session().query(Publication).count() == 0, "no publications loaded"
+    assert re.search("500 Server Error.*Customization error", caplog.text)
+
+
+def test_not_found_error(test_session, tmp_path, caplog, mock_authors, requests_mock):
+    """
+    A 404 error from WoS should be logged, but should not stop harvesting.
+    """
+    requests_mock.get(
+        re.compile(".*"),
+        text="Not Found",
+        reason="Not Found",
+        status_code=404,
+        headers={"Content-Type": "application/text"},
+    )
+
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    wos.harvest(snapshot, limit=50)
+    assert test_session().query(Publication).count() == 0, "no publications loaded"
+    assert (
+        "404 Client Error: Not Found for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK&usrQuery=AI"
+        in caplog.text
+    )
+
+
+def test_server_error(test_session, tmp_path, caplog, mock_authors, requests_mock):
+    """
+    A 500 error from WoS should be logged, but should not stop harvesting.
+    """
+    requests_mock.get(
+        re.compile(".*"),
+        text="shrug",
+        reason="Internal Server Error",
+        status_code=500,
+        headers={"Content-Type": "application/text"},
+    )
+
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    wos.harvest(snapshot, limit=50)
+    assert test_session().query(Publication).count() == 0, "no publications loaded"
+    assert (
+        "500 Server Error: Internal Server Error for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK&usrQuery=AI"
+        in caplog.text
+    )
+    assert " -- shrug" in caplog.text
+
+
+def test_empty_payload(test_session, tmp_path, caplog, mock_authors, requests_mock):
+    """
+    A 200 OK from WoS with an empty JSON payload should be skipped over.
+    """
+    requests_mock.get(re.compile(".*"), text="", status_code=200)
+
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+    wos.harvest(snapshot, limit=50)
+
+    assert test_session().query(Publication).count() == 0, "no publications loaded"
+    assert "got empty string instead of JSON" in caplog.text
+
+
+def test_bad_wos_json(test_session, tmp_path, caplog, mock_authors, requests_mock):
+    """
+    A 200 OK from WoS with an empty JSON payload should be skipped over.
+    """
+    requests_mock.get(re.compile(".*"), text="ffff", status_code=200)
+
+    snapshot = Snapshot.create(tmp_path, "rialto_test")
+
+    with pytest.raises(requests.exceptions.JSONDecodeError):
+        wos.harvest(snapshot, limit=50)
+
+    assert "uhoh, instead of JSON we got: ffff" in caplog.text
+
+
+def test_get_doi(caplog):
+    wos_json_id_list = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {
+                    "identifier": [
+                        {"type": "issn", "value": "1234-5678"},
+                        {"type": "doi", "value": "abc12310.1234/abc123"},
+                    ]
+                }
+            }
+        }
+    }
+    assert wos.get_doi(wos_json_id_list) == "10.1234/abc123"
+
+    wos_json_single_id = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {
+                    "identifier": {"type": "doi", "value": "abc12310.1234/abc123"}
+                }
+            }
+        }
+    }
+    assert wos.get_doi(wos_json_single_id) == "10.1234/abc123"
+
+    wos_json_no_doi = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {"identifier": {"type": "issn", "value": "1234-5678"}}
+            }
+        }
+    }
+    assert wos.get_doi(wos_json_no_doi) is None
+
+    wos_json_no_id: dict = {"dynamic_data": {"cluster_related": {"identifiers": {}}}}
+    assert wos.get_doi(wos_json_no_id) is None
+
+    wos_json_identifiers_empty_string: dict = {
+        "UID": "WOS:000089165000013",
+        "dynamic_data": {"cluster_related": {"identifiers": ""}},
+    }
+    assert wos.get_doi(wos_json_identifiers_empty_string) is None
+    assert "WOS:000089165000013" not in caplog.text
+
+    wos_json_identifiers_nonempty_string: dict = {
+        "UID": "WOS:000089165000014",
+        "dynamic_data": {"cluster_related": {"identifiers": "abc123"}},
+    }
+    assert wos.get_doi(wos_json_identifiers_nonempty_string) == "abc123"
+    assert "WOS:000089165000014" not in caplog.text
+
+    wos_json_no_cluster_related_empty_string: dict = {
+        "UID": "WOS:000012345000067",
+        "dynamic_data": {"cluster_related": ""},
+    }
+    assert wos.get_doi(wos_json_no_cluster_related_empty_string) is None
+    assert (
+        "error 'str' object has no attribute 'get' trying to parse identifiers from {'UID': 'WOS:000012345000067'"
+        in caplog.text
+    )
+
+
+def test_fill_in(snapshot, test_session, mock_no_wos_publication, mock_wos_doi, caplog):
+    caplog.set_level(logging.INFO)
+    wos.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624199")
+            .first()
+        )
+        assert pub.wos_json == {
+            "title": "An example title",
+            "type": "article",
+            "publication_year": 1891,
+            "dynamic_data": {
+                "cluster_related": {
+                    "identifiers": {
+                        "identifier": [
+                            {"type": "doi", "value": "10.1515/9781503624199"}
+                        ]
+                    }
+                }
+            },
+        }
+
+    # adds 1 publication to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "wos-fillin.jsonl") == 1
+    assert "filled in 1 publications" in caplog.text
+
+
+def test_fill_in_no_wos(
+    snapshot,
+    test_session,
+    mock_publication,
+    mock_no_wos_publication,
+    caplog,
+    monkeypatch,
+):
+    caplog.set_level(logging.INFO)
+
+    # make it look like wos returns no publications by DOI
+    monkeypatch.setattr(wos, "publications_from_dois", lambda *args, **kwargs: [])
+    wos.fill_in(snapshot)
+
+    with test_session.begin() as session:
+        pub = (
+            session.query(Publication)
+            .where(Publication.doi == "10.1515/9781503624199")
+            .first()
+        )
+        assert pub.wos_json is None
+
+    # adds 0 publications to the jsonl file
+    assert num_jsonl_objects(snapshot.path / "wos-fillin.jsonl") == 0
+    assert "filled in 0 publications" in caplog.text
+
+
+@pytest.mark.skipif(wos_key is None, reason="no Web of Science key")
+def test_publications_from_dois():
+    # there are 231 DOIs in this list and publications_from_dois look them up in batches of 50
+    dois = list(pandas.read_csv("test/data/dois.csv").doi)
+
+    pubs = list(wos.publications_from_dois(dois))
+
+    # the number of pubs we get back should exceed the batch size if the paging is working
+    assert len(pubs) > 50
+
+
+@pytest.mark.skipif(wos_key is None, reason="no Web of Science key")
+@pytest.mark.skip(
+    reason="API unexpectedly dropping result for 10.1061/(asce)0733-9429(1997)123:9(828)"
+)  # https://github.com/sul-dlss/rialto-airflow/issues/800
+def test_get_list_of_publications_from_dois():
+    """
+    This is a live test of WoS API to ensure we can query by DOI even if it includes a parens in it
+    """
+
+    dois = [
+        "10.1061/(asce)0733-9429(1997)123:9(828)",  # DOI with a parens
+        "10.1002/adma.202103646",
+        "10.1001/jamacardio.2021.6059",
+        "10.1021/ef'7003333",  # DOI with a single quote
+        "doi_not_found",  # not found DOI, not really a DOI
+        '10.1021/ef"7003333',  # DOI with a double quote
+    ]
+
+    pubs = list(wos.publications_from_dois(dois))
+
+    assert len(pubs) == 3, "returns all three publications that are actually found"
+
+
+@pytest.fixture
+def mock_wos_api(monkeypatch):
+    def f(*args, **kwargs):
+        query = args[0]
+        if "my.unretrievable" in query:
+            raise requests.exceptions.HTTPError(
+                "https://wos-api.clarivate.com/api/wos?thisrequest=wontwork",
+                400,
+                "Server.Parser.NO_MATCHRULE, Translation Exception : NO_MATCHRULE:No matching rule found",
+            )
+
+        # NOTE: the below is not at all similar to the real API response, and
+        # would have to be fleshed out if this mock was used for anything that
+        # tries to use an API result.
+        yield {"key": "value"}
+
+    monkeypatch.setattr(wos, "_wos_api", f)
+
+
+def test_publications_from_doi_batch_with_error_doi(mock_wos_api, caplog):
+    dois = [
+        "10.29309/tpmj/2015.22.05.1304",
+        "10.1337/my.unretrievable.D01",  # should error in batch, and individually
+        "10.1021/nl401130d",
+        "10.1097/pcc.0000000000003026",
+        "10.2331/suisan.19.1069",
+        "10.1103/physrevb.53.r4221",
+        "10.1130/b31546.1",
+    ]
+
+    pubs = list(wos.publications_from_dois(dois))
+
+    assert len(pubs) == 6  # 6 of the 7 DOIs should return a result without error
+    assert re.search(
+        f"Unexpected error querying for DOIs in DOI batch, trying one at a time.*{dois[0]}.*{dois[-1]}.*error.*400: 'Server.Parser.NO_MATCHRULE, Translation Exception : NO_MATCHRULE:No matching rule found",
+        caplog.text,
+    )
+    assert (
+        'Unexpected error querying for single DOI from larger batch.  DOI="10.1337/my.unretrievable.D01"'
+        in caplog.text
+    )
+
+
+@pytest.fixture
+def mock_response_500(monkeypatch):
+    """
+    NOTE: The text property of the returned requests.Response object can be
+    referenced without error; we just had trouble overriding it when first
+    implementing this fixture, and overriding it wasn't essential to the tests
+    first using the fixture.
+    """
+
+    def raise_for_status():
+        raise requests.exceptions.HTTPError(
+            "https://rest.service/api/path?param=value",
+            500,
+            "🤮",
+        )
+
+    mock_resp = requests.Response()
+    monkeypatch.setattr(mock_resp, "raise_for_status", raise_for_status)
+    return mock_resp
+
+
+@pytest.fixture
+def mock_response_200(monkeypatch):
+    def raise_for_status():
+        pass
+
+    mock_resp = requests.Response()
+    monkeypatch.setattr(mock_resp, "raise_for_status", raise_for_status)
+    return mock_resp
+
+
+def test_check_status_should_raise_true(mock_response_500, mock_response_200, caplog):
+    with pytest.raises(requests.exceptions.HTTPError):
+        wos.check_status(resp=mock_response_500, should_raise_for_status=True)
+
+    assert (
+        wos.check_status(resp=mock_response_200, should_raise_for_status=True) is True
+    )
+
+    assert num_log_record_matches(caplog.records, logging.ERROR, "🤮") == 1
+
+
+def test_check_status_should_raise_false(mock_response_500, mock_response_200, caplog):
+    assert (
+        wos.check_status(resp=mock_response_500, should_raise_for_status=False) is False
+    )
+    assert (
+        wos.check_status(resp=mock_response_200, should_raise_for_status=False) is True
+    )
+
+    assert num_log_record_matches(caplog.records, logging.ERROR, "🤮") == 1
+
+
+def test_get_pmid_from_identifier_list():
+    pub = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {
+                    "identifier": [
+                        {"type": "issn", "value": "1234-5678"},
+                        {"type": "pmid", "value": "29780978"},
+                    ]
+                }
+            }
+        }
+    }
+    assert wos.get_pmid(pub) == "29780978"
+
+
+def test_get_pmid_from_single_identifier_dict():
+    pub = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {"identifier": {"type": "pmid", "value": "29780978"}}
+            }
+        }
+    }
+    assert wos.get_pmid(pub) == "29780978"
+
+
+def test_get_pmid_returns_none_when_no_pmid():
+    pub = {
+        "dynamic_data": {
+            "cluster_related": {
+                "identifiers": {"identifier": [{"type": "issn", "value": "1234-5678"}]}
+            }
+        }
+    }
+    assert wos.get_pmid(pub) is None
+
+
+def test_get_pmid_returns_none_when_identifiers_not_dict():
+    pub = {"dynamic_data": {"cluster_related": {"identifiers": "some_string"}}}
+    assert wos.get_pmid(pub) is None
+
+
+def test_get_pmid_returns_none_on_attribute_error():
+    pub = {"dynamic_data": {"cluster_related": None}}
+    assert wos.get_pmid(pub) is None


### PR DESCRIPTION
**What was changed?**
Closes #840 to create a DAG for incremental harvest, set up side-by-side with the existing harvest DAG, and simply as a copy of the code to start. 

Note that the issue specified calling the DAG `harvest2`, but I called it `harvest_incremental` here. Open to changing it back to `harvest2` if that's preferred. 
