### PR TITLE
Incrementally load authors

### DIFF
--- a/rialto_airflow/harvest_incremental/authors.py
+++ b/rialto_airflow/harvest_incremental/authors.py
@@ -1,11 +1,13 @@
 import csv
 import logging
 
+from psycopg2 import Error as Psycopg2Error
+from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 
-from rialto_airflow.database import get_engine
-from rialto_airflow.schema.rialto import Author, RIALTO_DB_NAME
+from rialto_airflow.database import get_session
+from rialto_airflow.schema.rialto import RIALTO_DB_NAME, Author
 from rialto_airflow.utils import rialto_authors_file
 
 
@@ -13,49 +15,150 @@ def load_authors_table(data_dir) -> None:
     """
     Load the authors data from the authors CSV into the database
     """
-    engine = get_engine(RIALTO_DB_NAME)
-    Session = sessionmaker(engine)
-
     authors_file = rialto_authors_file(data_dir)
     check_headers(authors_file)
 
-    logging.debug(f"Loading authors from {authors_file} into database {RIALTO_DB_NAME}")
-    with open(authors_file, "r") as file:
-        errors = []
-        csv_reader = csv.DictReader(file)
-        for row in csv_reader:
-            try:
-                with Session.begin() as session:
-                    author = Author(
-                        sunet=row["sunetid"],
-                        cap_profile_id=row["cap_profile_id"] or None,
-                        orcid=row["orcidid"] or None,
-                        first_name=row["first_name"],
-                        last_name=row["last_name"],
-                        status=to_boolean(row["active"]),
-                        academic_council=to_boolean(row["academic_council"]),
-                        role=row["role"],
-                        schools=to_array(row["all_schools"]),
-                        departments=to_array(row["all_departments"]),
-                        primary_school=row["primary_school"],
-                        primary_dept=row["primary_department"],
-                        primary_division=row["primary_division"],
-                    )
-                    session.add(author)
-            except IntegrityError as e:
-                message = f"Skipping author: {row['sunetid'], row['orcidid']}: {e}"
-                logging.debug(
-                    message
-                )  # this is debug level so we can watch as it goes if need be, but errors are logged in aggregate at warning level at end
-                errors.append(message)
-                continue
-            finally:
-                session.close()
+    session_maker = get_session(RIALTO_DB_NAME)
 
