### PR TITLE
use mais orcid prod API for consistency in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,11 @@ Note that if you have hard-coded values in the compose.yml files, they will over
 For MaIS tests, update your .env with values shown below / pulled from vault as indicated:
 
 ```
-AIRFLOW_VAR_MAIS_TOKEN_URL=https://mais-uat.auth.us-west-2.amazoncognito.com
-AIRFLOW_VAR_MAIS_BASE_URL=https://mais.suapiuat.stanford.edu
-AIRFLOW_VAR_MAIS_CLIENT_ID=${get from vault at `puppet/application/rialto-airflow/test/mais_client_id`}
-AIRFLOW_VAR_MAIS_SECRET=${get from vault at `puppet/application/rialto-airflow/test/mais_secret`}
+AIRFLOW_VAR_MAIS_CLIENT_ID=${get from vault at `puppet/application/rialto-airflow/prod/mais_client_id`}
+AIRFLOW_VAR_MAIS_SECRET=${get from vault at `puppet/application/rialto-airflow/prod/mais_secret`}
 ```
 
-Note: The MaIS `test_mais.py` file depends on the MaIS API being configured specifically with the UAT (not prod) credentials.  If no credentials are available in the environment variables, the tests will be skipped completely.  If production credentials are supplied, some of the tests may fail, since they assert checks against UAT data.
+Note: The MaIS `test_mais.py` file depends on the MaIS API being configured specifically with PROD credentials (which is the default in the compose.yaml file).  If no credentials are available in the environment variables, the tests will be skipped completely.  If UAT credentials are supplied, some of the tests may fail, since they assert checks against Prod data.
 
 ### Test coverage reporting
 

--- a/rialto_airflow/mais.py
+++ b/rialto_airflow/mais.py
@@ -121,7 +121,11 @@ def fetch_orcid_user(access_token: str, base_url: str, user_id: str) -> ORCIDRec
 
 
 def current_orcid_users(
-    mais_client_id: str, mais_client_secret: str, mais_token_url: str, base_url: str
+    mais_client_id: str,
+    mais_client_secret: str,
+    mais_token_url: str,
+    base_url: str,
+    limit: Optional[int] = None,
 ) -> list[ORCIDRecord]:
     """Retrieves the current ORCID records from the MAIS ORCID API."""
 
@@ -129,7 +133,7 @@ def current_orcid_users(
         raise ValueError("AIRFLOW_VAR_MAIS_BASE_URL is a required value")
 
     all_users = fetch_orcid_users(
-        mais_client_id, mais_client_secret, mais_token_url, base_url
+        mais_client_id, mais_client_secret, mais_token_url, base_url, limit
     )
 
     # Create a dictionary to store the most recent record for each ORCID iD

--- a/test/test_mais.py
+++ b/test/test_mais.py
@@ -86,24 +86,21 @@ def test_fetch_orcid_users_with_limit(client_id, client_secret, token_url, base_
 def test_fetch_orcid_user_valid_id(access_token, base_url, client_id, client_secret):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
-    orcid_id = "https://sandbox.orcid.org/0000-0002-4589-7232"  # Example Valid ID
+    orcid_id = "https://orcid.org/0000-0002-1859-6354"  # Example Valid ID
     user_data = mais.fetch_orcid_user(access_token, base_url, orcid_id)
     assert isinstance(user_data, dict)
 
 
-def test_current_orcid_users(
-    client_id, client_secret, token_url, base_url, monkeypatch
-):
+def test_current_orcid_users(client_id, client_secret, token_url, base_url):
     if not (client_secret and client_id):
         pytest.skip("No MAIS credentials available")
-    monkeypatch.setattr(
-        mais, "page_size", lambda *args: 5
-    )  # monkey patch a smaller page size so we can hit the paging code in UAT
+    limit = 50  # don't hit all prod data, it takes too long
     current_users = mais.current_orcid_users(
-        client_id, client_secret, token_url, base_url
+        client_id, client_secret, token_url, base_url, limit
     )
     assert isinstance(current_users, list)
     assert len(current_users) > 0
+    assert len(current_users) == limit  # there are at least this many users in prod
     seen_orcids = set()
     for user in current_users:
         orcid_id = user.get("orcid_id")


### PR DESCRIPTION
**What was changed?**

Fixes #421  Allows us to test against the Mais ORCID Prod API, instead of UAT.  This allows us to run a local harvest against prod data without having to reconfigure our local .env just to run the tests.

In order to complete this work, we need to: 

- [x] update env values for Mais API for the client_id and client_secret in github secrets to use prod values (CI will fail until we do this)
- [ ] remind devs to update their local .env file to use prod credentials (else local MaIS tests will fail)
- [x] remove vault values from `puppet/application/rialto-airflow/test`
