### PR TITLE
Add incremental harvesting from OpenAlex

### DIFF
--- a/rialto_airflow/harvest_incremental/openalex.py
+++ b/rialto_airflow/harvest_incremental/openalex.py
@@ -1,3 +1,4 @@
+import datetime
 from functools import cache
 import logging
 import os
@@ -14,6 +15,7 @@ from rialto_airflow.schema.rialto import (
     Publication,
     pub_author_association,
     RIALTO_DB_NAME,
+    Harvest,
 )
 from rialto_airflow.utils import normalize_doi, normalize_pmid
 
@@ -27,21 +29,49 @@ def harvest(limit=None) -> None:
     """
     Walk through all the Author ORCIDs and generate publications for them.
     """
-    count = 0
+    pub_count = 0
+    author_count = 0
     stop = False
 
     with get_session(RIALTO_DB_NAME).begin() as select_session:
+        previous_harvest = Harvest.get_previous()
+        previous_harvest_date = None
+        if previous_harvest is not None:
+            previous_harvest_date = previous_harvest.created_at.isoformat()
+
+        logging.debug(f"previous harvest date is {previous_harvest_date}")
         # get all authors that have an ORCID
         for author in (
             select_session.query(Author).where(Author.orcid.is_not(None)).all()
         ):
+            author_count += 1
+            if limit is not None and author_count > limit:
+                stop = True
+
             if stop is True:
-                logging.warning(f"Reached limit of {limit} publications stopping")
+                logging.warning(
+                    f"Reached limit of {limit} publications or authors, stopping"
+                )
                 break
 
-            for openalex_pub in orcid_publications(author.orcid):
-                count += 1
-                if limit is not None and count > limit:
+            # if the author was created or updated after the last harvest (e.g. adding an ORCID),
+            # we want to get all their publications, not just ones since the last harvest timestamp.
+            author_harvest_date = previous_harvest_date
+            if previous_harvest is not None:
+                # when the author was updated after the last harvest started, get all pubs for that author.
+                if (
+                    author.updated_at is not None
+                    and author.updated_at >= previous_harvest.created_at
+                ):
+                    author_harvest_date = None
+            logging.debug(
+                f"harvesting publications for author {author.orcid} with harvest date {author_harvest_date}"
+            )
+            for openalex_pub in publications_from_orcid(
+                author.orcid, harvest_date=author_harvest_date
+            ):
+                pub_count += 1
+                if limit is not None and pub_count > limit:
                     stop = True
                     break
 
@@ -50,6 +80,7 @@ def harvest(limit=None) -> None:
                 pubmed_id = normalize_pmid(openalex_pub.get("ids", {}).get("pmid"))
 
                 with get_session(RIALTO_DB_NAME).begin() as insert_session:
+                    harvested_at = datetime.datetime.now(datetime.timezone.utc)
                     # if there's a DOI constraint violation we need to update instead of insert
                     pub_id = insert_session.execute(
                         insert(Publication)
@@ -57,12 +88,14 @@ def harvest(limit=None) -> None:
                             doi=doi,
                             openalex_json=openalex_pub,
                             pubmed_id=pubmed_id,
+                            openalex_harvested=harvested_at,
                         )
                         .on_conflict_do_update(
                             constraint="publication_doi_key",
                             set_=dict(
                                 openalex_json=openalex_pub,
                                 pubmed_id=pubmed_id,
+                                openalex_harvested=harvested_at,
                             ),
                         )
                         .returning(Publication.id)
@@ -77,14 +110,15 @@ def harvest(limit=None) -> None:
                     )
 
 
-def orcid_publications(orcid: str) -> Generator[dict, None, None]:
+def publications_from_orcid(
+    orcid: str, harvest_date: str | None = None
+) -> Generator[dict, None, None]:
     """
     Pass in the ORCID ID and get an iterator for publications by that author.
     """
     # TODO: I think we can maybe have this function take a list of orcids and
     # batch process them since we can filter by multiple orcids in one request?
     logging.debug(f"looking up publications for orcid {orcid}")
-
     # get the first (and hopefully only) openalex id for the orcid
     authors = Authors().filter(orcid=orcid).get()
     if len(authors) == 0:
@@ -93,9 +127,17 @@ def orcid_publications(orcid: str) -> Generator[dict, None, None]:
         logging.warning(f"found more than one openalex author id for {orcid}")
     author_id = authors[0]["id"]
 
