### PR TITLE
Add incremental harvesting for WOS

### DIFF
--- a/rialto_airflow/harvest_incremental/wos.py
+++ b/rialto_airflow/harvest_incremental/wos.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import datetime
 from itertools import batched
 from time import sleep
 
@@ -17,6 +18,7 @@ from rialto_airflow.schema.rialto import (
     Publication,
     pub_author_association,
     RIALTO_DB_NAME,
+    Harvest,
 )
 from rialto_airflow.utils import (
     normalize_doi,
@@ -31,21 +33,49 @@ def harvest(limit=None) -> None:
     """
     Walk through all the Author ORCIDs and generate publications for them.
     """
-    count = 0
+    pub_count = 0
+    author_count = 0
     stop = False
 
     with get_session(RIALTO_DB_NAME).begin() as select_session:
+        previous_harvest = Harvest.get_previous()
+        previous_harvest_date = None
+        if previous_harvest is not None:
+            previous_harvest_date = previous_harvest.created_at
+            logging.info(
+                f"previous harvest found, so only harvesting publications loaded since {previous_harvest_date}"
+            )
+
         # get all authors that have an ORCID
         for author in (
             select_session.query(Author).where(Author.orcid.is_not(None)).all()
         ):
+            author_count += 1
+            if limit is not None and author_count > limit:
+                stop = True
+
             if stop is True:
-                logging.warning(f"Reached limit of {limit} publications stopping")
+                logging.warning(
+                    f"Reached limit of {limit} publications or authors, stopping"
+                )
                 break
 
-            for wos_pub in orcid_publications(author.orcid):
-                count += 1
-                if limit is not None and count > limit:
+            # if the author was created or updated (e.g. adding an ORCID) after the last harvest,
+            # we want to get all their publications, not just ones since the last harvest timestamp.
+            # create a variable that can be mutated just for this author loop.
+            author_harvest_date = previous_harvest_date
+            if previous_harvest is not None:
+                if (
+                    author.updated_at is not None
+                    and author.updated_at >= previous_harvest.created_at
+                ):
+                    author_harvest_date = None
+
+            for wos_pub in publications_from_orcid(
+                author.orcid, harvest_date=author_harvest_date
+            ):
+                pub_count += 1
+                if limit is not None and pub_count > limit:
                     stop = True
                     break
 
@@ -54,6 +84,7 @@ def harvest(limit=None) -> None:
                 pubmed_id = get_pmid(wos_pub)
 
                 with get_session(RIALTO_DB_NAME).begin() as insert_session:
+                    harvested_at = datetime.datetime.now(datetime.timezone.utc)
                     # if there's a DOI constraint violation we need to update instead of insert
                     pub_id = insert_session.execute(
                         insert(Publication)
@@ -62,11 +93,15 @@ def harvest(limit=None) -> None:
                             wos_json=wos_pub,
                             wos_id=wos_id,
                             pubmed_id=pubmed_id,
+                            wos_harvested=harvested_at,
                         )
                         .on_conflict_do_update(
                             constraint="publication_doi_key",
                             set_=dict(
-                                wos_json=wos_pub, wos_id=wos_id, pubmed_id=pubmed_id
+                                wos_json=wos_pub,
+                                wos_id=wos_id,
+                                pubmed_id=pubmed_id,
+                                wos_harvested=harvested_at,
                             ),
                         )
                         .returning(Publication.id)
@@ -117,15 +152,26 @@ def fill_in():
     logging.info(f"filled in {count} publications")
 
 
-def orcid_publications(orcid) -> Generator[dict, None, None]:
+def publications_from_orcid(orcid, harvest_date=None) -> Generator[dict, None, None]:
     """
-    A generator that returns publications associated with a given ORCID.
+    A generator that returns new or updated publications associated with a given ORCID, taking the last harvest date into account.
     """
     # WoS doesn't recognize ORCID URIs which are stored in User table
     if m := re.match(r"^https?://orcid.org/(.+)$", orcid):
         orcid = m.group(1)
 
-    yield from _wos_api(f"AI={orcid}")
+    query_params = {}
+    query_params["usrQuery"] = f"AI={orcid}"
+    if harvest_date is not None:
+        # construct a date limiter that is relative to the current date, since WOK does not allow use of the modifiedTimeSpan limiter
+        # date limiter should use the number of days since the start of the previous finished harvest + "D", e.g. "7D"
+        # Although harvest_date will have been saved as a UTC datetime, to avoid a TypeError making sure it's timezone-aware.
+        harvest_date = harvest_date.astimezone(datetime.timezone.utc)
+        current_date = datetime.datetime.now(datetime.timezone.utc)
+        number_of_days = (current_date - harvest_date).days
+        if number_of_days > 0:
+            query_params["loadTimeSpan"] = f"{number_of_days}D"
+    yield from _wos_api(query_params=query_params)
 
 
 def publications_from_dois(dois: list[str]) -> Generator[dict, None, None]:
@@ -150,7 +196,9 @@ def publications_from_dois(dois: list[str]) -> Generator[dict, None, None]:
     for doi_batch in batched(dois, n=50):
         try:
             yield from _wos_api(
-                f"DO=({' '.join(f'"{doi}"' for doi in doi_batch)})",
+                query_params={
+                    "usrQuery": f"DO=({' '.join(f'"{doi}"' for doi in doi_batch)})"
+                },
                 should_raise_for_status=True,
                 timeout=(6.05, 60),
             )
@@ -160,7 +208,9 @@ def publications_from_dois(dois: list[str]) -> Generator[dict, None, None]:
             )
             for doi in doi_batch:
                 try:
