### PR TITLE
Harvest dimensions incrementally

### DIFF
--- a/rialto_airflow/harvest_incremental/dimensions.py
+++ b/rialto_airflow/harvest_incremental/dimensions.py
@@ -36,8 +36,7 @@ def harvest(limit: None | int = None) -> None:
     with get_session(RIALTO_DB_NAME).begin() as select_session:
         previous_harvest = Harvest.get_previous()
         previous_harvest_date = None
-        if previous_harvest is not None and previous_harvest.created_at is not None:
-            # Dimensions expects the date in YYYY-MM-DD format.
+        if previous_harvest is not None:
             previous_harvest_date = previous_harvest.created_at.strftime("%Y-%m-%d")
 
         # get all authors that have an ORCID

--- a/rialto_airflow/harvest_incremental/dimensions.py
+++ b/rialto_airflow/harvest_incremental/dimensions.py
@@ -33,6 +33,12 @@ def harvest(limit: None | int = None) -> None:
     stop = False
 
     with get_session(RIALTO_DB_NAME).begin() as select_session:
+        previous_harvest = Harvest.get_previous()
+        previous_harvest_date = None
+        if previous_harvest is not None and previous_harvest.created_at is not None:
+            # Dimensions expects the date in YYYY-MM-DD format.
+            previous_harvest_date = previous_harvest.created_at.strftime("%Y-%m-%d")
+
         # get all authors that have an ORCID
         for author in (
             select_session.query(Author).where(Author.orcid.is_not(None)).all()
@@ -41,7 +47,9 @@ def harvest(limit: None | int = None) -> None:
                 logging.warning(f"Reached limit of {limit} publications stopping")
                 break
 
-            for dimensions_pub_json in publications_from_orcid(author.orcid):
+            for dimensions_pub_json in publications_from_orcid(
+                author.orcid, harvest_date=previous_harvest_date
+            ):
                 count += 1
                 if limit is not None and count > limit:
                     stop = True
@@ -103,23 +111,14 @@ def publications_from_dois(dois: list, batch_size=200):
             yield normalize_publication(pub)
 
 
-def publications_from_orcid(orcid: str, batch_size=200):
+def publications_from_orcid(orcid: str, batch_size=200, harvest_date=None):
     """
     Get the publications metadata for a given ORCID, for records created (inserted) since the last harvest.
     """
-    previous_harvest = Harvest.get_previous()
-    # Dimensions expects the date in YYYY-MM-DD format.
-    previous_harvest_date = None
-    if previous_harvest is not None and previous_harvest.created_at is not None:
-        previous_harvest_date = previous_harvest.created_at.strftime("%Y-%m-%d")
     orcid = normalize_orcid(orcid)
     logging.debug(f"looking up publications for orcid {orcid}")
     fields = " + ".join(publication_fields())
-    date_limit = (
-        f' and date_inserted >= "{previous_harvest_date}"'
-        if previous_harvest_date
-        else ""
-    )
+    date_limit = f' and date_inserted >= "{harvest_date}"' if harvest_date else ""
     q = f"""
         search publications where researchers.orcid_id = "{orcid}"{date_limit}
         return publications[{fields}]

--- a/rialto_airflow/harvest_incremental/dimensions.py
+++ b/rialto_airflow/harvest_incremental/dimensions.py
@@ -29,7 +29,8 @@ def harvest(limit: None | int = None) -> None:
     """
     Walk through all the Author ORCIDs and generate publications for them.
     """
-    count = 0
+    pub_count = 0
+    author_count = 0
     stop = False
 
     with get_session(RIALTO_DB_NAME).begin() as select_session:
@@ -43,15 +44,33 @@ def harvest(limit: None | int = None) -> None:
         for author in (
             select_session.query(Author).where(Author.orcid.is_not(None)).all()
         ):
+            author_count += 1
+            if limit is not None and author_count > limit:
+                stop = True
+
             if stop is True:
-                logging.warning(f"Reached limit of {limit} publications stopping")
+                logging.warning(
+                    f"Reached limit of {limit} publications or authors, stopping"
+                )
                 break
+
+            # if the author was created or updated after the last harvest (e.g. adding an ORCID),
+            # we want to get all their publications, not just ones since the last harvest timestamp.
+            if previous_harvest is not None:
+                # TODO: remove the created_at check once updated_at gets populated upon create
+                if author.created_at >= previous_harvest.created_at:
+                    previous_harvest_date = None
+                elif (
+                    author.updated_at is not None
+                    and author.updated_at >= previous_harvest.created_at
+                ):
+                    previous_harvest_date = None
 
             for dimensions_pub_json in publications_from_orcid(
                 author.orcid, harvest_date=previous_harvest_date
             ):
-                count += 1
-                if limit is not None and count > limit:
+                pub_count += 1
+                if limit is not None and pub_count > limit:
                     stop = True
                     break
 

--- a/rialto_airflow/harvest_incremental/dimensions.py
+++ b/rialto_airflow/harvest_incremental/dimensions.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import time
@@ -10,12 +11,13 @@ from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert
 
 from rialto_airflow.database import get_session
-from rialto_airflow.schema.harvest import (
+from rialto_airflow.schema.rialto import (
+    Harvest,
     Author,
     Publication,
     pub_author_association,
+    RIALTO_DB_NAME,
 )
-from rialto_airflow.schema.rialto import RIALTO_DB_NAME
 from rialto_airflow.utils import (
     normalize_doi,
     normalize_orcid,
@@ -52,6 +54,7 @@ def harvest(limit: None | int = None) -> None:
                     else None
                 )
                 with get_session(RIALTO_DB_NAME).begin() as insert_session:
+                    harvested_at = datetime.datetime.now(datetime.timezone.utc)
                     # if there's a DOI constraint violation, update the existing row's JSON
                     pub_id = insert_session.execute(
                         insert(Publication)
@@ -59,11 +62,14 @@ def harvest(limit: None | int = None) -> None:
                             doi=doi,
                             dim_json=dimensions_pub_json,
                             pubmed_id=pubmed_id,
+                            dim_harvested=harvested_at,
                         )
                         .on_conflict_do_update(
                             constraint="publication_doi_key",
                             set_=dict(
-                                dim_json=dimensions_pub_json, pubmed_id=pubmed_id
+                                dim_json=dimensions_pub_json,
+                                pubmed_id=pubmed_id,
+                                dim_harvested=harvested_at,
                             ),
                         )
                         .returning(Publication.id)
@@ -99,16 +105,25 @@ def publications_from_dois(dois: list, batch_size=200):
 
 def publications_from_orcid(orcid: str, batch_size=200):
     """
-    Get the publications metadata for a given ORCID.
+    Get the publications metadata for a given ORCID, for records created (inserted) since the last harvest.
     """
+    previous_harvest = Harvest.get_previous()
+    # Dimensions expects the date in YYYY-MM-DD format.
+    previous_harvest_date = None
+    if previous_harvest is not None and previous_harvest.created_at is not None:
+        previous_harvest_date = previous_harvest.created_at.strftime("%Y-%m-%d")
     orcid = normalize_orcid(orcid)
     logging.debug(f"looking up publications for orcid {orcid}")
     fields = " + ".join(publication_fields())
+    date_limit = (
+        f' and date_inserted >= "{previous_harvest_date}"'
+        if previous_harvest_date
+        else ""
+    )
     q = f"""
-        search publications where researchers.orcid_id = "{orcid}"
+        search publications where researchers.orcid_id = "{orcid}"{date_limit}
         return publications[{fields}]
         """
-
     result = query_with_retry(q, retry=5)
     for pub in result["publications"]:
         yield normalize_publication(pub)
@@ -272,7 +287,10 @@ def fill_in():
                     update_stmt = (
                         update(Publication)
                         .where(Publication.doi == doi)
-                        .values(dim_json=dimensions_pub, pubmed_id=pubmed_id)
+                        .values(
+                            dim_json=dimensions_pub,
+                            pubmed_id=pubmed_id,
+                        )
                     )
                     update_session.execute(update_stmt)
 

--- a/rialto_airflow/schema/rialto.py
+++ b/rialto_airflow/schema/rialto.py
@@ -66,15 +66,17 @@ class Publication(RialtoSchemaBase):
     crossref_json: Mapped[Optional[dict]] = mapped_column(JSONB(none_as_null=True))
     wos_id: Mapped[Optional[str]] = mapped_column(String)
     pubmed_id: Mapped[Optional[str]] = mapped_column(String)
-    openalex_harvested: Mapped[Optional[DateTime]] = mapped_column(DateTime)
-    dim_harvested: Mapped[Optional[DateTime]] = mapped_column(DateTime)
-    sulpub_harvested: Mapped[Optional[DateTime]] = mapped_column(DateTime)
-    wos_harvested: Mapped[Optional[DateTime]] = mapped_column(DateTime)
-    pubmed_harvested: Mapped[Optional[DateTime]] = mapped_column(DateTime)
-    created_at: Mapped[Optional[DateTime]] = mapped_column(
+    openalex_harvested: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime)
+    dim_harvested: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime)
+    sulpub_harvested: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime)
+    wos_harvested: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime)
+    pubmed_harvested: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime)
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime, server_default=utcnow()
     )
-    updated_at: Mapped[Optional[DateTime]] = mapped_column(DateTime, onupdate=utcnow())
+    updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime, onupdate=utcnow()
+    )
     types: Mapped[Optional[List[str]]] = mapped_column(ARRAY(String))
     publisher: Mapped[Optional[str]] = mapped_column(String)
     journal_name: Mapped[Optional[str]] = mapped_column(String)
@@ -119,10 +121,12 @@ class Author(RialtoSchemaBase):
     primary_school: Mapped[Optional[str]] = mapped_column(String)
     primary_dept: Mapped[Optional[str]] = mapped_column(String)
     primary_division: Mapped[Optional[str]] = mapped_column(String)
-    created_at: Mapped[Optional[DateTime]] = mapped_column(
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime, server_default=utcnow()
     )
-    updated_at: Mapped[Optional[DateTime]] = mapped_column(DateTime, onupdate=utcnow())
+    updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime, onupdate=utcnow()
+    )
     publications: Mapped[List["Publication"]] = relationship(
         "Publication", secondary=pub_author_association, back_populates="authors"
     )
@@ -137,10 +141,12 @@ class Funder(RialtoSchemaBase):
     ror_id: Mapped[Optional[str]] = mapped_column(String, unique=True)
     openalex_id: Mapped[Optional[str]] = mapped_column(String, unique=True)
     federal: Mapped[Optional[bool]] = mapped_column(Boolean, default=False)
-    created_at: Mapped[Optional[DateTime]] = mapped_column(
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime, server_default=utcnow()
     )
-    updated_at: Mapped[Optional[DateTime]] = mapped_column(DateTime, onupdate=utcnow())
+    updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime, onupdate=utcnow()
+    )
     publications: Mapped[List["Publication"]] = relationship(
         "Publication", secondary=pub_funder_association, back_populates="funders"
     )
@@ -150,8 +156,10 @@ class Harvest(RialtoSchemaBase):
     __tablename__ = "harvest"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    finished_at: Mapped[Optional[DateTime]] = mapped_column(DateTime, nullable=True)
-    created_at: Mapped[Optional[DateTime]] = mapped_column(
+    finished_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime, server_default=utcnow()
     )
 

--- a/rialto_airflow/schema/rialto.py
+++ b/rialto_airflow/schema/rialto.py
@@ -141,7 +141,7 @@ class Funder(RialtoSchemaBase):
     ror_id: Mapped[Optional[str]] = mapped_column(String, unique=True)
     openalex_id: Mapped[Optional[str]] = mapped_column(String, unique=True)
     federal: Mapped[Optional[bool]] = mapped_column(Boolean, default=False)
-    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+    created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime, server_default=utcnow()
     )
     updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
@@ -159,7 +159,7 @@ class Harvest(RialtoSchemaBase):
     finished_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime, nullable=True
     )
-    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+    created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime, server_default=utcnow()
     )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -206,11 +206,6 @@ def snapshot(tmp_path):
 
 
 @pytest.fixture
-def snapshot_incremental(tmp_path):
-    return Snapshot.create(data_dir=tmp_path, database_name="rialto_incremental_test")
-
-
-@pytest.fixture
 def test_incremental_engine(monkeypatch):
     """
     This pytest fixture will ensure that the rialto_incremental_test database exists and has

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm.session import close_all_sessions
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from rialto_airflow.database import create_schema, engine_setup
+from rialto_airflow.harvest_incremental import dimensions
 from rialto_airflow.schema.harvest import (
     HarvestSchemaBase,
     Author,
@@ -14,6 +15,7 @@ from rialto_airflow.schema.harvest import (
     pub_author_association,
 )
 from rialto_airflow.schema.reports import ReportsSchemaBase
+from rialto_airflow.schema import rialto
 from rialto_airflow.schema.rialto import RialtoSchemaBase
 from rialto_airflow.schema.rialto import Author as RialtoAuthor
 from rialto_airflow.schema.rialto import Publication as RialtoPublication
@@ -69,6 +71,12 @@ def test_session(test_engine):
         yield sessionmaker(test_engine)
     finally:
         close_all_sessions()
+
+
+@pytest.fixture
+def mock_rialto_db_name(monkeypatch):
+    monkeypatch.setattr(rialto, "RIALTO_DB_NAME", "rialto_incremental_test")
+    monkeypatch.setattr(dimensions, "RIALTO_DB_NAME", "rialto_incremental_test")
 
 
 @pytest.fixture

--- a/test/harvest_incremental/test_dimensions.py
+++ b/test/harvest_incremental/test_dimensions.py
@@ -70,25 +70,6 @@ def test_publication_fields():
     assert "book" in fields
 
 
-def test_previous_harvest_date_formatting(
-    test_incremental_session, mock_rialto_db_name
-):
-    """Test that previous harvest date is correctly formatted as YYYY-MM-DD."""
-    with test_incremental_session.begin() as session:
-        harvest = Harvest(
-            created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
-            finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
-        )
-        session.add(harvest)
-
-    previous_harvest = Harvest.get_previous()
-    assert previous_harvest is not None
-    assert previous_harvest.created_at is not None
-
-    previous_harvest_date = previous_harvest.created_at.strftime("%Y-%m-%d")
-    assert previous_harvest_date == "2026-04-27", "date formatted as YYYY-MM-DD"
-
-
 def test_harvest_passes_previous_harvest_date_to_orcid_query(
     test_incremental_session,
     mock_incremental_authors,
@@ -102,7 +83,7 @@ def test_harvest_passes_previous_harvest_date_to_orcid_query(
                 finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
             )
         )
-        # Make sure Authors are similar to those loaded in productio, with created_at dates.
+        # Make sure Authors are similar to those loaded in production, with created_at dates.
         session.query(Author).where(Author.orcid.is_not(None)).update(
             {
                 Author.created_at: datetime.datetime(2026, 4, 20, 0, 0, 0),
@@ -113,15 +94,20 @@ def test_harvest_passes_previous_harvest_date_to_orcid_query(
     harvest_dates = []
 
     def _capture_harvest_date(orcid, harvest_date=None):
+        # capture the harvest_date that is passed to publications_from_orcid so that we can assert on it later
         harvest_dates.append(harvest_date)
-        return iter(())
+        yield from ()
 
     monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_harvest_date)
 
     dimensions.harvest()
 
-    assert harvest_dates, "publications_from_orcid should be called for ORCID authors"
-    assert set(harvest_dates) == {"2026-04-27"}
+    assert harvest_dates, (
+        "publications_from_orcid is passed the recent finished harvest date"
+    )
+    assert set(harvest_dates) == {"2026-04-27"}, (
+        "formatted previous harvest date passed to publications_from_orcid"
+    )
 
 
 def test_harvest_omits_previous_harvest_date_for_recently_created_authors(
@@ -147,15 +133,19 @@ def test_harvest_omits_previous_harvest_date_for_recently_created_authors(
     harvest_dates = []
 
     def _capture_harvest_date(orcid, harvest_date=None):
+        # capture the harvest_date that is passed
+        # don't return results since we're just testing the harvest_date logic.
         harvest_dates.append(harvest_date)
-        return iter(())
+        yield from ()
 
     monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_harvest_date)
 
     dimensions.harvest()
 
-    assert harvest_dates, "publications_from_orcid should be called for ORCID authors"
-    assert set(harvest_dates) == {None}
+    assert harvest_dates, "publications_from_orcid should be called for authors"
+    assert set(harvest_dates) == {None}, (
+        "previous harvest date should be omitted for recently created authors"
+    )
 
 
 def test_harvest_omits_previous_harvest_date_for_recently_updated_authors(
@@ -182,34 +172,25 @@ def test_harvest_omits_previous_harvest_date_for_recently_updated_authors(
 
     def _capture_harvest_date(orcid, harvest_date=None):
         harvest_dates.append(harvest_date)
-        return iter(())
+        yield from ()
 
     monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_harvest_date)
 
     dimensions.harvest()
 
-    assert harvest_dates, "publications_from_orcid should be called for ORCID authors"
-    assert set(harvest_dates) == {None}
+    assert harvest_dates, (
+        "publications_from_orcid should be called with harvest_date for ORCID authors"
+    )
+    assert set(harvest_dates) == {None}, (
+        "previous harvest date should be omitted for recently updated authors"
+    )
 
 
-def test_publications_from_orcid(test_incremental_session, mock_rialto_db_name):
-    with test_incremental_session.begin() as session:
-        # Creating a previous harvest far enough back (2010) to get a large and consistent
-        # set of publications from the API.
-        session.add(
-            Harvest(
-                created_at=datetime.datetime(2010, 4, 27, 16, 38, 10),
-                finished_at=datetime.datetime(2010, 4, 28, 0, 0, 0),
-            )
-        )
-    previous_harvest = Harvest.get_previous()
-    if previous_harvest is not None and previous_harvest.created_at is not None:
-        previous_harvest_date = previous_harvest.created_at.strftime("%Y-%m-%d")
-    assert previous_harvest_date == "2010-04-27"
-
+def test_publications_from_orcid(mock_rialto_db_name):
     pubs = list(
         dimensions.publications_from_orcid(
-            "0000-0002-2317-1967", harvest_date=previous_harvest_date
+            "0000-0002-2317-1967",
+            harvest_date="2010-04-27",  # using the same date as the previous harvest to get a consistent set of publications
         )
     )
     assert len(pubs) == 17
@@ -376,8 +357,9 @@ def test_harvest_stops_when_author_limit_is_exceeded(
     queried_orcids = []
 
     def _capture_orcid(orcid, harvest_date=None):
+        # keep track of ORCIDs queries but don't return any publications (so that we're only testing the author limit)
         queried_orcids.append(orcid)
-        return iter(())
+        yield from ()
 
     monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_orcid)
 

--- a/test/harvest_incremental/test_dimensions.py
+++ b/test/harvest_incremental/test_dimensions.py
@@ -8,7 +8,7 @@ import dotenv
 import dimcli
 
 from rialto_airflow.harvest_incremental import dimensions
-from rialto_airflow.schema.rialto import Harvest, Publication
+from rialto_airflow.schema.rialto import Author, Harvest, Publication
 
 from test.utils import num_log_record_matches
 
@@ -102,6 +102,13 @@ def test_harvest_passes_previous_harvest_date_to_orcid_query(
                 finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
             )
         )
+        # Make sure Authors are similar to those loaded in productio, with created_at dates.
+        session.query(Author).where(Author.orcid.is_not(None)).update(
+            {
+                Author.created_at: datetime.datetime(2026, 4, 20, 0, 0, 0),
+                Author.updated_at: None,
+            }
+        )
 
     harvest_dates = []
 
@@ -115,6 +122,74 @@ def test_harvest_passes_previous_harvest_date_to_orcid_query(
 
     assert harvest_dates, "publications_from_orcid should be called for ORCID authors"
     assert set(harvest_dates) == {"2026-04-27"}
+
+
+def test_harvest_omits_previous_harvest_date_for_recently_created_authors(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    monkeypatch,
+):
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        session.query(Author).where(Author.orcid.is_not(None)).update(
+            {
+                Author.created_at: datetime.datetime(2026, 4, 28, 0, 0, 0),
+                Author.updated_at: None,
+            }
+        )
+
+    harvest_dates = []
+
+    def _capture_harvest_date(orcid, harvest_date=None):
+        harvest_dates.append(harvest_date)
+        return iter(())
+
+    monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_harvest_date)
+
+    dimensions.harvest()
+
+    assert harvest_dates, "publications_from_orcid should be called for ORCID authors"
+    assert set(harvest_dates) == {None}
+
+
+def test_harvest_omits_previous_harvest_date_for_recently_updated_authors(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    monkeypatch,
+):
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        session.query(Author).where(Author.orcid.is_not(None)).update(
+            {
+                Author.created_at: datetime.datetime(2026, 4, 20, 0, 0, 0),
+                Author.updated_at: datetime.datetime(2026, 4, 28, 0, 0, 0),
+            }
+        )
+
+    harvest_dates = []
+
+    def _capture_harvest_date(orcid, harvest_date=None):
+        harvest_dates.append(harvest_date)
+        return iter(())
+
+    monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_harvest_date)
+
+    dimensions.harvest()
+
+    assert harvest_dates, "publications_from_orcid should be called for ORCID authors"
+    assert set(harvest_dates) == {None}
 
 
 def test_publications_from_orcid(test_incremental_session, mock_rialto_db_name):
@@ -289,7 +364,28 @@ def test_log_message(
 ):
     caplog.set_level(logging.INFO)
     dimensions.harvest(limit=50)
-    assert "Reached limit of 50 publications stopping" in caplog.text
+    assert "Reached limit of 50 publications or authors, stopping" in caplog.text
+
+
+def test_harvest_stops_when_author_limit_is_exceeded(
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    caplog,
+    monkeypatch,
+):
+    queried_orcids = []
+
+    def _capture_orcid(orcid, harvest_date=None):
+        queried_orcids.append(orcid)
+        return iter(())
+
+    monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_orcid)
+
+    caplog.set_level(logging.INFO)
+    dimensions.harvest(limit=1)
+
+    assert queried_orcids == ["https://orcid.org/0000-0000-0000-0001"]
+    assert "Reached limit of 1 publications or authors, stopping" in caplog.text
 
 
 @pytest.fixture

--- a/test/harvest_incremental/test_dimensions.py
+++ b/test/harvest_incremental/test_dimensions.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import pytest
@@ -7,7 +8,7 @@ import dotenv
 import dimcli
 
 from rialto_airflow.harvest_incremental import dimensions
-from rialto_airflow.schema.rialto import Publication
+from rialto_airflow.schema.rialto import Harvest, Publication
 
 from test.utils import num_log_record_matches
 
@@ -35,15 +36,63 @@ def test_publication_fields():
     assert "book" in fields
 
 
-def test_publications_from_orcid():
+def test_publications_from_orcid(test_incremental_session, mock_rialto_db_name):
+    with test_incremental_session.begin() as session:
+        # Previous harvest exists, but we should still get a large and consistent set of publications by setting this to 2000.
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2000, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2000, 4, 28, 0, 0, 0),
+            )
+        )
+
     pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
     assert len(pubs) == 17
     assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
 
 
