### PR TITLE
Harvest updates from sul_pub

### DIFF
--- a/alembic_rialto/versions/e1d3bfbd9ffd_cascade_delete_pub_funder_association.py
+++ b/alembic_rialto/versions/e1d3bfbd9ffd_cascade_delete_pub_funder_association.py
@@ -1,0 +1,51 @@
+"""cascade delete pub_funder_association
+
+Revision ID: e1d3bfbd9ffd
+Revises: ad881a79ea4d
+Create Date: 2026-05-01
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e1d3bfbd9ffd"
+down_revision: Union[str, Sequence[str], None] = "ad881a79ea4d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_constraint(
+        "pub_funder_association_publication_id_fkey",
+        "pub_funder_association",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "pub_funder_association_publication_id_fkey",
+        "pub_funder_association",
+        "publication",
+        ["publication_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(
+        "pub_funder_association_publication_id_fkey",
+        "pub_funder_association",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "pub_funder_association_publication_id_fkey",
+        "pub_funder_association",
+        "publication",
+        ["publication_id"],
+        ["id"],
+    )

--- a/rialto_airflow/harvest_incremental/sul_pub.py
+++ b/rialto_airflow/harvest_incremental/sul_pub.py
@@ -8,6 +8,7 @@ from urllib3.util import Retry
 
 from rialto_airflow.database import get_session
 from rialto_airflow.schema.rialto import (
+    Harvest,
     Author,
     Publication,
     pub_author_association,
@@ -17,7 +18,16 @@ from rialto_airflow.utils import normalize_doi, normalize_pmid, normalize_wos_id
 
 
 def harvest(host, key, per_page=1000, limit=None):
-    for sulpub_pub in publications(host, key, per_page, limit):
+
+    # look for a previous harvest to use
+    prev_harvest = Harvest.get_previous()
+    prev_harvest_date = (
+        prev_harvest.created_at.strftime("%Y-%m-%d")
+        if prev_harvest is not None
+        else None
+    )
+
+    for sulpub_pub in publications(host, key, per_page, limit, prev_harvest_date):
         with get_session(RIALTO_DB_NAME).begin() as session:
             doi = extract_doi(sulpub_pub)
 
@@ -68,11 +78,14 @@ def harvest(host, key, per_page=1000, limit=None):
                 )
 
 
-def publications(host, key, per_page=1000, limit=None):
+def publications(host, key, per_page=1000, limit=None, harvest_date=None):
     url = f"https://{host}/publications.json"
 
     http_headers = {"CAPKEY": key}
     params = {"per": per_page}
+
+    if harvest_date is not None:
+        params["changedSince"] = harvest_date
 
     page = 0
     record_count = 0

--- a/rialto_airflow/schema/rialto.py
+++ b/rialto_airflow/schema/rialto.py
@@ -44,7 +44,11 @@ pub_author_association = Table(
 pub_funder_association = Table(
     "pub_funder_association",
     RialtoSchemaBase.metadata,
-    Column("publication_id", ForeignKey("publication.id"), primary_key=True),
+    Column(
+        "publication_id",
+        ForeignKey("publication.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
     Column("funder_id", ForeignKey("funder.id"), primary_key=True),
 )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm.session import close_all_sessions
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from rialto_airflow.database import create_schema, engine_setup
-from rialto_airflow.harvest_incremental import dimensions
+from rialto_airflow.harvest_incremental import dimensions, sul_pub
 from rialto_airflow.schema.harvest import (
     HarvestSchemaBase,
     Author,
@@ -77,6 +77,7 @@ def test_session(test_engine):
 def mock_rialto_db_name(monkeypatch):
     monkeypatch.setattr(rialto, "RIALTO_DB_NAME", "rialto_incremental_test")
     monkeypatch.setattr(dimensions, "RIALTO_DB_NAME", "rialto_incremental_test")
+    monkeypatch.setattr(sul_pub, "RIALTO_DB_NAME", "rialto_incremental_test")
 
 
 @pytest.fixture
@@ -231,13 +232,12 @@ def test_incremental_engine(monkeypatch):
 
 
 @pytest.fixture
-def test_incremental_session(test_incremental_engine, monkeypatch):
+def test_incremental_session(test_incremental_engine):
     """
     Returns a sqlalchemy session for the test database.
     """
-    # monkeypatch.setattr(publication, "RIALTO_DB_NAME", "rialto_incremental_test")
     try:
-        yield sessionmaker(engine_setup("rialto_incremental_test", echo=True))
+        yield sessionmaker(test_incremental_engine)
     finally:
         close_all_sessions()
 

--- a/test/harvest_incremental/test_sul_pub.py
+++ b/test/harvest_incremental/test_sul_pub.py
@@ -1,26 +1,11 @@
-import os
 import logging
 
-import dotenv
-import pytest
+import datetime
 
-from rialto_airflow.schema.rialto import Publication
+from rialto_airflow.schema.rialto import Harvest, Publication
 from rialto_airflow.harvest_incremental import sul_pub
 
 from test.utils import num_log_record_matches
-
-
-@pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(sul_pub, "RIALTO_DB_NAME", "rialto_incremental_test")
-
-
-dotenv.load_dotenv()
-
-sul_pub_host = os.environ.get("AIRFLOW_VAR_SUL_PUB_HOST")
-sul_pub_key = os.environ.get("AIRFLOW_VAR_SUL_PUB_KEY")
-
-no_auth = not (sul_pub_host and sul_pub_key)
 
 
 response = {
@@ -71,7 +56,7 @@ def test_harvest(
     requests_mock.get("/publications.json?page=2", json={"records": []})
 
     # harvest from sulpub
-    sul_pub.harvest(sul_pub_host, sul_pub_key)
+    sul_pub.harvest("example.org", "fake-key")
 
     # make sure there are publications in the database
     with test_incremental_session.begin() as session:
@@ -100,6 +85,66 @@ def test_harvest(
         )
 
 
+def test_harvest_with_previous_harvest(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    monkeypatch,
+    caplog,
+):
+    caplog.set_level(logging.DEBUG)
+
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+
+    harvest_dates = []
+
+    def _capture_harvest_date(host, key, per_page=1000, limit=None, harvest_date=None):
+        harvest_dates.append(harvest_date)
+        return []
+
+    monkeypatch.setattr(sul_pub, "publications", _capture_harvest_date)
+
+    # harvest from sulpub
+    sul_pub.harvest("example.org", "fake-key")
+
+    assert "2026-04-27" in harvest_dates
+
+
+def test_harvest_date(requests_mock):
+    """
+    Ensure that the harvest date is making it into sul_pub API query parameter.
+    """
+    now = datetime.date.today()
+    last_week = now - datetime.timedelta(days=7)
+    harvest_date = last_week.strftime("%Y-%m-%d")
+
+    requests_mock.get(f"/publications.json?changedSince={harvest_date}", json=response)
+    requests_mock.get(
+        f"/publications.json?changedSince={harvest_date}&page=2", json={"records": []}
+    )
+
+    assert (
+        len(
+            list(
+                sul_pub.publications(
+                    "example.org",
+                    "fake-key",
+                    per_page=1000,
+                    limit=None,
+                    harvest_date=harvest_date,
+                )
+            )
+        )
+        == 3
+    )
+
+
 def test_harvest_limit(
     test_incremental_session,
     mock_incremental_authors,
@@ -117,7 +162,7 @@ def test_harvest_limit(
     requests_mock.get("/publications.json?page=2", json={"records": []})
 
     # harvest from sulpub with a limit of one publication
-    sul_pub.harvest(sul_pub_host, sul_pub_key, limit=1)
+    sul_pub.harvest("example.org", "fake-key", limit=1)
 
     # make sure a publication is in the database and linked to the authors
     with test_incremental_session.begin() as session:
@@ -152,7 +197,7 @@ def test_harvest_when_doi_exists(
     requests_mock.get("/publications.json?page=2", json={"records": []})
 
     # harvest from sulpub
-    sul_pub.harvest(sul_pub_host, sul_pub_key)
+    sul_pub.harvest("example.org", "fake-key")
 
     # ensure that the existing publication for the DOI was updated
     with test_incremental_session.begin() as session:
@@ -183,7 +228,7 @@ def test_harvest_when_author_exists(
     requests_mock.get("/publications.json?page=2", json={"records": []})
 
     # harvest from sulpub
-    sul_pub.harvest(sul_pub_host, sul_pub_key)
+    sul_pub.harvest("example.org", "fake-key")
 
     # ensure that the existing publication for the DOI was updated
     with test_incremental_session.begin() as session:


### PR DESCRIPTION
**What was changed?**

This change will use the most recent harvest date as way to fetch only recently updated publications.

It includes a migration to ensure that deleting a Publication will cascade to the `pub_funder_association` table. I had a situation where the `remove_duplicates` step was trying to remove a publication and wasn't able to:

```
IntegrityError: (psycopg2.errors.ForeignKeyViolation) update or delete on table "publication" violates foreign key constraint "pub_funder_association_publication_id_fkey" on table "pub_funder_association"
DETAIL:  Key (id)=(20756) is still referenced from table "pub_funder_association".
```

I think this also means we should adjust the `remove_duplicates` task to preserve links between publications and funders, like it already does for authors. See #875 

Closes #848

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)

n/a