-    logging.info(f"Loaded {session.query(Author).count()} authors")
-    if errors:
-        # show all errors at the end of the log
-        logging.warning(f"Errors with {len(errors)} authors: {errors}")
+    # we need to control commit and rollback directly in order to handle
+    # the different constraint violations that can be encountered
+    session = session_maker()
+
+    logging.debug(f"Loading authors from {authors_file} into database {RIALTO_DB_NAME}")
+
+    new_authors = updated_authors = processed_authors = ignored_authors = 0
+
+    with open(authors_file, "r") as file:
+        for row in csv.DictReader(file):
+            processed_authors += 1
+            row_dict = row_to_dict(row)
+            try:
+                match upsert_author(session, row_dict):
+                    case "inserted":
+                        new_authors += 1
+                    case "updated":
+                        updated_authors += 1
+                    case "noop":
+                        ignored_authors += 1
+
+            except IntegrityError as e:
+                assert isinstance(e.orig, Psycopg2Error)  # needed for type checking
+                session.rollback()
+                constraint = e.orig.diag.constraint_name
+
+                if constraint == "author_orcid_key":
+                    ignored_authors += 1
+                    logging.warning(
+                        f"Ignored author sunet={row_dict['sunet']} because there's another author with ORCID {row_dict['orcid']}"
+                    )
+
+                elif constraint == "author_cap_profile_id_key":
+                    result = handle_duplicate_cap_profile_id(session, row, row_dict)
+                    if result is True:
+                        updated_authors += 1
+                    else:
+                        ignored_authors += 1
+
+        logging.info(
+            f"processed={processed_authors} new={new_authors} updated={updated_authors} ignored={ignored_authors}"
+        )
+
+
+def row_to_dict(row: dict) -> dict:
+    return dict(
+        sunet=row["sunetid"],
+        cap_profile_id=row["cap_profile_id"] or None,
+        orcid=row["orcidid"] or None,
+        first_name=row["first_name"],
+        last_name=row["last_name"],
+        status=to_boolean(row["active"]),
+        academic_council=to_boolean(row["academic_council"]),
+        role=row["role"],
+        schools=to_array(row["all_schools"]),
+        departments=to_array(row["all_departments"]),
+        primary_school=row["primary_school"],
+        primary_dept=row["primary_department"],
+        primary_division=row["primary_division"],
+    )
+
+
+def upsert_author(session: Session, row_dict: dict) -> str:
+    """
+    Insert author, or update if the sunet already exists and values have changed.
+    If there is a constraint violation related to the orcid or cap_profile_id an
+    IntegrityError exception will be raised.
+
+    Returns "inserted", "updated", or "noop" depending on what it did.
+    """
+    author = session.query(Author).where(Author.sunet == row_dict["sunet"]).first()
+
+    if author is None:
+        session.add(Author(**row_dict))
+        session.commit()
+        return "inserted"
+
+    # if no values are changing on the author no update is needed
+    # this prevents changing updated_at when there are no changes
+    if not any(getattr(author, col) != row_dict[col] for col in row_dict):
+        return "noop"
+
+    # update the author using the new data, and commit
+    for col, val in row_dict.items():
+        setattr(author, col, val)
+    session.add(author)
+    session.commit()
+    return "updated"
+
+
+def handle_duplicate_cap_profile_id(
+    session: Session, row: dict, row_dict: dict
+) -> bool:
+    """
+    Handle a cap_profile_id uniqueness conflict and return the number of errors
+    encountered.
+
+    If the author being added is inactive it is ignored.
+
+    If the author being added is active, and there is an inactive author with the same
+    cap_profile_id in the database already, the inactive author will be replaced
+    with the active one.
+
+    True will be returned if an author was updated, otherwise False.
+    """
+
+    cap_profile_id = row["cap_profile_id"]
+
+    if to_boolean(row["active"]) is False:
+        logging.warning(
+            f"Ignored inactive author sunet={row_dict['sunet']} with pre-existing cap_profile_id {cap_profile_id} and a different sunet"
+        )
+        return False
+
+    inactive_author = (
+        session.query(Author)
+        .where(Author.cap_profile_id == cap_profile_id)
+        .where(Author.status.is_(False))
+        .first()
+    )
+
+    if inactive_author is None:
+        logging.warning(
+            f"Unable to insert active author when there is already an active author with cap_profile_id {cap_profile_id}"
+        )
+        return False
+
+    old_sunet = inactive_author.sunet
+
+    session.execute(
+        update(Author).where(Author.id == inactive_author.id).values(row_dict)
+    )
+    session.commit()
+
+    logging.info(
+        f"Updated inactive author sunet={old_sunet} with active author sunet={row_dict['sunet']} for cap_profile_id={cap_profile_id}"
+    )
+
+    return True
 
 
 def check_headers(authors_file: str) -> None:
@@ -85,8 +188,6 @@ def check_headers(authors_file: str) -> None:
 
 def to_boolean(value: str) -> bool:
     bool_map = {"true": True, "false": False}
-
-    # will raise KeyError if unexpected value
     return bool_map[value.strip().lower()]
 
 

--- a/rialto_airflow/schema/rialto.py
+++ b/rialto_airflow/schema/rialto.py
@@ -75,7 +75,7 @@ class Publication(RialtoSchemaBase):
         DateTime, server_default=utcnow()
     )
     updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
-        DateTime, onupdate=utcnow()
+        DateTime, default=utcnow(), onupdate=utcnow()
     )
     types: Mapped[Optional[List[str]]] = mapped_column(ARRAY(String))
     publisher: Mapped[Optional[str]] = mapped_column(String)
@@ -125,7 +125,7 @@ class Author(RialtoSchemaBase):
         DateTime, server_default=utcnow()
     )
     updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
