### PR TITLE
PubMed incremental harvest

### DIFF
--- a/rialto_airflow/harvest_incremental/pubmed.py
+++ b/rialto_airflow/harvest_incremental/pubmed.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import os
@@ -20,6 +21,7 @@ from rialto_airflow.schema.rialto import (
     Publication,
     pub_author_association,
     RIALTO_DB_NAME,
+    Harvest,
 )
 from rialto_airflow.utils import normalize_doi, normalize_pmid
 
@@ -61,8 +63,11 @@ def harvest(limit=None) -> None:
     """
     Walk through all the Author ORCIDs and generate publications for them from pubmed.
     """
-    count = 0
+    pub_count = 0
+    author_count = 0
     stop = False
+
+    previous_harvest = Harvest.get_previous()
 
     with get_session(RIALTO_DB_NAME).begin() as select_session:
         # get all authors that have an ORCID
@@ -73,14 +78,30 @@ def harvest(limit=None) -> None:
                 logging.warning(f"Reached limit of {limit} publications stopping")
                 break
 
-            pmids = pmids_from_orcid(author.orcid)
+            author_count += 1
+            if limit and author_count > limit:
+                logging.warning(f"Reached limit of {limit} authors stopping")
+                break
+
+            # if the author has had their information added or modified since the last
+            # harvest then we will want to backfill publications since we
+            # haven't collected their publications before
+
+            if (
+                previous_harvest is not None
+                and author.updated_at > previous_harvest.created_at
+            ):
+                pmids = pmids_from_orcid(author.orcid)
+            else:
+                pmids = pmids_from_orcid(author.orcid, previous_harvest)
+
             if not pmids:
                 logging.debug(f"No publications found for {author.orcid}")
                 continue
 
             for pubmed_pub in publications_from_pmids(pmids):
-                count += 1
-                if limit is not None and count > limit:
+                pub_count += 1
+                if limit is not None and pub_count > limit:
                     stop = True
                     break
 
@@ -88,6 +109,8 @@ def harvest(limit=None) -> None:
                 pubmed_id = normalize_pmid(get_identifier(pubmed_pub, "pubmed"))
 
                 with get_session(RIALTO_DB_NAME).begin() as insert_session:
+                    harvested_at = datetime.datetime.now(datetime.timezone.utc)
+
                     # if there's a DOI constraint violation we need to update instead of insert
                     pub_id = insert_session.execute(
                         insert(Publication)
@@ -95,10 +118,15 @@ def harvest(limit=None) -> None:
                             doi=doi,
                             pubmed_json=pubmed_pub,
                             pubmed_id=pubmed_id,
+                            pubmed_harvested=harvested_at,
                         )
                         .on_conflict_do_update(
                             constraint="publication_doi_key",
-                            set_=dict(pubmed_json=pubmed_pub, pubmed_id=pubmed_id),
+                            set_=dict(
+                                pubmed_json=pubmed_pub,
+                                pubmed_id=pubmed_id,
+                                pubmed_harvested=harvested_at,
+                            ),
                         )
                         .returning(Publication.id)
                     ).scalar_one()
@@ -162,7 +190,9 @@ def fill_in() -> None:
     logging.info(f"filled in {count} publications")
 
 
-def pmids_from_orcid(orcid: str) -> list[str]:
+def pmids_from_orcid(
+    orcid: str, previous_harvest: Optional[Harvest] = None
+) -> list[str]:
     """
     Returns PMIDs associated with a given ORCID.
     """
@@ -170,7 +200,7 @@ def pmids_from_orcid(orcid: str) -> list[str]:
     if m := re.match(r"^https?://orcid.org/(.+)$", orcid):
         orcid = m.group(1)
 
-    return _pubmed_search_api(f"{orcid}[auid]")
+    return _pubmed_search_api(f"{orcid}[auid]", previous_harvest=previous_harvest)
 
 
 # NOTE: You will get a list of PMIDs that may be shorter than the list of DOIs if not all are found
