### PR TITLE
use edat and relative dates for pubmed incremental harvests

### DIFF
--- a/rialto_airflow/harvest_incremental/pubmed.py
+++ b/rialto_airflow/harvest_incremental/pubmed.py
@@ -23,7 +23,7 @@ from rialto_airflow.schema.rialto import (
     RIALTO_DB_NAME,
     Harvest,
 )
-from rialto_airflow.utils import normalize_doi, normalize_pmid
+from rialto_airflow.utils import days_since, normalize_doi, normalize_pmid
 
 
 PUBMED_KEY = os.environ.get("AIRFLOW_VAR_PUBMED_KEY")
@@ -279,9 +279,13 @@ def _pubmed_search_api(
     params = {**BASE_PARAMS, "retmode": "json", "term": query}
 
     if previous_harvest:
-        params["datetype"] = "mdat"
-        params["mindate"] = previous_harvest.created_at.strftime("%Y/%m/%d")
-        params["maxdate"] = datetime.date.today().strftime("%Y/%m/%d")
+        params["datetype"] = "edat"
+        # Calculate number of days since the start of the previous finished harvest
+        number_of_days = days_since(previous_harvest.created_at)
+        if number_of_days <= 0:
+            logging.info("Zero days since last harvest, nothing to do.")
+            return []
+        params["reldate"] = number_of_days
 
     logging.debug(f"searching pubmed with {params}")
 

--- a/rialto_airflow/harvest_incremental/wos.py
+++ b/rialto_airflow/harvest_incremental/wos.py
@@ -21,6 +21,7 @@ from rialto_airflow.schema.rialto import (
     Harvest,
 )
 from rialto_airflow.utils import (
+    days_since,
     normalize_doi,
     normalize_pmid,
     normalize_wos_id,
@@ -169,10 +170,7 @@ def publications_from_orcid(orcid, harvest_date=None) -> Generator[dict, None, N
     if harvest_date is not None:
         # construct a date limiter that is relative to the current date, since WOK does not allow use of the modifiedTimeSpan limiter
         # date limiter should use the number of days since the start of the previous finished harvest + "D", e.g. "7D"
-        # Although harvest_date will have been saved as a UTC datetime, to avoid a TypeError making sure it's timezone-aware.
-        harvest_date = harvest_date.astimezone(datetime.timezone.utc)
-        current_date = datetime.datetime.now(datetime.timezone.utc)
-        number_of_days = (current_date - harvest_date).days
+        number_of_days = days_since(harvest_date)
         if number_of_days > 0:
             query_params["loadTimeSpan"] = f"{number_of_days}D"
     yield from _wos_api(query_params=query_params)

--- a/rialto_airflow/utils.py
+++ b/rialto_airflow/utils.py
@@ -1,8 +1,9 @@
+import datetime
 import re
 import logging
 from functools import cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 
 def rialto_authors_file(data_dir):
@@ -202,3 +203,21 @@ def add_orcid(data: dict[Any, Any], orcid: str):
     of an orcid key.
     """
     return {"orcid": orcid, "data": data}
+
+
+def days_since(
+    start_date: datetime.datetime, end_date: Optional[datetime.datetime] = None
+) -> int:
+    """
+    Returns the number of days between start_date and end_date.
+    If end_date is None, it defaults to the current time.
+    Both dates are converted to UTC for calculation.
+    """
+    start_date = start_date.astimezone(datetime.timezone.utc)
+
+    if end_date is None:
+        end_date = datetime.datetime.now(datetime.timezone.utc)
+    else:
+        end_date = end_date.astimezone(datetime.timezone.utc)
+
+    return (end_date - start_date).days

--- a/test/harvest_incremental/test_pubmed.py
+++ b/test/harvest_incremental/test_pubmed.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import re
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -343,7 +344,6 @@ def test_incremental_harvest(
     test_incremental_session,
     mock_rialto_db_name,
     requests_mock,
-    time_machine,
 ):
     """
     Ensure that a previous Harvest alters how pubmed IDs are fetched.
@@ -351,49 +351,52 @@ def test_incremental_harvest(
 
     # Mock the current time to a fixed value
     now = datetime.datetime(2026, 5, 13, 12, 0, 0, tzinfo=datetime.timezone.utc)
-    time_machine.move_to(now)
 
-    with test_incremental_session.begin() as session:
-        session.add(
-            Harvest(
-                created_at=datetime.datetime(
-                    2026, 4, 27, 16, 38, 10, tzinfo=datetime.timezone.utc
-                ),
-                finished_at=datetime.datetime(
-                    2026, 4, 28, 0, 0, 0, tzinfo=datetime.timezone.utc
-                ),
+    with patch("rialto_airflow.utils.datetime") as mock_datetime:
+        mock_datetime.datetime.now.return_value = now
+        mock_datetime.timezone = datetime.timezone
+
+        with test_incremental_session.begin() as session:
+            session.add(
+                Harvest(
+                    created_at=datetime.datetime(
+                        2026, 4, 27, 16, 38, 10, tzinfo=datetime.timezone.utc
+                    ),
+                    finished_at=datetime.datetime(
+                        2026, 4, 28, 0, 0, 0, tzinfo=datetime.timezone.utc
+                    ),
+                )
             )
-        )
-        session.add(
-            Author(
-                first_name="Jane",
-                last_name="Stanford",
-                orcid="0000-0000-0000-0001",
-                created_at=datetime.datetime(
-                    2026, 4, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
-                ),
-                updated_at=datetime.datetime(
-                    2026, 4, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
-                ),
+            session.add(
+                Author(
+                    first_name="Jane",
+                    last_name="Stanford",
+                    orcid="0000-0000-0000-0001",
+                    created_at=datetime.datetime(
+                        2026, 4, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    updated_at=datetime.datetime(
+                        2026, 4, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+                    ),
+                )
             )
+
+        requests_mock.get(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            json={"esearchresult": {"count": 0}},
         )
 
-    requests_mock.get(
-        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
-        json={"esearchresult": {"count": 0}},
-    )
+        # harvest from Pubmed
+        pubmed.harvest()
 
-    # harvest from Pubmed
-    pubmed.harvest()
-
-    assert requests_mock.called
-    assert len(requests_mock.request_history) == 1
-    req = requests_mock.request_history[0]
-    assert req.qs["term"] == ["0000-0000-0000-0001[auid]"]
-    assert req.qs["datetype"] == ["edat"]
-    assert req.qs["reldate"] == ["15"]
-    assert "mindate" not in req.qs
-    assert "maxdate" not in req.qs
+        assert requests_mock.called
+        assert len(requests_mock.request_history) == 1
+        req = requests_mock.request_history[0]
+        assert req.qs["term"] == ["0000-0000-0000-0001[auid]"]
+        assert req.qs["datetype"] == ["edat"]
+        assert req.qs["reldate"] == ["15"]
+        assert "mindate" not in req.qs
+        assert "maxdate" not in req.qs
 
 
 def test_incremental_harvest_with_new_author(

--- a/test/harvest_incremental/test_pubmed.py
+++ b/test/harvest_incremental/test_pubmed.py
@@ -343,16 +343,25 @@ def test_incremental_harvest(
     test_incremental_session,
     mock_rialto_db_name,
     requests_mock,
+    time_machine,
 ):
     """
     Ensure that a previous Harvest alters how pubmed IDs are fetched.
     """
 
+    # Mock the current time to a fixed value
+    now = datetime.datetime(2026, 5, 13, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    time_machine.move_to(now)
+
     with test_incremental_session.begin() as session:
         session.add(
             Harvest(
-                created_at=datetime.datetime(2026, 4, 27, 16, 38, 10),
-                finished_at=datetime.datetime(2026, 4, 28, 0, 0, 0),
+                created_at=datetime.datetime(
+                    2026, 4, 27, 16, 38, 10, tzinfo=datetime.timezone.utc
+                ),
+                finished_at=datetime.datetime(
+                    2026, 4, 28, 0, 0, 0, tzinfo=datetime.timezone.utc
+                ),
             )
         )
         session.add(
@@ -360,8 +369,12 @@ def test_incremental_harvest(
                 first_name="Jane",
                 last_name="Stanford",
                 orcid="0000-0000-0000-0001",
-                created_at=datetime.datetime(2026, 4, 1, 0, 0, 0),
-                updated_at=datetime.datetime(2026, 4, 1, 0, 0, 0),
+                created_at=datetime.datetime(
+                    2026, 4, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+                ),
+                updated_at=datetime.datetime(
+                    2026, 4, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+                ),
             )
         )
 
@@ -377,9 +390,10 @@ def test_incremental_harvest(
     assert len(requests_mock.request_history) == 1
     req = requests_mock.request_history[0]
     assert req.qs["term"] == ["0000-0000-0000-0001[auid]"]
-    assert req.qs["datetype"] == ["mdat"]
-    assert req.qs["mindate"] == ["2026/04/27"]
-    assert req.qs["maxdate"] == [datetime.date.today().strftime("%Y/%m/%d")]
+    assert req.qs["datetype"] == ["edat"]
+    assert req.qs["reldate"] == ["15"]
+    assert "mindate" not in req.qs
+    assert "maxdate" not in req.qs
 
 
 def test_incremental_harvest_with_new_author(

--- a/test/harvest_incremental/test_pubmed.py
+++ b/test/harvest_incremental/test_pubmed.py
@@ -978,3 +978,50 @@ def test_pubmed_search_json_decode_error_recovers_on_retry(requests_mock, caplog
     assert result == ["123"]
     assert "Failed to decode JSON response from PubMed, retrying" in caplog.text
     assert "Failed to decode JSON response from PubMed after retries" not in caplog.text
+
+
+def test_pubmed_incremental_zero_days_coverage(
+    test_incremental_session,
+    mock_rialto_db_name,
+    requests_mock,
+):
+    """
+    Specifically cover the case where number_of_days <= 0.
+    """
+    now = datetime.datetime(2026, 5, 13, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+    # Last harvest was 10 days ago
+    last_harvest_time = now - datetime.timedelta(days=10)
+
+    with patch("rialto_airflow.utils.datetime") as mock_datetime:
+        mock_datetime.datetime.now.return_value = now
+        mock_datetime.timezone = datetime.timezone
+
+        with test_incremental_session.begin() as session:
+            session.add(
+                Harvest(
+                    created_at=last_harvest_time,
+                    finished_at=now,
+                )
+            )
+            # Author updated *before* last harvest to trigger the else block
+            session.add(
+                Author(
+                    first_name="Jane",
+                    last_name="Stanford",
+                    orcid="0000-0000-0000-0001",
+                    updated_at=last_harvest_time - datetime.timedelta(days=1),
+                )
+            )
+
+        # Mock days_since to return 0 to trigger the early return
+        with patch(
+            "rialto_airflow.harvest_incremental.pubmed.days_since"
+        ) as mock_days_since:
+            mock_days_since.return_value = 0
+
+            # harvest from Pubmed
+            pubmed.harvest()
+
+    # Verify PubMed was NOT called
+    assert not requests_mock.called

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 from pathlib import Path
 
 import pytest
@@ -124,3 +125,24 @@ def test_normalize_wos_id():
     assert utils.normalize_wos_id("wos:001008232900698") == "001008232900698"
     assert utils.normalize_wos_id("001008232900698") == "001008232900698"
     assert utils.normalize_wos_id("RC:29780978") == "RC:29780978"
+
+
+def test_days_since():
+    # Test with explicit end date
+    start = datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2026, 5, 11, tzinfo=datetime.timezone.utc)
+    assert utils.days_since(start, end) == 10
+
+    # Test with default end date (now)
+    # Since we can't easily mock now here without a fixture, we'll just test that it returns an int
+    assert isinstance(utils.days_since(start), int)
+
+    # Test with different timezones
+    # 2026-05-01 00:00:00 UTC
+    start_utc = datetime.datetime(2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    # 2026-05-11 05:00:00 UTC (which is midnight EST)
+    end_est = datetime.datetime(
+        2026, 5, 11, 0, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-5))
+    )
+    # Difference should be 10 days (and 5 hours, but .days truncates)
+    assert utils.days_since(start_utc, end_est) == 10


### PR DESCRIPTION
**What was changed?**

Fixes #904.  Uses the same params for Pubmed incremental harvesting as we do in sul-pub, since we know it works there.  Refactor out the calculation for "days since" since we now use it in two places.  

note: gemini-cli assisted code.

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