-        DateTime, onupdate=utcnow()
+        DateTime, default=utcnow(), onupdate=utcnow()
     )
     publications: Mapped[List["Publication"]] = relationship(
         "Publication", secondary=pub_author_association, back_populates="authors"

--- a/test/harvest_incremental/test_authors.py
+++ b/test/harvest_incremental/test_authors.py
@@ -1,10 +1,32 @@
 import csv
 import logging
+
+import pandas
 import pytest
-from rialto_airflow.schema.rialto import Author
+
 from rialto_airflow.harvest_incremental import authors as authors_mod
 from rialto_airflow.harvest_incremental.authors import load_authors_table
-from test.utils import num_log_record_matches
+from rialto_airflow.schema.rialto import Author, Publication
+
+_CSV_FIELDNAMES = [
+    "sunetid",
+    "first_name",
+    "last_name",
+    "full_name",
+    "orcidid",
+    "orcid_update_scope",
+    "cap_profile_id",
+    "role",
+    "academic_council",
+    "primary_affiliation",
+    "primary_school",
+    "primary_department",
+    "primary_division",
+    "all_schools",
+    "all_departments",
+    "all_divisions",
+    "active",
+]
 
 
 @pytest.fixture
@@ -34,51 +56,30 @@ def test_author_fixture(test_incremental_session, author):
 
 @pytest.fixture
 def authors_csv(tmp_path):
-    # Create a fixture authors CSV file
     fixture_file = tmp_path / "authors.csv"
     with open(fixture_file, "w", newline="") as csvfile:
-        writer = csv.writer(csvfile)
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writeheader()
         writer.writerow(
-            [
-                "sunetid",
-                "first_name",
-                "last_name",
-                "full_name",
-                "orcidid",
-                "orcid_update_scope",
-                "cap_profile_id",
-                "role",
-                "academic_council",
-                "primary_affiliation",
-                "primary_school",
-                "primary_department",
-                "primary_division",
-                "all_schools",
-                "all_departments",
-                "all_divisions",
-                "active",
-            ]
-        )
-        writer.writerow(
-            [
-                "janes",
-                "Jane",
-                "Stanford",
-                "Jane Stanford",
-                "https://orcid.org/0000-0000-0000-0001",
-                "true",
-                "12345",
-                "staff",
-                "false",
-                "Engineering",
-                "School of Engineering",
-                "Computer Science",
-                "Philanthropy Division",
-                "Independent Labs, Institutes, and Centers (Dean of Research)|School of Humanities and Sciences",
-                "Computer Science|Horticulture",
-                "Philanthropy Division|Other Division",
-                "true",
-            ]
+            {
+                "sunetid": "janes",
+                "first_name": "Jane",
+                "last_name": "Stanford",
+                "full_name": "Jane Stanford",
+                "orcidid": "https://orcid.org/0000-0000-0000-0001",
+                "orcid_update_scope": "true",
+                "cap_profile_id": "12345",
+                "role": "staff",
+                "academic_council": "false",
+                "primary_affiliation": "Engineering",
+                "primary_school": "School of Engineering",
+                "primary_department": "Computer Science",
+                "primary_division": "Philanthropy Division",
+                "all_schools": "Independent Labs, Institutes, and Centers (Dean of Research)|School of Humanities and Sciences",
+                "all_departments": "Computer Science|Horticulture",
+                "all_divisions": "Philanthropy Division|Other Division",
+                "active": "true",
+            }
         )
     return fixture_file
 
@@ -86,6 +87,9 @@ def authors_csv(tmp_path):
 def test_load_authors_table(
     test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
 ):
+    """
+    Make sure we can load the authors.csv.
+    """
     load_authors_table(tmp_path)
 
     with test_incremental_session.begin() as session:
@@ -108,7 +112,55 @@ def test_load_authors_table(
         ]
         assert author.departments == ["Computer Science", "Horticulture"]
         assert author.created_at is not None
-    assert "Errors:" not in caplog.text
+        assert author.updated_at is not None
+
+    assert "processed=1 new=1 updated=0 ignored=0" in caplog.text
+
+
+def test_update_by_sunet(
+    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
+):
+    """
+    Make sure that author updates work correctly. Reloading the same data should
+    not change the author.updated_at value. Any changes to author's data should
+    get loaded and update the author.updated_at timestamp.
+    """
+    # load initial author
+    load_authors_table(tmp_path)
+    assert "processed=1 new=1 updated=0 ignored=0" in caplog.text
+
+    # get the author's updated time
+    with test_incremental_session.begin() as session:
+        authors = session.query(Author).all()
+        assert len(authors) == 1
+        updated_at = authors[0].updated_at
+        assert updated_at is not None
+
+    # loading unchanged data doesn't change updated_at
+    load_authors_table(tmp_path)
+    with test_incremental_session.begin() as session:
+        assert session.query(Author).count() == 1
+        author = session.query(Author).where(Author.sunet == "janes").one()
+        assert author.updated_at == updated_at, "no changes doesn't alter updated_at"
+    assert "processed=1 new=0 updated=0 ignored=1" in caplog.text
+
+    # update the csv with new information for the author
+    df = pandas.read_csv(tmp_path / "authors.csv")
+    df.at[0, "primary_school"] = "School of Something Else"
+    df.at[0, "primary_department"] = "Various"
+    df.to_csv(tmp_path / "authors.csv", index=False)
+
+    # load again and ensure values have changed
+    load_authors_table(tmp_path)
+    assert "processed=1 new=0 updated=1 ignored=0" in caplog.text
+
+    with test_incremental_session.begin() as session:
+        assert session.query(Author).count() == 1
+
+        author = session.query(Author).where(Author.sunet == "janes").one()
+        assert author.primary_school == "School of Something Else"
+        assert author.primary_dept == "Various"
+        assert author.updated_at >= updated_at, "updated_at should reflect the change"
 
 
 def test_load_dupe_orcid(
@@ -117,30 +169,18 @@ def test_load_dupe_orcid(
     caplog.set_level(logging.DEBUG)
     # add a row with a duplicate ORCID to the CSV
     with open(authors_csv, "a", newline="") as csvfile:
-        writer = csv.writer(csvfile)
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
         writer.writerow(
-            [
-                "lelands",
-                "Leland",
-                "Stanford, Jr.",
-                "Leland Stanford, Jr.",
-                "https://orcid.org/0000-0000-0000-0001",
-                "true",
-                "67890",
-                "faculty",
-                "true",
-                "Humanities",
-                "School of Humanities and Sciences",
-                "History",
-                "History Division",
-                "School of Humanities and Sciences",
-                "History",
-                "History Division",
-                "true",
-            ]
+            {
+                "sunetid": "lelands",
+                "orcidid": "https://orcid.org/0000-0000-0000-0001",
+                "academic_council": True,
+                "active": True,
+            }
         )
 
     load_authors_table(tmp_path)
+    assert "processed=2 new=1 updated=0 ignored=1" in caplog.text
 
     with test_incremental_session.begin() as session:
         assert session.query(Author).count() == 1
@@ -148,78 +188,163 @@ def test_load_dupe_orcid(
         assert session.query(Author).where(Author.sunet == "lelands").count() == 0
 
     assert (
-        len([record for record in caplog.records if record.levelname == "WARNING"]) == 1
-    )
-    assert (
-        "Skipping author: ('lelands', 'https://orcid.org/0000-0000-0000-0001')"
+        "Ignored author sunet=lelands because there's another author with ORCID https://orcid.org/0000-0000-0000-0001"
         in caplog.text
     )
-    assert num_log_record_matches(
-        caplog.records, logging.WARNING, "Errors with 1 authors: "
+
+
+def test_load_dupe_cap_id_inactive(
+    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
+):
+    """
+    If the author being added has the same cap_profile_id as an existing author
+    with a different sunet, and the author being added is inactive, then it is
+    ignored.
+    """
+    with open(authors_csv, "a", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writerow(
+            {
+                "sunetid": "lelands",  # different from what was loaded by fixture
+                "cap_profile_id": "12345",  # same as what was loaded before by fixture
+                "active": False,  # the author is inactive
+                "academic_council": False,
+            }
+        )
+
+    load_authors_table(tmp_path)
+    assert "processed=2 new=1 updated=0 ignored=1" in caplog.text
+
+    assert (
+        "Ignored inactive author sunet=lelands with pre-existing cap_profile_id 12345 and a different sunet"
+        in caplog.text
     )
+
+    with test_incremental_session.begin() as session:
+        assert session.query(Author).count() == 1
+        assert session.query(Author).where(Author.sunet == "janes").first() is not None
+
+
+def test_load_dupe_cap_id_update_inactive(
+    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
+):
+
+    # create an inactive author linked to a publication in the database
+    with test_incremental_session.begin() as session:
+        author = Author(
+            sunet="lelands",
+            cap_profile_id="12345",
+            first_name="Leland",
+            last_name="Stanford",
+            status=False,
+        )
+        pub = Publication(title="Test pub", authors=[author])
+        session.add(pub)
+        session.add(author)
+
+    # rewrite the authors.csv with an active author with a different sunet but the same
+    # cap_profile_id
+    with open(authors_csv, "w", newline="") as csvfile:  # note: ovewriting
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sunetid": "lelands2",
+                "cap_profile_id": "12345",
+                "active": True,
+                "academic_council": False,
+            }
+        )
+
+    # load the CSV
+    load_authors_table(tmp_path)
+    assert "processed=1 new=0 updated=1 ignored=0" in caplog.text
+
+    assert (
+        "Updated inactive author sunet=lelands with active author sunet=lelands2 for cap_profile_id=12345"
+        in caplog.text
+    )
+
+    # the inactive sunet should be gone but the publications should be
+    # preserved on the new sunet
+    with test_incremental_session.begin() as session:
+        assert session.query(Author).count() == 1
+        author = session.query(Author).where(Author.sunet == "lelands2").first()
+        assert author, "found author active author"
+        assert author.status is True, "they are active"
+        assert len(author.publications) == 1, (
+            "removal of inactive author preserved their publications"
+        )
+
+
+def test_load_dupe_cap_id(
+    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
+):
+    """
+    Load an authors.csv with two active authors with the same cap_profile_id. We
+    should only keep the first one and ignore the second.
+    """
+    # write two rows with same cap_profile_id
+    # the first one is inactive and should be removed
+    with open(authors_csv, "w", newline="") as csvfile:  # ovewrite authors.csv
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sunetid": "lelands",
+                "cap_profile_id": "12345",  # same as what was loaded before by fixture
+                "active": True,
+                "academic_council": False,
+            }
+        )
+        writer.writerow(
+            {
+                "sunetid": "lelands2",
+                "cap_profile_id": "12345",  # same as what was loaded before by fixture
+                "active": True,
+                "academic_council": False,
+            }
+        )
+
+    load_authors_table(tmp_path)
+    assert "processed=2 new=1 updated=0 ignored=1" in caplog.text
+
+    assert (
+        "Unable to insert active author when there is already an active author with cap_profile_id 12345"
+        in caplog.text
+    )
+
+    # the inactive author should have been removed
+    with test_incremental_session.begin() as session:
+        assert session.query(Author).count() == 1
 
 
 def test_load_null_cap_id(
     test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
 ):
-    # add row with null cap_profile_id
+    """
+    Test that we can load authors with no cap_profile_id.
+    """
     with open(authors_csv, "a", newline="") as csvfile:
-        writer = csv.writer(csvfile)
-        writer.writerows(
-            [
-                [
-                    "lelands",
-                    "Leland",
-                    "Stanford, Jr.",
-                    "Leland Stanford, Jr.",
-                    "https://orcid.org/0000-0000-0000-0002",
-                    "true",
-                    None,
-                    "faculty",
-                    "true",
-                    "Humanities",
-                    "School of Humanities and Sciences",
-                    "History",
-                    "History Division",
-                    "School of Humanities and Sciences",
-                    "History",
-                    "History Division",
-                    "true",
-                ],
-                [
-                    "rsmith",
-                    "Robert",
-                    "Smith",
-                    "Robert Smith",
-                    "https://orcid.org/0000-0000-0000-0003",
-                    "true",
-                    None,
-                    "faculty",
-                    "true",
-                    "Humanities",
-                    "School of Humanities and Sciences",
-                    "History",
-                    "History Division",
-                    "School of Humanities and Sciences",
-                    "History",
-                    "History Division",
-                    "true",
-                ],
-            ]
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writerow(
+            {
+                "sunetid": "lelands",
+                "cap_profile_id": None,
+                "active": False,
+                "academic_council": False,
+            }
         )
 
     load_authors_table(tmp_path)
+    assert "processed=2 new=2 updated=0 ignored=0" in caplog.text
 
     with test_incremental_session.begin() as session:
-        assert session.query(Author).count() == 3
+        assert session.query(Author).count() == 2
         assert (
             session.query(Author)
             .where(Author.sunet == "lelands")
             .first()
             .cap_profile_id
-            is None
-        )
-        assert (
-            session.query(Author).where(Author.sunet == "rsmith").first().cap_profile_id
             is None
         )


### PR DESCRIPTION
**What was changed?**

To support incremental updates we want to be able to reload `authors.csv` into an already populated author table.

The author table has three unique constraints: 

1. sunet: If we get a unique constraint violation for sunet, we updated the existing row with the potentially new information.
2. cap_profile_id: If we get a unique constraint violation for the cap_profile_id, we look for an inactive author, and if found, update it with the new author's information.
3. orcid: If we get a unique constraint violation for the orcid we log it and move on.

Care must also be taken to ensure that we only update Author.updated_at when data actually changes.

The task output log message on completion indicating how many authors were created, updated or skipped.

In addition to the unit tests, I ran the load_authors task in my development environment multiple times to ensure that it behaved correctly.

Aside: the task runs in 2 minutes instead of 15 now that we aren't starting a new session for each row.

Closes #843

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog) ✅ 