-    # get all the works for the openalex author id
-    for page in Works().filter(author={"id": author_id}).paginate(per_page=200):
-        yield from page
+    if harvest_date is not None:
+        for page in (
+            Works()
+            .filter(from_updated_date=harvest_date, author={"id": author_id})
+            .paginate(per_page=200)
+        ):
+            yield from page
+    else:
+        # get all the works for the openalex author id
+        for page in Works().filter(author={"id": author_id}).paginate(per_page=200):
+            yield from page
 
 
 def fill_in() -> None:

--- a/test/harvest_incremental/test_openalex.py
+++ b/test/harvest_incremental/test_openalex.py
@@ -1,20 +1,23 @@
+import datetime
 import logging
 import pytest
 
 import pyalex
 import requests
 from rialto_airflow.harvest_incremental import openalex
-from rialto_airflow.schema.rialto import Publication
+from rialto_airflow.schema.rialto import Publication, Harvest, Author
 
 from test.utils import num_log_record_matches
 
 
-def test_orcid_publications():
+def test_publications_from_orcid():
     """
     This is a live test of OpenAlex API, to make sure paging works properly.
     """
     count = 0
-    for pub in openalex.orcid_publications("https://orcid.org/0000-0002-8030-5327"):
+    for pub in openalex.publications_from_orcid(
+        "https://orcid.org/0000-0002-8030-5327", harvest_date=None
+    ):
         assert pub
 
         count += 1
@@ -38,7 +41,7 @@ def mock_openalex(monkeypatch):
             "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/36857419"},
         }
 
-    monkeypatch.setattr(openalex, "orcid_publications", f)
+    monkeypatch.setattr(openalex, "publications_from_orcid", f)
 
 
 def test_harvest(
@@ -130,7 +133,7 @@ def mock_many_openalex(monkeypatch):
                 "publication_year": 1891,
             }
 