-@pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(dimensions, "RIALTO_DB_NAME", "rialto_incremental_test")
+def test_publications_from_orcid_uses_previous_harvest_date(
+    test_incremental_session, mock_rialto_db_name, monkeypatch
+):
+    queries = []
+
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+
+    def mock_query_with_retry(query, retry=5):
+        queries.append(query)
+        return {"publications": []}
+
+    monkeypatch.setattr(dimensions, "query_with_retry", mock_query_with_retry)
+
+    list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
+
+    assert 'date_inserted >= "2026-04-27"' in queries[0]
+    assert 'date_inserted >= "2026-04-27T"' not in queries[0]
+
+
+def test_publications_from_orcid_omits_previous_harvest_date_when_none_exists(
+    test_incremental_session, mock_rialto_db_name, monkeypatch
+):
+    queries = []
+
+    with test_incremental_session.begin() as session:
+        session.add(Harvest())
+
+    def mock_query_with_retry(query, retry=5):
+        queries.append(query)
+        return {"publications": []}
+
+    monkeypatch.setattr(dimensions, "query_with_retry", mock_query_with_retry)
+
+    list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
+
+    assert "date_inserted >=" not in queries[0]
 
 
 @pytest.fixture
@@ -87,10 +136,11 @@ def mock_dimensions_dsl_query_error(monkeypatch):
     )  # wrapped in a lambda because dimensions.dsl is a fn that returns a dimcli.Dsl instance
 
 