@@ -234,12 +264,20 @@ def publications_from_pmids(pmids: list[str], retries=10) -> list[dict[Any, Any]
         return pubs
 
 
-def _pubmed_search_api(query, retries=10) -> list:
+def _pubmed_search_api(
+    query: str, previous_harvest: Optional[Harvest] = None, retries: int = 10
+) -> list:
     """
     Return a list of pmids given a general search query.
     """
 
     params = {**BASE_PARAMS, "retmode": "json", "term": query}
+
+    if previous_harvest:
+        params["datetype"] = "mdat"
+        params["mindate"] = previous_harvest.created_at.strftime("%Y/%m/%d")
+        params["maxdate"] = datetime.date.today().strftime("%Y/%m/%d")
+
     logging.debug(f"searching pubmed with {params}")
 
     response = http.get(SEARCH_URL, params=params, headers=HEADERS)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,7 +7,6 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from rialto_airflow import harvest_incremental
 from rialto_airflow.database import create_schema, engine_setup
-from rialto_airflow.harvest_incremental import dimensions, wos
 from rialto_airflow.publish import publication
 from rialto_airflow.schema import harvest as harvest_schema
 from rialto_airflow.schema import rialto as rialto_schema
@@ -93,8 +92,9 @@ def mock_rialto_db_name(monkeypatch):
     monkeypatch.setattr(
         harvest_incremental.wos, "RIALTO_DB_NAME", "rialto_incremental_test"
     )
-    monkeypatch.setattr(dimensions, "RIALTO_DB_NAME", "rialto_incremental_test")
-    monkeypatch.setattr(wos, "RIALTO_DB_NAME", "rialto_incremental_test")
+    monkeypatch.setattr(
+        harvest_incremental.dimensions, "RIALTO_DB_NAME", "rialto_incremental_test"
+    )
 
 
 @pytest.fixture

--- a/test/harvest_incremental/test_pubmed.py
+++ b/test/harvest_incremental/test_pubmed.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import re
 
@@ -6,7 +7,7 @@ import requests
 from xml.parsers.expat import ExpatError
 
 from rialto_airflow.harvest_incremental import pubmed
-from rialto_airflow.schema.rialto import Publication
+from rialto_airflow.schema.rialto import Author, Harvest, Publication
 from test.utils import load_jsonl_file, num_log_record_matches
 
 
@@ -338,7 +339,94 @@ def test_harvest(
         assert pubs[0].authors[1].orcid == "https://orcid.org/0000-0000-0000-0002"
 
 
-def test_harvest_limit(
+def test_incremental_harvest(
+    test_incremental_session,
+    mock_rialto_db_name,
+    requests_mock,
+):
+    """
+    Ensure that a previous Harvest alters how pubmed IDs are fetched.
+    """
+
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        session.add(
+            Author(
+                first_name="Jane",
+                last_name="Stanford",
+                orcid="0000-0000-0000-0001",
+                created_at=datetime.datetime(2026, 4, 1, 0, 0, 0),
+                updated_at=datetime.datetime(2026, 4, 1, 0, 0, 0),
+            )
+        )
+
+    requests_mock.get(
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+        json={"esearchresult": {"count": 0}},
+    )
+
+    # harvest from Pubmed
+    pubmed.harvest()
+
+    assert requests_mock.called
+    assert len(requests_mock.request_history) == 1
+    req = requests_mock.request_history[0]
+    assert req.qs["term"] == ["0000-0000-0000-0001[auid]"]
+    assert req.qs["datetype"] == ["mdat"]
+    assert req.qs["mindate"] == ["2026/04/27"]
+    assert req.qs["maxdate"] == [datetime.date.today().strftime("%Y/%m/%d")]
+
+
+def test_incremental_harvest_with_new_author(
+    test_incremental_session,
+    mock_rialto_db_name,
+    requests_mock,
+):
+    """
+    Ensure that an updated Author causes a full harvest of their publications
+    independent of whether there was a previous Harvest.
+    """
+
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        session.add(
+            Author(
+                first_name="Jane",
+                last_name="Stanford",
+                orcid="0000-0000-0000-0001",
+                created_at=datetime.datetime(2026, 5, 1, 0, 0, 0),
+                updated_at=datetime.datetime(2026, 5, 1, 0, 0, 0),
+            )
+        )
+
+    requests_mock.get(
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+        json={"esearchresult": {"count": 0}},
+    )
+
+    # harvest from Pubmed
+    pubmed.harvest()
+
+    assert requests_mock.called
+    assert len(requests_mock.request_history) == 1
+    req = requests_mock.request_history[0]
+    assert req.qs["term"] == ["0000-0000-0000-0001[auid]"]
+    assert "datetype" not in req.qs
+    assert "mindate" not in req.qs
+    assert "maxdate" not in req.qs
+
+
+def test_harvest_publication_limit(
     test_incremental_session,
     mock_incremental_authors,
     mock_rialto_db_name,
@@ -373,6 +461,34 @@ def test_harvest_limit(
             )
             == 1
         )
+
+
+def test_harvest_author_limit(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    caplog,
+    requests_mock,
+):
+    """
+    With some authors loaded and a mocked Pubmed API and an artificially low
+    harvest limit, confirm that processing stops as expected and logs appropriately.
+    """
+
+    requests_mock.get(
+        re.compile(".*"),
+        json={
+            "header": {"type": "esearch", "version": "0.3"},
+            "esearchresult": {"count": "0"},
+        },
+        status_code=200,
+        headers={"Content-Type": "application/json"},
+    )
+
+    # harvest from Pubmed with a limit of one publication
+    pubmed.harvest(1)
+
+    assert "Reached limit of 1 authors stopping" in caplog.text
 
 
 def test_harvest_no_pubmed_results(


### PR DESCRIPTION
**What was changed?**

This change adds incremental harvesting for PubMed.

One detail about PubMed harvesting is that if you want to get records
that were modified since a particular date you need to provide both a 
min and max date range.

Closes #847

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)

n/a
