### PR TITLE
Crossref fill_in only checks newly updated pubs

### DIFF
--- a/rialto_airflow/dags/harvest_incremental.py
+++ b/rialto_airflow/dags/harvest_incremental.py
@@ -142,7 +142,7 @@ def harvest_incremental():
         """
         Fill in Crossref data for DOIs from other publication sources.
         """
-        crossref.fill_in()
+        crossref.fill_in(harvest_id)
 
     @task_group()
     def fill_in(harvest_id):

--- a/rialto_airflow/harvest_incremental/crossref.py
+++ b/rialto_airflow/harvest_incremental/crossref.py
@@ -10,20 +10,24 @@ import requests
 from sqlalchemy import select, update
 
 from rialto_airflow.database import get_session
-from rialto_airflow.schema.rialto import Publication, RIALTO_DB_NAME
+from rialto_airflow.schema.rialto import Publication, RIALTO_DB_NAME, Harvest
 from rialto_airflow.utils import normalize_doi
 
 RIALTO_EMAIL = os.environ.get("AIRFLOW_VAR_CROSSREF_EMAIL")
 
 
-def fill_in() -> None:
+def fill_in(harvest_id) -> None:
     """Harvest Crossref data for DOIs from other publication sources."""
     count = 0
+    harvest_created_at = (
+        select(Harvest.created_at).where(Harvest.id == harvest_id).scalar_subquery()
+    )
     with get_session(RIALTO_DB_NAME).begin() as select_session:
         stmt = (
             select(Publication.doi)
             .where(Publication.doi.is_not(None))
             .where(Publication.crossref_json.is_(None))
+            .where(Publication.updated_at > harvest_created_at)
             .execution_options(yield_per=1000)
         )
 

--- a/rialto_airflow/harvest_incremental/dimensions.py
+++ b/rialto_airflow/harvest_incremental/dimensions.py
@@ -281,7 +281,6 @@ def fill_in(harvest_id: int) -> None:
             select(Publication.doi)
             .where(Publication.doi.is_not(None))
             .where(Publication.dim_json.is_(None))
-            .where(Publication.updated_at.is_not(None))
             .where(Publication.updated_at > harvest_created_at)
             .execution_options(yield_per=100)
         )

--- a/test/harvest_incremental/test_crossref.py
+++ b/test/harvest_incremental/test_crossref.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import re
 
@@ -187,12 +188,52 @@ def test_unexpected_json(caplog, requests_mock):
     assert "Unexpected JSON response {'foo': 'bar'}" in caplog.text
 
 
+def test_fill_in_filters_publications_using_harvest_created_at(
+    test_incremental_session, mock_rialto_db_name, monkeypatch, active_harvest_id
+):
+    """
+    Ensure that only publications that have been updated since the active
+    harvest started will be filled in.
+    """
+
+    with test_incremental_session.begin() as session:
+        session.add_all(
+            [
+                Publication(
+                    doi="10.1111/older",
+                    crossref_json=None,
+                    updated_at=datetime.datetime(2025, 12, 31, 0, 0, 0),
+                ),
+                Publication(
+                    doi="10.1111/newer",
+                    crossref_json=None,
+                    updated_at=datetime.datetime(2026, 4, 30, 0, 0, 0),
+                ),
+            ]
+        )
+
+    queried_dois = []
+
+    def _capture_dois(dois):
+        queried_dois.append(dois)
+        return []
+
+    monkeypatch.setattr(crossref, "get_dois", _capture_dois)
+
+    crossref.fill_in(harvest_id=active_harvest_id)
+
+    assert queried_dois == [["10.1111/newer"]], (
+        "only publications updated after the selected harvest created_at should be queried"
+    )
+
+
 def test_fill_in(
     test_incremental_session,
     mock_incremental_publication,
     mock_rialto_db_name,
     caplog,
     monkeypatch,
+    active_harvest_id,
 ):
     caplog.set_level(logging.INFO)
 
@@ -206,7 +247,7 @@ def test_fill_in(
     ]
     monkeypatch.setattr(crossref, "get_dois", lambda _: records)
 
-    crossref.fill_in()
+    crossref.fill_in(active_harvest_id)
 
     with test_incremental_session.begin() as session:
         pub = (


### PR DESCRIPTION
**What was changed?**
Crossref only tries to fill in newly updated publications.

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
N/A