-    monkeypatch.setattr(openalex, "orcid_publications", f)
+    monkeypatch.setattr(openalex, "publications_from_orcid", f)
 
 
 def test_log_message(
@@ -141,7 +144,7 @@ def test_log_message(
 ):
     caplog.set_level(logging.INFO)
     openalex.harvest(limit=50)
-    assert "Reached limit of 50 publications stopping" in caplog.text
+    assert "Reached limit of 50 publications or authors, stopping" in caplog.text
 
 
 class MockWorks:
@@ -368,3 +371,193 @@ def test_source_by_issn_jsonerror(monkeypatch, caplog):
     source = openalex.source_by_issn("XXXX-0836")
     assert source is None
     assert "Error decoding JSON for ISSN XXXX-0836" in caplog.text
+
+
+def test_harvest_passes_previous_harvest_date_to_orcid_query(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    monkeypatch,
+):
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        # Make sure Authors are similar to those loaded in production, with timestamps.
+        session.query(Author).where(Author.orcid.is_not(None)).update(
+            {
+                Author.created_at: datetime.datetime(2026, 4, 20, 0, 0, 0),
+                Author.updated_at: datetime.datetime(2026, 4, 20, 0, 0, 0),
+            }
+        )
+
+    harvest_dates = []
+
+    def _capture_harvest_date(orcid, harvest_date=None):
+        # capture the harvest_date that is passed to publications_from_orcid so that we can assert on it later
+        harvest_dates.append(harvest_date)
+        yield from ()
+
+    monkeypatch.setattr(openalex, "publications_from_orcid", _capture_harvest_date)
+
+    openalex.harvest()
+    assert harvest_dates, (
+        "publications_from_orcid is passed the recent finished harvest date"
+    )
+    assert set(harvest_dates) == {"2026-04-27T16:38:10"}, (
+        "formatted previous harvest date passed to publications_from_orcid"
+    )
+
+
+def test_harvest_omits_previous_harvest_date_for_recently_updated_authors(
+    test_incremental_session,
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    monkeypatch,
+):
+    with test_incremental_session.begin() as session:
+        session.add(
+            Harvest(
+                created_at=datetime.datetime(2026, 4, 25, 16, 38, 10),
+                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+            )
+        )
+        session.query(Author).where(
+            Author.orcid == "https://orcid.org/0000-0000-0000-0001"
+        ).update(
+            {
+                Author.created_at: datetime.datetime(2025, 1, 1, 0, 0, 0),
+                Author.updated_at: datetime.datetime(2026, 4, 28, 0, 0, 0),
+            }
+        )
+        session.query(Author).where(
+            Author.orcid == "https://orcid.org/0000-0000-0000-0002"
+        ).update(
+            {
+                Author.created_at: datetime.datetime(2025, 1, 20, 0, 0, 0),
+                Author.updated_at: datetime.datetime(2025, 1, 1, 0, 0, 0),
+            }
+        )
+
+    harvest_dates = []
+
+    def _capture_harvest_date(orcid, harvest_date=None):
+        harvest_dates.append(harvest_date)
+        yield from ()
+
+    monkeypatch.setattr(openalex, "publications_from_orcid", _capture_harvest_date)
+
+    openalex.harvest()
+
+    assert harvest_dates, (
+        "publications_from_orcid should be called with harvest_date for ORCID authors"
+    )
+    assert len(harvest_dates) == 2, "two ORCID authors should be harvested"
+    assert harvest_dates == [None, "2026-04-25T16:38:10"], (
+        "recently updated author should omit previous harvest date while unupdatedauthor should keep it"
+    )
+
+
+def test_publications_from_orcid_omits_from_updated_date_when_harvest_date_is_none(
+    monkeypatch,
+):
+    class MockAuthors:
+        def filter(self, **kwargs):
+            return self
+
+        def get(self):
+            return [{"id": "https://openalex.org/A123"}]
+
+    class MockWorks:
+        def __init__(self):
+            self.filter_kwargs = None
+            self.per_page = None
+
+        def filter(self, **kwargs):
+            self.filter_kwargs = kwargs
+            return self
+
+        def paginate(self, per_page=200):
+            self.per_page = per_page
+            yield []
+
+    mock_works = MockWorks()
+
+    monkeypatch.setattr(openalex, "Authors", lambda: MockAuthors())
+    monkeypatch.setattr(openalex, "Works", lambda: mock_works)
+
+    list(
+        openalex.publications_from_orcid(
+            "https://orcid.org/0000-0002-8030-5327", harvest_date=None
+        )
+    )
+
+    assert mock_works.filter_kwargs == {"author": {"id": "https://openalex.org/A123"}}
+    assert mock_works.per_page == 200
+
+
+def test_publications_from_orcid_includes_from_updated_date_when_harvest_date_exists(
+    monkeypatch,
+):
+    class MockAuthors:
+        def filter(self, **kwargs):
+            return self
+
+        def get(self):
+            return [{"id": "https://openalex.org/A123"}]
+
+    class MockWorks:
+        def __init__(self):
+            self.filter_kwargs = None
+            self.per_page = None
+
+        def filter(self, **kwargs):
+            self.filter_kwargs = kwargs
+            return self
+
+        def paginate(self, per_page=200):
+            self.per_page = per_page
+            yield []
+
+    mock_works = MockWorks()
+    harvest_date = "2026-04-27T16:38:10"
+
+    monkeypatch.setattr(openalex, "Authors", lambda: MockAuthors())
+    monkeypatch.setattr(openalex, "Works", lambda: mock_works)
+
+    list(
+        openalex.publications_from_orcid(
+            "https://orcid.org/0000-0002-8030-5327", harvest_date=harvest_date
+        )
+    )
+
+    assert mock_works.filter_kwargs == {
+        "from_updated_date": harvest_date,
+        "author": {"id": "https://openalex.org/A123"},
+    }
+    assert mock_works.per_page == 200
+
+
+def test_harvest_stops_when_author_limit_is_exceeded(
+    mock_incremental_authors,
+    mock_rialto_db_name,
+    caplog,
+    monkeypatch,
+):
+    queried_orcids = []
+
+    def _capture_orcid(orcid, harvest_date=None):
+        # keep track of ORCID queries but doesn't return any publications (so that we're only testing the author limit)
+        queried_orcids.append(orcid)
+        yield from ()
+
+    monkeypatch.setattr(openalex, "publications_from_orcid", _capture_orcid)
+
+    caplog.set_level(logging.INFO)
+    openalex.harvest(limit=1)
+
+    assert queried_orcids == ["https://orcid.org/0000-0000-0000-0001"]
+    assert "Reached limit of 1 publications or authors, stopping" in caplog.text


### PR DESCRIPTION
**What was changed?**
Closes #845 to add incremental harvesting of OpenAlex. Uses a `from_updated_date` to restrict the publications retrieved to those within the date ranges since the last harvest started. 

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
N/A
