### PR TITLE
Remove mock_rialto_db_name override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,23 +43,6 @@ addopts = "-v --cov --cov-report=html --cov-report=term --log-level INFO --log-f
 [tool.coverage.run]
 omit = ["test/*"]
 
-[tool.mypy]
-check_untyped_defs = true # Type-checks the interior of functions without type annotations.
-
-[[tool.mypy.overrides]]
-module = [
-    "dimcli",
-    "honeybadger",
-    "pyalex",
-    "requests_oauthlib",
-    "sqlalchemy_utils",
-    "jsonpath_ng",
-    "dominate",
-    "dominate.tags",
-    "typing_extensions"
-]
-ignore_missing_imports = true
-
 [dependency-groups]
 dev = [
     "apache-airflow==3.1.8",

--- a/rialto_airflow/harvest_incremental/__init__.py
+++ b/rialto_airflow/harvest_incremental/__init__.py
@@ -1,0 +1,23 @@
+from rialto_airflow.harvest_incremental import (
+    authors,
+    crossref,
+    deduplicate,
+    dimensions,
+    distill,
+    openalex,
+    pubmed,
+    sul_pub,
+    wos,
+)
+
+__all__ = [
+    "authors",
+    "crossref",
+    "deduplicate",
+    "dimensions",
+    "distill",
+    "openalex",
+    "pubmed",
+    "sul_pub",
+    "wos",
+]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,26 +5,13 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import close_all_sessions
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
+from rialto_airflow import harvest_incremental
 from rialto_airflow.database import create_schema, engine_setup
-from rialto_airflow.harvest_incremental import dimensions, sul_pub
-from rialto_airflow.schema.harvest import (
-    HarvestSchemaBase,
-    Author,
-    Funder,
-    Publication,
-    pub_author_association,
-)
-from rialto_airflow.schema.reports import ReportsSchemaBase
-from rialto_airflow.schema import rialto
-from rialto_airflow.schema.rialto import RialtoSchemaBase
-from rialto_airflow.schema.rialto import Author as RialtoAuthor
-from rialto_airflow.schema.rialto import Publication as RialtoPublication
-from rialto_airflow.schema.rialto import (
-    pub_author_association as rialto_pub_author_association,
-)
-from rialto_airflow.snapshot import Snapshot
 from rialto_airflow.publish import publication
-
+from rialto_airflow.schema import harvest as harvest_schema
+from rialto_airflow.schema import rialto as rialto_schema
+from rialto_airflow.schema import reports as reports_schema
+from rialto_airflow.snapshot import Snapshot
 
 dotenv.load_dotenv()
 
@@ -48,7 +35,7 @@ def test_engine(monkeypatch):
     create_database(db_uri)
 
     # note: rialto_airflow.database.create_schema wants the database name not uri
-    create_schema(db_name, HarvestSchemaBase)
+    create_schema(db_name, harvest_schema.HarvestSchemaBase)
 
     # it's handy seeing SQL statements in the log when testing
     return engine_setup(db_name, echo=True)
@@ -75,9 +62,36 @@ def test_session(test_engine):
 
 @pytest.fixture
 def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(rialto, "RIALTO_DB_NAME", "rialto_incremental_test")
-    monkeypatch.setattr(dimensions, "RIALTO_DB_NAME", "rialto_incremental_test")
-    monkeypatch.setattr(sul_pub, "RIALTO_DB_NAME", "rialto_incremental_test")
+    # TODO: hopefully these can go away once incremental harvesting replaces the
+    # full snapshot harvesting, and we don't need to juggle the databases
+    monkeypatch.setattr(rialto_schema, "RIALTO_DB_NAME", "rialto_incremental_test")
+    monkeypatch.setattr(
+        harvest_incremental.dimensions, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
+    monkeypatch.setattr(
+        harvest_incremental.sul_pub, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
+    monkeypatch.setattr(
+        harvest_incremental.authors, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
+    monkeypatch.setattr(
+        harvest_incremental.crossref, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
+    monkeypatch.setattr(
+        harvest_incremental.deduplicate, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
+    monkeypatch.setattr(
+        harvest_incremental.distill, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
+    monkeypatch.setattr(
+        harvest_incremental.openalex, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
+    monkeypatch.setattr(
+        harvest_incremental.pubmed, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
+    monkeypatch.setattr(
+        harvest_incremental.wos, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
 
 
 @pytest.fixture
@@ -85,7 +99,7 @@ def mock_authors(test_session):
     with test_session.begin() as session:
         session.bulk_save_objects(
             [
-                Author(
+                harvest_schema.Author(
                     sunet="janes",
                     cap_profile_id="12345",
                     orcid="https://orcid.org/0000-0000-0000-0001",
@@ -93,7 +107,7 @@ def mock_authors(test_session):
                     last_name="Stanford",
                     status=True,
                 ),
-                Author(
+                harvest_schema.Author(
                     sunet="lelands",
                     cap_profile_id="123456",
                     orcid="https://orcid.org/0000-0000-0000-0002",
@@ -103,7 +117,7 @@ def mock_authors(test_session):
                 ),
                 # this user intentionally lacks an ORCID to help test code that
                 # ignores harvesting for users that lack an ORCID
-                Author(
+                harvest_schema.Author(
                     sunet="lelelandjr",
                     cap_profile_id="1234567",
                     orcid=None,
@@ -120,7 +134,7 @@ def mock_incremental_authors(test_incremental_session):
     with test_incremental_session.begin() as session:
         session.bulk_save_objects(
             [
-                RialtoAuthor(
+                rialto_schema.Author(
                     sunet="janes",
                     cap_profile_id="12345",
                     orcid="https://orcid.org/0000-0000-0000-0001",
@@ -128,7 +142,7 @@ def mock_incremental_authors(test_incremental_session):
                     last_name="Stanford",
                     status=True,
                 ),
-                RialtoAuthor(
+                rialto_schema.Author(
                     sunet="lelands",
                     cap_profile_id="123456",
                     orcid="https://orcid.org/0000-0000-0000-0002",
@@ -138,7 +152,7 @@ def mock_incremental_authors(test_incremental_session):
                 ),
                 # this user intentionally lacks an ORCID to help test code that
                 # ignores harvesting for users that lack an ORCID
-                RialtoAuthor(
+                rialto_schema.Author(
                     sunet="lelelandjr",
                     cap_profile_id="1234567",
                     orcid=None,
@@ -153,7 +167,7 @@ def mock_incremental_authors(test_incremental_session):
 @pytest.fixture
 def mock_incremental_publication(test_incremental_session):
     with test_incremental_session.begin() as session:
-        pub = RialtoPublication(
+        pub = rialto_schema.Publication(
             doi="10.1515/9781503624153",
             sulpub_json={"sulpub": "data"},
             wos_json={"wos": "data"},
@@ -169,7 +183,7 @@ def mock_incremental_association(
 ):
     with test_incremental_session.begin() as session:
         session.execute(
-            insert(rialto_pub_author_association).values(
+            insert(rialto_schema.pub_author_association).values(
                 publication_id=1,
                 author_id=1,
             )
@@ -179,7 +193,7 @@ def mock_incremental_association(
 @pytest.fixture
 def mock_publication(test_session):
     with test_session.begin() as session:
-        pub = Publication(
+        pub = harvest_schema.Publication(
             doi="10.1515/9781503624153",
             sulpub_json={"sulpub": "data"},
             wos_json={"wos": "data"},
@@ -193,7 +207,7 @@ def mock_publication(test_session):
 def mock_association(test_session, mock_publication, mock_authors):
     with test_session.begin() as session:
         session.execute(
-            insert(pub_author_association).values(
+            insert(harvest_schema.pub_author_association).values(
                 # TODO: should the IDs be looked up in case they aren't always 1?
                 publication_id=1,
                 author_id=1,
@@ -225,7 +239,7 @@ def test_incremental_engine(monkeypatch):
     create_database(db_uri)
 
     # note: rialto_airflow.database.create_schema wants the database name not uri
-    create_schema(db_name, RialtoSchemaBase)
+    create_schema(db_name, rialto_schema.RialtoSchemaBase)
 
     # it's handy seeing SQL statements in the log when testing
     return engine_setup(db_name, echo=True)
@@ -261,7 +275,7 @@ def test_reports_engine(monkeypatch):
     create_database(db_uri)
 
     # note: rialto_airflow.database.create_schema wants the database name not uri
-    create_schema(db_name, ReportsSchemaBase)
+    create_schema(db_name, reports_schema.ReportsSchemaBase)
 
     # it's handy seeing SQL statements in the log when testing
     return engine_setup(db_name, echo=True)
@@ -562,7 +576,7 @@ def dataset(
     """
 
     with test_session.begin() as session:
-        pub = Publication(
+        pub = harvest_schema.Publication(
             doi="10.000/000001",
             title="My Life",
             apc=123,
@@ -581,7 +595,7 @@ def dataset(
             journal_name="Proceedings of the National Academy of Sciences of the United States of America",
         )
 
-        pub2 = Publication(
+        pub2 = harvest_schema.Publication(
             doi="10.000/000002",
             title="My Life Part 2",
             apc=500,
@@ -597,7 +611,7 @@ def dataset(
             faculty_authored=True,
         )
 
-        author1 = Author(
+        author1 = harvest_schema.Author(
             first_name="Jane",
             last_name="Stanford",
             sunet="janes",
@@ -614,7 +628,7 @@ def dataset(
             academic_council=True,
         )
 
-        author2 = Author(
+        author2 = harvest_schema.Author(
             first_name="Leland",
             last_name="Stanford",
             sunet="lelands",
@@ -630,7 +644,7 @@ def dataset(
             academic_council=False,
         )
 
-        author3 = Author(
+        author3 = harvest_schema.Author(
             first_name="Frederick",
             last_name="Olmstead",
             sunet="folms",
@@ -644,7 +658,7 @@ def dataset(
             academic_council=False,
         )
 
-        author4 = Author(
+        author4 = harvest_schema.Author(
             first_name="Frederick",
             last_name="Terman",
             sunet="fterm",
@@ -658,10 +672,10 @@ def dataset(
             academic_council=True,
         )
 
-        funder1 = Funder(
+        funder1 = harvest_schema.Funder(
             name="National Institutes of Health", grid_id="12345", federal=True
         )
-        funder2 = Funder(
+        funder2 = harvest_schema.Funder(
             name="Andrew Mellon Foundation", grid_id="123456", federal=False
         )
 
@@ -694,7 +708,7 @@ def dataset_incremental(
     using the rialto schema models.
     """
     with test_incremental_session.begin() as session:
-        pub = RialtoPublication(
+        pub = rialto_schema.Publication(
             doi="10.000/000001",
             title="My Life",
             apc=123,
@@ -713,7 +727,7 @@ def dataset_incremental(
             journal_name="Proceedings of the National Academy of Sciences of the United States of America",
         )
 
-        author1 = RialtoAuthor(
+        author1 = rialto_schema.Author(
             first_name="Jane",
             last_name="Stanford",
             sunet="janes",
@@ -730,7 +744,7 @@ def dataset_incremental(
             academic_council=True,
         )
 
-        author2 = RialtoAuthor(
+        author2 = rialto_schema.Author(
             first_name="Leland",
             last_name="Stanford",
             sunet="lelands",

--- a/test/harvest_incremental/test_authors.py
+++ b/test/harvest_incremental/test_authors.py
@@ -4,7 +4,6 @@ import logging
 import pandas
 import pytest
 
-from rialto_airflow.harvest_incremental import authors as authors_mod
 from rialto_airflow.harvest_incremental.authors import load_authors_table
 from rialto_airflow.schema.rialto import Author, Publication
 
@@ -42,11 +41,6 @@ def author(test_incremental_session):
                 status=True,
             )
         )
-
-
-@pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(authors_mod, "RIALTO_DB_NAME", "rialto_incremental_test")
 
 
 def test_author_fixture(test_incremental_session, author):

--- a/test/harvest_incremental/test_crossref.py
+++ b/test/harvest_incremental/test_crossref.py
@@ -1,21 +1,11 @@
 import logging
 import re
 
-import dotenv
 import pandas
-import pytest
 
 from rialto_airflow.schema.rialto import Publication
 from rialto_airflow.harvest_incremental import crossref
 from test.utils import num_log_record_matches
-
-
-@pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(crossref, "RIALTO_DB_NAME", "rialto_incremental_test")
-
-
-dotenv.load_dotenv()
 
 
 def test_get_dois():

--- a/test/harvest_incremental/test_deduplicate.py
+++ b/test/harvest_incremental/test_deduplicate.py
@@ -6,11 +6,6 @@ from rialto_airflow.harvest_incremental import deduplicate
 
 
 @pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(deduplicate, "RIALTO_DB_NAME", "rialto_incremental_test")
-
-
-@pytest.fixture
 def dataset(
     test_incremental_session,
     dim_json,

--- a/test/harvest_incremental/test_dimensions.py
+++ b/test/harvest_incremental/test_dimensions.py
@@ -1,18 +1,14 @@
 import datetime
 import logging
 import os
+
+import dimcli
 import pytest
 import requests
 
-import dotenv
-import dimcli
-
 from rialto_airflow.harvest_incremental import dimensions
 from rialto_airflow.schema.rialto import Author, Harvest, Publication
-
 from test.utils import num_log_record_matches
-
-dotenv.load_dotenv()
 
 
 def _assert_publication_has_two_expected_authors(pub):

--- a/test/harvest_incremental/test_distill.py
+++ b/test/harvest_incremental/test_distill.py
@@ -1,16 +1,8 @@
-import pytest
-
-from rialto_airflow.harvest_incremental import distill as distill_mod
 from rialto_airflow.harvest_incremental.distill import distill
 from rialto_airflow.schema.rialto import Publication
 
 # This simply tests that the distill function is working. For the detailed testing of distill rules see
 # the test/distill directory.
-
-
-@pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(distill_mod, "RIALTO_DB_NAME", "rialto_incremental_test")
 
 
 def test_distill(

--- a/test/harvest_incremental/test_openalex.py
+++ b/test/harvest_incremental/test_openalex.py
@@ -1,4 +1,3 @@
-import dotenv
 import logging
 import pytest
 
@@ -8,8 +7,6 @@ from rialto_airflow.harvest_incremental import openalex
 from rialto_airflow.schema.rialto import Publication
 
 from test.utils import num_log_record_matches
-
-dotenv.load_dotenv()
 
 
 def test_orcid_publications():
@@ -25,11 +22,6 @@ def test_orcid_publications():
             break
 
     assert count == 400, "found 100 publications"
-
-
-@pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(openalex, "RIALTO_DB_NAME", "rialto_incremental_test")
 
 
 @pytest.fixture

--- a/test/harvest_incremental/test_pubmed.py
+++ b/test/harvest_incremental/test_pubmed.py
@@ -10,11 +10,6 @@ from test.utils import load_jsonl_file, num_log_record_matches
 
 
 @pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(pubmed, "RIALTO_DB_NAME", "rialto_incremental_test")
-
-
-@pytest.fixture
 def mock_pubmed_fetch(monkeypatch):
     """
     Mock our function for fetching publications from a list of PMIDs from Pubmed.

--- a/test/harvest_incremental/test_wos.py
+++ b/test/harvest_incremental/test_wos.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 
-import dotenv
 import pandas
 import pytest
 import requests
@@ -11,15 +10,8 @@ from rialto_airflow.schema.rialto import Publication
 from rialto_airflow.harvest_incremental import wos
 from test.utils import num_log_record_matches
 
-dotenv.load_dotenv()
-
 
 wos_key = os.environ.get("AIRFLOW_VAR_WOS_KEY")
-
-
-@pytest.fixture
-def mock_rialto_db_name(monkeypatch):
-    monkeypatch.setattr(wos, "RIALTO_DB_NAME", "rialto_incremental_test")
 
 
 @pytest.fixture


### PR DESCRIPTION
**What was changed?**

I ran into an issue with the harvest_incremental sulpub test not using
the right database (rialto_test instead rialto_incrmental_test). The
problem turned out to be that the test module was overriding the
mock_rialto_db_name fixture.

I took the opportunity to import and separate out the different
sqlalchemy schemas in the same way, to make it a bit easier to digest.

There was also some unnecessary dotenv loading going on that can be
removed since that is happening in conftest.

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)

n/a