-def test_query_with_retry(mock_dimensions_dsl_query_error, caplog):
+def test_query_with_retry(mock_dimensions_dsl_query_error, caplog, monkeypatch):
+    monkeypatch.setattr(dimensions.Harvest, "get_previous", lambda: None)
     pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
     assert len(pubs) == 17
-    assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
+    assert "10.1016/j.annemergmed.2025.05.017" in [pub["doi"] for pub in pubs]
     assert num_log_record_matches(
         caplog.records,
         logging.WARNING,
@@ -137,7 +187,10 @@ def mock_dimensions_dsl_query_login_error(monkeypatch):
     )  # wrapped in a lambda because dimensions.dsl is a fn that returns a dimcli.Dsl instance
 
 
-def test_query_with_login_retry(mock_dimensions_dsl_query_login_error, caplog):
+def test_query_with_login_retry(
+    mock_dimensions_dsl_query_login_error, caplog, monkeypatch
+):
+    monkeypatch.setattr(dimensions.Harvest, "get_previous", lambda: None)
     pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
     assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
     assert num_log_record_matches(

--- a/test/harvest_incremental/test_dimensions.py
+++ b/test/harvest_incremental/test_dimensions.py
@@ -15,6 +15,40 @@ from test.utils import num_log_record_matches
 dotenv.load_dotenv()
 
 
+def _assert_publication_has_two_expected_authors(pub):
+    assert len(pub.authors) == 2, "publication has two authors"
+    assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
+    assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+
+
+def _mock_dimensions_dsl_query_error(monkeypatch, error_message, status_code):
+    """Raise one retriable request error for ORCID publication queries."""
+    patched_dsl = dimensions.dsl()
+    original_query_iterative = patched_dsl.query_iterative
+
+    req_count = 0
+
+    def query_iterative_raise_sometimes_fn(*args, **kwargs):
+        nonlocal req_count
+        if "search publications where researchers.orcid_id = " not in args[0]:
+            return original_query_iterative(*args, **kwargs)
+
+        req_count += 1
+        if req_count > 1:
+            return original_query_iterative(*args, **kwargs)
+
+        exception = dimensions.requests.exceptions.RequestException(error_message)
+        response = requests.Response()
+        response.status_code = status_code
+        exception.response = response
+        raise exception
+
+    monkeypatch.setattr(
+        patched_dsl, "query_iterative", query_iterative_raise_sometimes_fn
+    )
+    monkeypatch.setattr(dimensions, "dsl", lambda: patched_dsl)
+
+
 def test_publications_from_dois():
     # use batch_size=1 to test paging for two DOIs
     pubs = list(
@@ -36,26 +70,31 @@ def test_publication_fields():
     assert "book" in fields
 
 
-def test_publications_from_orcid(test_incremental_session, mock_rialto_db_name):
-    with test_incremental_session.begin() as session:
-        # Previous harvest exists, but we should still get a large and consistent set of publications by setting this to 2000.
-        session.add(
-            Harvest(
-                created_at=datetime.datetime(2000, 4, 27, 16, 38, 10),
-                finished_at=datetime.datetime(2000, 4, 28, 0, 0, 0),
-            )
-        )
-
-    pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
-    assert len(pubs) == 17
-    assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
-
-
-def test_publications_from_orcid_uses_previous_harvest_date(
-    test_incremental_session, mock_rialto_db_name, monkeypatch
+def test_previous_harvest_date_formatting(
+    test_incremental_session, mock_rialto_db_name
 ):
-    queries = []
+    """Test that previous harvest date is correctly formatted as YYYY-MM-DD."""
+    with test_incremental_session.begin() as session:
+        harvest = Harvest(
+            created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+            finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+        )
+        session.add(harvest)
 
+    previous_harvest = Harvest.get_previous()
+    assert previous_harvest is not None
+    assert previous_harvest.created_at is not None
+
+    previous_harvest_date = previous_harvest.created_at.strftime("%Y-%m-%d")
+    assert previous_harvest_date == "2026-04-27", "date formatted as YYYY-MM-DD"
+
+
+def test_harvest_passes_previous_harvest_date_to_orcid_query(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    monkeypatch,
+):
     with test_incremental_session.begin() as session:
         session.add(
             Harvest(
@@ -64,16 +103,42 @@ def test_publications_from_orcid_uses_previous_harvest_date(
             )
         )
 
-    def mock_query_with_retry(query, retry=5):
-        queries.append(query)
-        return {"publications": []}
+    harvest_dates = []
 
-    monkeypatch.setattr(dimensions, "query_with_retry", mock_query_with_retry)
+    def _capture_harvest_date(orcid, harvest_date=None):
+        harvest_dates.append(harvest_date)
+        return iter(())
 
-    list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
+    monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_harvest_date)
 
-    assert 'date_inserted >= "2026-04-27"' in queries[0]
-    assert 'date_inserted >= "2026-04-27T"' not in queries[0]
+    dimensions.harvest()
+
+    assert harvest_dates, "publications_from_orcid should be called for ORCID authors"
+    assert set(harvest_dates) == {"2026-04-27"}
+
+
+def test_publications_from_orcid(test_incremental_session, mock_rialto_db_name):
+    with test_incremental_session.begin() as session:
+        # Creating a previous harvest far enough back (2010) to get a large and consistent
+        # set of publications from the API.
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2010, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2010, 4, 28, 0, 0, 0),
+            )
+        )
+    previous_harvest = Harvest.get_previous()
+    if previous_harvest is not None and previous_harvest.created_at is not None:
+        previous_harvest_date = previous_harvest.created_at.strftime("%Y-%m-%d")
+    assert previous_harvest_date == "2010-04-27"
+
+    pubs = list(
+        dimensions.publications_from_orcid(
+            "0000-0002-2317-1967", harvest_date=previous_harvest_date
+        )
+    )
+    assert len(pubs) == 17
+    assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
 
 
 def test_publications_from_orcid_omits_previous_harvest_date_when_none_exists(
@@ -81,122 +146,35 @@ def test_publications_from_orcid_omits_previous_harvest_date_when_none_exists(
 ):
     queries = []
 
-    with test_incremental_session.begin() as session:
-        session.add(Harvest())
-
     def mock_query_with_retry(query, retry=5):
         queries.append(query)
         return {"publications": []}
 
     monkeypatch.setattr(dimensions, "query_with_retry", mock_query_with_retry)
-
-    list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
+    list(dimensions.publications_from_orcid("0000-0002-2317-1967", harvest_date=None))
 
     assert "date_inserted >=" not in queries[0]
 
 
-@pytest.fixture
-def mock_dimensions_dsl_query_error(monkeypatch):
-    """
-    Mock our function for fetching publications by orcid from Dimensions
-    such that the first call results in a retriable error.
-    """
-
-    patched_dsl = dimensions.dsl()  # Dimensions dimcli.Dsl instance lets you query
-    original_query_iterative = (
-        patched_dsl.query_iterative
-    )  # a ref to the real query_iterative function
-
-    # for the first call to query_iterative that does an orcid query on publications,
-    # raise a request exception.  for the rest, just call the real query function.
-    req_count = 0
-
-    def query_iterative_raise_sometimes_fn(*args, **kwargs):
-        nonlocal req_count
-        if "search publications where researchers.orcid_id = " not in args[0]:
-            return original_query_iterative(*args, **kwargs)
-
-        req_count += 1
-        if req_count > 1:
-            return original_query_iterative(*args, **kwargs)
-        else:
-            exception = dimensions.requests.exceptions.RequestException(
-                "transient error"
-            )
-            response = requests.Response()
-            response.status_code = 429
-            exception.response = response
-            raise exception
-
-    monkeypatch.setattr(
-        patched_dsl, "query_iterative", query_iterative_raise_sometimes_fn
-    )
-    monkeypatch.setattr(
-        dimensions, "dsl", lambda: patched_dsl
-    )  # wrapped in a lambda because dimensions.dsl is a fn that returns a dimcli.Dsl instance
-
-
-def test_query_with_retry(mock_dimensions_dsl_query_error, caplog, monkeypatch):
-    monkeypatch.setattr(dimensions.Harvest, "get_previous", lambda: None)
-    pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
-    assert len(pubs) == 17
-    assert "10.1016/j.annemergmed.2025.05.017" in [pub["doi"] for pub in pubs]
-    assert num_log_record_matches(
-        caplog.records,
-        logging.WARNING,
-        "Dimensions query error retry 1 of 5: transient error",
-    )
-
-
-@pytest.fixture
-def mock_dimensions_dsl_query_login_error(monkeypatch):
-    """
-    Mock our function for fetching publications by orcid from Dimensions
-    such that the first call results in an authentication error.
-    """
-
-    patched_dsl = dimensions.dsl()  # Dimensions dimcli.Dsl instance lets you query
-    original_query_iterative = (
-        patched_dsl.query_iterative
-    )  # a ref to the real query_iterative function
-
-    # for the first call to query_iterative that does an orcid query on publications,
-    # raise a request exception. For the rest, just call the real query function.
-    req_count = 0
-
-    def query_iterative_raise_sometimes_fn(*args, **kwargs):
-        nonlocal req_count
-        if "search publications where researchers.orcid_id = " not in args[0]:
-            return original_query_iterative(*args, **kwargs)
-
-        req_count += 1
-        if req_count > 1:
-            return original_query_iterative(*args, **kwargs)
-        else:
-            exception = dimensions.requests.exceptions.RequestException("login error")
-            response = requests.Response()
-            response.status_code = 401
-            exception.response = response
-            raise exception
-
-    monkeypatch.setattr(
-        patched_dsl, "query_iterative", query_iterative_raise_sometimes_fn
-    )
-    monkeypatch.setattr(
-        dimensions, "dsl", lambda: patched_dsl
-    )  # wrapped in a lambda because dimensions.dsl is a fn that returns a dimcli.Dsl instance
-
-
-def test_query_with_login_retry(
-    mock_dimensions_dsl_query_login_error, caplog, monkeypatch
+@pytest.mark.parametrize(
+    "error_message,status_code,expected_doi",
+    [
+        ("transient error", 429, "10.1016/j.annemergmed.2025.05.017"),
+        ("login error", 401, "10.1002/emp2.12007"),
+    ],
+)
+def test_query_with_retry_variants(
+    caplog, monkeypatch, error_message, status_code, expected_doi
 ):
-    monkeypatch.setattr(dimensions.Harvest, "get_previous", lambda: None)
-    pubs = list(dimensions.publications_from_orcid("0000-0002-2317-1967"))
-    assert "10.1002/emp2.12007" in [pub["doi"] for pub in pubs]
+    _mock_dimensions_dsl_query_error(monkeypatch, error_message, status_code)
+    pubs = list(
+        dimensions.publications_from_orcid("0000-0002-2317-1967", harvest_date=None)
+    )
+    assert expected_doi in [pub["doi"] for pub in pubs]
     assert num_log_record_matches(
         caplog.records,
         logging.WARNING,
-        "Dimensions query error retry 1 of 5: login error",
+        f"Dimensions query error retry 1 of 5: {error_message}",
     )
 
 
@@ -232,10 +210,10 @@ def test_harvest(
 
         pub = session.query(Publication).first()
         assert pub.doi == "10.1515/9781503624153", "doi was normalized"
-
-        assert len(pub.authors) == 2, "publication has two authors"
-        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
-        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+        assert isinstance(pub.dim_harvested, datetime.datetime), (
+            "harvest timestamp is a datetime"
+        )
+        _assert_publication_has_two_expected_authors(pub)
 
 
 def test_harvest_when_doi_exists(
@@ -257,10 +235,10 @@ def test_harvest_when_doi_exists(
         assert pub.dim_json["title"] == "An example title", "dimensions json updated"
         assert pub.sulpub_json == {"sulpub": "data"}, "sulpub data the same"
         assert pub.openalex_json is None
-
-        assert len(pub.authors) == 2, "publication has two authors"
-        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
-        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+        assert isinstance(pub.dim_harvested, datetime.datetime), (
+            "harvest timestamp is a datetime"
+        )
+        _assert_publication_has_two_expected_authors(pub)
 
 
 def test_harvest_when_pub_author_association_exists(
@@ -283,10 +261,7 @@ def test_harvest_when_pub_author_association_exists(
         assert pub.dim_json["title"] == "An example title", "dimensions json updated"
         assert pub.wos_json == {"wos": "data"}, "wos data the same"
         assert pub.pubmed_json is None
-
-        assert len(pub.authors) == 2, "publication has two authors"
-        assert pub.authors[0].orcid == "https://orcid.org/0000-0000-0000-0001"
-        assert pub.authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
+        _assert_publication_has_two_expected_authors(pub)
 
 
 @pytest.fixture

--- a/test/harvest_incremental/test_harvest.py
+++ b/test/harvest_incremental/test_harvest.py
@@ -1,15 +1,8 @@
 import datetime
 
-import pytest
 from sqlalchemy import inspect
 
-from rialto_airflow.schema import rialto
 from rialto_airflow.schema.rialto import Harvest
-
-
-@pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(rialto, "RIALTO_DB_NAME", "rialto_incremental_test")
 
 
 def test_create_persists_harvest(test_incremental_session, mock_rialto_db_name):

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -93,12 +93,7 @@ def test_drop_database(
             teardown_database(snapshot.database_name)
 
 
-def test_create_schema(
-    snapshot,
-    mock_rialto_postgres,
-    monkeypatch,
-    teardown_database,
-):
+def test_create_schema(snapshot, mock_rialto_postgres, monkeypatch, teardown_database):
     # During testing, we want to be able to drop the database at the end.
     # Mocking the engine obtained by create_schema to avoid connections staying open and preventing teardown.
     def mock_engine_setup(db_name):
@@ -205,11 +200,9 @@ def test_create_schema(
 
 
 def test_create_rialto_schema(
-    mock_rialto_postgres,
-    monkeypatch,
-    teardown_database,
+    mock_rialto_postgres, mock_rialto_db_name, monkeypatch, teardown_database
 ):
-    database_name = "rialto_incremental_test"
+    database_name = rialto.RIALTO_DB_NAME
 
     # During testing, we want to be able to drop the database at the end.
     # Mocking the engine obtained by create_schema to avoid connections staying open and preventing teardown.
@@ -217,7 +210,6 @@ def test_create_rialto_schema(
         return null_pool_engine(db_name)
 
     monkeypatch.setattr(database, "engine_setup", mock_engine_setup)
-    monkeypatch.setattr(rialto, "RIALTO_DB_NAME", database_name)
 
     try:
         if database.database_exists(database_name):


### PR DESCRIPTION
**What was changed?**
Closes #844. Implements incremental harvesting from Dimensions. Populates the `dim_harvested` field with the current time for provenance. 

Supports using a harvest limit for publications and authors, and harvests all pubs for new/updated authors. 

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
The publications and authors don't change. We'll want to update the changelog with something about incremental harvesting when this is released. 