-                    yield from _wos_api(f'DO=("{doi}")', timeout=(6.05, 15))
+                    yield from _wos_api(
+                        query_params={"usrQuery": f'DO=("{doi}")'}, timeout=(6.05, 15)
+                    )
                 except Exception as e:
                     logging.error(
                         f'Unexpected error querying for single DOI from larger batch.  DOI="{doi}" -- error={e}'
@@ -180,14 +230,13 @@ def _wos_api_retry() -> Retry:
 
 
 def _wos_api(
-    query,
+    query_params: Params,
     should_raise_for_status: bool = False,
     timeout: int | tuple[float, float] | None = None,
 ) -> Generator[dict, None, None]:
     """
     A generator that returns publications associated a list of DOIs.
     """
-
     # For API details see: https://api.clarivate.com/swagger-ui/?apikey=none&url=https%3A%2F%2Fdeveloper.clarivate.com%2Fapis%2Fwos%2Fswagger
 
     wos_key = os.environ.get("AIRFLOW_VAR_WOS_KEY")
@@ -197,14 +246,14 @@ def _wos_api(
     # the number of records to get in each request (100 is max)
     count = 100
 
-    params: Params = {
+    api_params: Params = {
         "databaseId": "WOK",
-        "usrQuery": query,
         "count": count,
         "firstRecord": 1,
         "optionView": "SR",  # SR = Short Records, which gives us the most basic info about the publication, skipping authors, to keep
     }
 
+    params: Params = {**api_params, **query_params}
     # retry any 429 statuses and stay within rate limits
     http = requests.Session()
     http.mount("https://", HTTPAdapter(max_retries=_wos_api_retry()))
@@ -223,7 +272,7 @@ def _wos_api(
         return
 
     if results["QueryResult"]["RecordsFound"] == 0:
-        logging.debug(f"No results found for {query}")
+        logging.debug(f"No results found for {params}")
         return
 
     yield from results["Data"]["Records"]["records"]["REC"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from rialto_airflow import harvest_incremental
 from rialto_airflow.database import create_schema, engine_setup
+from rialto_airflow.harvest_incremental import dimensions, wos
 from rialto_airflow.publish import publication
 from rialto_airflow.schema import harvest as harvest_schema
 from rialto_airflow.schema import rialto as rialto_schema
@@ -92,6 +93,8 @@ def mock_rialto_db_name(monkeypatch):
     monkeypatch.setattr(
         harvest_incremental.wos, "RIALTO_DB_NAME", "rialto_incremental_test"
     )
+    monkeypatch.setattr(dimensions, "RIALTO_DB_NAME", "rialto_incremental_test")
+    monkeypatch.setattr(wos, "RIALTO_DB_NAME", "rialto_incremental_test")
 
 
 @pytest.fixture

--- a/test/harvest_incremental/test_dimensions.py
+++ b/test/harvest_incremental/test_dimensions.py
@@ -106,44 +106,6 @@ def test_harvest_passes_previous_harvest_date_to_orcid_query(
     )
 
 
-def test_harvest_omits_previous_harvest_date_for_recently_created_authors(
-    test_incremental_session,
-    mock_incremental_authors,
-    mock_rialto_db_name,
-    monkeypatch,
-):
-    with test_incremental_session.begin() as session:
-        session.add(
-            Harvest(
-                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
-                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
-            )
-        )
-        session.query(Author).where(Author.orcid.is_not(None)).update(
-            {
-                Author.created_at: datetime.datetime(2026, 4, 28, 0, 0, 0),
-                Author.updated_at: None,
-            }
-        )
-
-    harvest_dates = []
-
-    def _capture_harvest_date(orcid, harvest_date=None):
-        # capture the harvest_date that is passed
-        # don't return results since we're just testing the harvest_date logic.
-        harvest_dates.append(harvest_date)
-        yield from ()
-
-    monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_harvest_date)
-
-    dimensions.harvest()
-
-    assert harvest_dates, "publications_from_orcid should be called for authors"
-    assert set(harvest_dates) == {None}, (
-        "previous harvest date should be omitted for recently created authors"
-    )
-
-
 def test_harvest_omits_previous_harvest_date_for_recently_updated_authors(
     test_incremental_session,
     mock_incremental_authors,

--- a/test/harvest_incremental/test_dimensions.py
+++ b/test/harvest_incremental/test_dimensions.py
@@ -106,6 +106,44 @@ def test_harvest_passes_previous_harvest_date_to_orcid_query(
     )
 
 
+def test_harvest_omits_previous_harvest_date_for_recently_created_authors(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    monkeypatch,
+):
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        session.query(Author).where(Author.orcid.is_not(None)).update(
+            {
+                Author.created_at: datetime.datetime(2026, 4, 28, 0, 0, 0),
+                Author.updated_at: None,
+            }
+        )
+
+    harvest_dates = []
+
+    def _capture_harvest_date(orcid, harvest_date=None):
+        # capture the harvest_date that is passed
+        # don't return results since we're just testing the harvest_date logic.
+        harvest_dates.append(harvest_date)
+        yield from ()
+
+    monkeypatch.setattr(dimensions, "publications_from_orcid", _capture_harvest_date)
+
+    dimensions.harvest()
+
+    assert harvest_dates, "publications_from_orcid should be called for authors"
+    assert set(harvest_dates) == {None}, (
+        "previous harvest date should be omitted for recently created authors"
+    )
+
+
 def test_harvest_omits_previous_harvest_date_for_recently_updated_authors(
     test_incremental_session,
     mock_incremental_authors,

--- a/test/harvest_incremental/test_wos.py
+++ b/test/harvest_incremental/test_wos.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import re
@@ -6,10 +7,9 @@ import pandas
 import pytest
 import requests
 
-from rialto_airflow.schema.rialto import Publication
+from rialto_airflow.schema.rialto import Publication, Author, Harvest
 from rialto_airflow.harvest_incremental import wos
 from test.utils import num_log_record_matches
-
 
 wos_key = os.environ.get("AIRFLOW_VAR_WOS_KEY")
 
@@ -44,7 +44,7 @@ def mock_wos(monkeypatch):
             },
         }
 
-    monkeypatch.setattr(wos, "orcid_publications", f)
+    monkeypatch.setattr(wos, "publications_from_orcid", f)
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def mock_many_wos(monkeypatch):
         for n in range(1, 1000):
             yield {"UID": f"mock:{n}"}
 
-    monkeypatch.setattr(wos, "orcid_publications", f)
+    monkeypatch.setattr(wos, "publications_from_orcid", f)
 
 
 @pytest.fixture
@@ -119,7 +119,7 @@ def test_orcid_publications_with_paging():
     orcid = "https://orcid.org/0000-0002-0673-5257"
 
     uids = set()
-    for pub in wos.orcid_publications(orcid):
+    for pub in wos.publications_from_orcid(orcid):
         assert pub
         assert pub["UID"] not in uids, "haven't seen publication before"
         uids.add(pub["UID"])
@@ -133,7 +133,11 @@ def test_orcid_publications_with_bad_orcid():
     This is a live test of the WoS API to ensure that a search for an invalid ORCID yields no results.
     """
     assert (
-        len(list(wos.orcid_publications("https://orcid.org/0000-0003-0784-7987-XXX")))
+        len(
+            list(
+                wos.publications_from_orcid("https://orcid.org/0000-0003-0784-7987-XXX")
+            )
+        )
         == 0
     )
 
@@ -143,6 +147,7 @@ def test_harvest(
     mock_incremental_authors,
     mock_rialto_db_name,
     mock_wos,
+    monkeypatch,
 ):
     """
     With some authors loaded and a mocked WoS API make sure that a
@@ -195,7 +200,168 @@ def test_log_message(
 ):
     caplog.set_level(logging.INFO)
     wos.harvest(limit=50)
-    assert "Reached limit of 50 publications stopping" in caplog.text
+    assert "Reached limit of 50 publications or authors, stopping" in caplog.text
+
+
+def test_harvest_with_previous_harvest_dates(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    mock_wos,
+    monkeypatch,
+):
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        # Make sure Authors are similar to those loaded in production, with created_at and updated_at dates.
+        session.query(Author).where(Author.orcid.is_not(None)).update(
+            {
+                Author.created_at: datetime.datetime(2026, 4, 20, 0, 0, 0),
+                Author.updated_at: datetime.datetime(2026, 4, 20, 0, 0, 0),
+            }
+        )
+
+    harvest_dates = []
+
+    def _capture_harvest_date(orcid, harvest_date=None):
+        # capture the harvest_date that is passed to orcid_publications so that we can assert on it later
+        # don't actually query and return any publications since we're just testing that the date is being passed in correctly
+        harvest_dates.append(harvest_date)
+        yield from ()
+
+    monkeypatch.setattr(wos, "publications_from_orcid", _capture_harvest_date)
+    wos.harvest()
+    assert set(harvest_dates) == {datetime.datetime(2026, 4, 27, 16, 38, 10)}, (
+        "formatted previous harvest date passed to publications_from_orcid"
+    )
+
+
+def test_harvest_omits_previous_harvest_date_for_recently_updated_authors(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    monkeypatch,
+):
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 25, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        session.query(Author).where(
+            Author.orcid == "https://orcid.org/0000-0000-0000-0001"
+        ).update(
+            {
+                Author.created_at: datetime.datetime(2025, 1, 1, 0, 0, 0),
+                Author.updated_at: datetime.datetime(2026, 4, 28, 0, 0, 0),
+            }
+        )
+        session.query(Author).where(
+            Author.orcid == "https://orcid.org/0000-0000-0000-0002"
+        ).update(
+            {
+                Author.created_at: datetime.datetime(2025, 1, 20, 0, 0, 0),
+                Author.updated_at: datetime.datetime(2025, 1, 1, 0, 0, 0),
+            }
+        )
+    harvest_dates = []
+
+    def _capture_harvest_date(orcid, harvest_date=None):
+        harvest_dates.append(harvest_date)
+        yield from ()
+
+    monkeypatch.setattr(wos, "publications_from_orcid", _capture_harvest_date)
+
+    wos.harvest()
+
+    assert harvest_dates, (
+        "publications_from_orcid should be called with harvest_date for ORCID authors"
+    )
+    assert harvest_dates, (
+        "publications_from_orcid should be called with harvest_date for ORCID authors"
+    )
+    assert len(harvest_dates) == 2, "two ORCID authors should be harvested"
+    assert harvest_dates == [None, datetime.datetime(2026, 4, 25, 16, 38, 10)], (
+        "recently updated author should omit previous harvest date while older updated author should keep it"
+    )
+
+
+def test_publications_from_orcid_omits_previous_harvest_date_when_none_exists(
+    test_incremental_session, mock_rialto_db_name, monkeypatch
+):
+    queries = []
+
+    def mock_wos_api(query_params):
+        # catch the query so that we can assert on it later,
+        # return an empty result set since we're just testing that the date filter is omitted when there is no previous harvest.
+        queries.append(query_params)
+        return {"publications": []}
+
+    monkeypatch.setattr(wos, "_wos_api", mock_wos_api)
+    list(wos.publications_from_orcid("0000-0002-2317-1967", harvest_date=None))
+
+    # because there is no previous harvest date, the query params should not include the loadTimeSpan filter
+    assert "loadTimeSpan" not in queries[0]
+
+
+def test_publications_from_orcid_includes_load_time_when_previous_harvest(
+    test_incremental_session, mock_rialto_db_name, monkeypatch
+):
+    queries = []
+
+    def mock_wos_api(query_params):
+        # catch the query so that we can assert on it later,
+        # return an empty result set since we're just testing that the date filter is included when there is a previous harvest.
+        queries.append(query_params)
+        yield from ()
+
+    class FixedDatetime(datetime.datetime):
+        # sets up a mock datetime class that returns a fixed current date so that we can assert on the loadTimeSpan value
+        # that is calculated based on the current date and the previous harvest date.
+        @classmethod
+        def now(cls, tz=None):
+            fixed_now = cls(2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+            return fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(wos.datetime, "datetime", FixedDatetime)
+    monkeypatch.setattr(wos, "_wos_api", mock_wos_api)
+    list(
+        wos.publications_from_orcid(
+            "0000-0002-2317-1967",
+            harvest_date=datetime.datetime(
+                2026, 4, 25, 0, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+        )
+    )
+
+    assert queries[0]["loadTimeSpan"] == "6D"
+
+
+def test_harvest_stops_when_author_limit_is_exceeded(
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    caplog,
+    monkeypatch,
+):
+    queried_orcids = []
+
+    def _capture_orcid(orcid, harvest_date=None):
+        # keep track of queries but don't return any publications (so that we're only testing the author limit)
+        queried_orcids.append(orcid)
+        yield from ()
+
+    monkeypatch.setattr(wos, "publications_from_orcid", _capture_orcid)
+
+    caplog.set_level(logging.INFO)
+    wos.harvest(limit=1)
+
+    assert queried_orcids == ["https://orcid.org/0000-0000-0000-0001"]
+    assert "Reached limit of 1 publications or authors, stopping" in caplog.text
 
 
 def test_customization_error(
@@ -245,7 +411,7 @@ def test_not_found_error(
     with test_incremental_session.begin() as session:
         assert session.query(Publication).count() == 0, "no publications loaded"
     assert (
-        "404 Client Error: Not Found for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK&usrQuery=AI"
+        "404 Client Error: Not Found for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK"
         in caplog.text
     )
 
@@ -272,7 +438,7 @@ def test_server_error(
     with test_incremental_session.begin() as session:
         assert session.query(Publication).count() == 0, "no publications loaded"
     assert (
-        "500 Server Error: Internal Server Error for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK&usrQuery=AI"
+        "500 Server Error: Internal Server Error for url: https://wos-api.clarivate.com/api/wos?databaseId=WOK"
         in caplog.text
     )
     assert " -- shrug" in caplog.text
@@ -474,7 +640,7 @@ def test_get_list_of_publications_from_dois():
 @pytest.fixture
 def mock_wos_api(monkeypatch):
     def f(*args, **kwargs):
-        query = args[0]
+        query = kwargs["query_params"]["usrQuery"]
         if "my.unretrievable" in query:
             raise requests.exceptions.HTTPError(
                 "https://wos-api.clarivate.com/api/wos?thisrequest=wontwork",


### PR DESCRIPTION
**What was changed?**
Fixes #846 to add incremental harvesting from WOS. 

Uses `loadTimeSpan` since `modifiedTimeSpan` is not available for WOK. `modifiedTimeSpan` is only available for WOS alone.

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
