### PR TITLE
refine doi format regexes

### DIFF
--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -39,8 +39,9 @@ def downloads_dir(data_dir):
 def _doi_candidate_regex() -> re.Pattern:
     """
     One of the few things we can truly rely on when it comes to DOI format is that it will start with '10.'
+    and have a prefix and suffix separated by a slash. The prefix must be at least 3 characters long.
     """
-    return re.compile("10\\..+")
+    return re.compile("10\\.[^/]{3,}/.+")
 
 
 def _doi_candidate_extract(possible_doi_with_junk: str) -> str | None:
@@ -56,13 +57,12 @@ def _doi_known_format_regex_list() -> list[re.Pattern]:
     * https://www.crossref.org/blog/dois-and-matching-regular-expressions/ (via a different answer to the above question)
     """
     doi_filter_patterns = [
-        "^10\\.\\d{4,9}/[-\\._;()/:a-zA-Z0-9]+$",  # matches e.g. '10.123456789/publication.ABC.123_123-a(23).1239'
+        "^10\\.\\d{3,9}/[-\\._;()/:a-zA-Z0-9]+$",  # matches e.g. '10.123456789/publication.ABC.123_123-a(23).1239'
         "^10\\.1002/[^\\s]+$",  # matches e.g. '10.1002/abc.1542.df'
         "^10\\.\\d{4}/\\d+-\\d+X?\\(\\d+\\)\\d+<[\\d\\w]+:[\\d\\w]*>\\d+\\.\\d+\\.\\w+;\\d$",  # matches e.g. '10.8888/7654-321X(12345)12345<1a2b3c:d4e5>1.2.a;1'
         "^10\\.1021/\\w\\w\\d+$",  # matches e.g. '10.1021/a_1029384756'
         "^10\\.1207/[\\w\\d]+\\&\\d+_\\d+$",  # matches e.g. '10.1207/a12b0z&456_765'
-        "^\\b(10[\\.][0-9]{4,}(?:[\\.][0-9]+)*/(?:(?![\"&'<>])\\S)+)\\b$",  # matches e.g. '10.1016.12.31/nature.S0735-1097(98)2000/12/31/34:7-7' (SO post builds to this regex)
-        "^\\d",
+        "^\\b(10[\\.][0-9]{3,}(?:[0-9.]+)*/(?:(?![\"&'<>])\\S)+)\\b$",  # matches e.g. '10.1016.12.31/nature.S0735-1097(98)2000/12/31/34:7-7' (SO post builds to this regex)
     ]
     return [re.compile(p) for p in doi_filter_patterns]
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -82,6 +82,17 @@ def test_normalize_doi():
         is None
     )
     assert utils.normalize_doi('10.1562/0031-8655(2004)"79') is None
+    assert utils.normalize_doi("10.1234") is None
+    assert utils.normalize_doi("10.1234/") is None
+    assert (
+        utils.normalize_doi("10.15/scnp00500056") is None
+    )  # two digits after 10. not allowed
+    assert (
+        utils.normalize_doi("10.153/scnp00500056") == "10.153/scnp00500056"
+    )  # legacy can have three digits after 10.
+    assert (
+        utils.normalize_doi("10.1007/s11367-016-1117-6") == "10.1007/s11367-016-1117-6"
+    )
 
 
 def test_normalize_pmid():


### PR DESCRIPTION
**What was changed?**

Looking at https://github.com/sul-dlss/rialto-airflow/issues/658

This:
- allows certain variants that are currently flagged as invalid but are actually, namely dois that only three digits after the `10.`, e.g. `10.102/es400396f`
- rejects DOIs without a suffix. e.g. `10.5772` and `10.1148/`

The others listed in the comment that are valid currently pass the validation without any changes needed: https://github.com/sul-dlss/rialto-airflow/issues/658#issuecomment-4209729455

Not sure how to determine if there are other rejected cases that should pass or other passed cases that should be rejected.

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
