### PR TITLE
use corret loadTimeSpan parameter for WOS API calls

### DIFF
--- a/rialto_airflow/harvest_incremental/wos.py
+++ b/rialto_airflow/harvest_incremental/wos.py
@@ -157,6 +157,30 @@ def fill_in(harvest_id: int) -> None:
     logging.info(f"filled in {count} publications")
 
 
+def format_wos_timespan(days: int) -> str:
+    """
+    Format the number of days into a string suitable for the WoS API loadTimeSpan parameter.
+    If the number of days is more than 6, it must be expressed in weeks (W) or years (Y).
+    - <= 6 days: use days (D)
+    - > 6 days and <= 52 weeks: use weeks (W)
+    - > 52 weeks: use years (Y)
+    Note: there is a month parameter (M) but we don't need it since we can go up to 52 weeks
+    """
+    if days <= 6:
+        return f"{days}D"
+
+    weeks = (
+        (days + 6) // 7
+    )  # drop any remainder since the API expects whole weeks, but round up to the next week
+    if weeks <= 52:
+        return f"{weeks}W"
+
+    years = (
+        (days + 364) // 365
+    )  # drop any remainder since the API expects whole years, but round up to the next year
+    return f"{years}Y"
+
+
 def publications_from_orcid(orcid, harvest_date=None) -> Generator[dict, None, None]:
     """
     A generator that returns new or updated publications associated with a given ORCID, taking the last harvest date into account.
@@ -169,10 +193,12 @@ def publications_from_orcid(orcid, harvest_date=None) -> Generator[dict, None, N
     query_params["usrQuery"] = f"AI={orcid}"
     if harvest_date is not None:
         # construct a date limiter that is relative to the current date, since WOK does not allow use of the modifiedTimeSpan limiter
-        # date limiter should use the number of days since the start of the previous finished harvest + "D", e.g. "7D"
+        # date limiter should use the number of days since the start of the previous finished harvest
+        # WoS API requires us to send the number of days as weeks or years if the number of days is more than 6 or the number of weeks is more than 52.
         number_of_days = days_since(harvest_date)
-        if number_of_days > 0:
-            query_params["loadTimeSpan"] = f"{number_of_days}D"
+        if number_of_days <= 0:
+            return
+        query_params["loadTimeSpan"] = format_wos_timespan(number_of_days)
     yield from _wos_api(query_params=query_params)
 
 

--- a/test/harvest_incremental/test_wos.py
+++ b/test/harvest_incremental/test_wos.py
@@ -342,6 +342,69 @@ def test_publications_from_orcid_includes_load_time_when_previous_harvest(
     assert queries[0]["loadTimeSpan"] == "6D"
 
 
+def test_publications_from_orcid_includes_load_time_in_weeks_when_more_than_6_days(
+    test_incremental_session, mock_rialto_db_name, monkeypatch
+):
+    queries = []
+
+    def mock_wos_api(query_params):
+        # catch the query so that we can assert on it later,
+        # return an empty result set since we're just testing that the date filter is included when there is a previous harvest.
+        queries.append(query_params)
+        yield from ()
+
+    class FixedDatetime(datetime.datetime):
+        # sets up a mock datetime class that returns a fixed current date so that we can assert on the loadTimeSpan value
+        # that is calculated based on the current date and the previous harvest date.
+        @classmethod
+        def now(cls, tz=None):
+            fixed_now = cls(2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+            return fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(wos.datetime, "datetime", FixedDatetime)
+    monkeypatch.setattr(wos, "_wos_api", mock_wos_api)
+    list(
+        wos.publications_from_orcid(
+            "0000-0002-2317-1967",
+            harvest_date=datetime.datetime(
+                2026, 4, 24, 0, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+        )
+    )
+
+    # 2026-05-01 - 2026-04-24 = 7 days -> 1W
+    assert queries[0]["loadTimeSpan"] == "1W"
+
+
+def test_publications_from_orcid_does_not_call_api_when_0_days(
+    test_incremental_session, mock_rialto_db_name, monkeypatch
+):
+    queries = []
+
+    def mock_wos_api(query_params):
+        queries.append(query_params)
+        yield from ()
+
+    class FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            fixed_now = cls(2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+            return fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(wos.datetime, "datetime", FixedDatetime)
+    monkeypatch.setattr(wos, "_wos_api", mock_wos_api)
+    list(
+        wos.publications_from_orcid(
+            "0000-0002-2317-1967",
+            harvest_date=datetime.datetime(
+                2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+        )
+    )
+
+    assert len(queries) == 0
+
+
 def test_harvest_stops_when_author_limit_is_exceeded(
     mock_incremental_authors,
     mock_rialto_db_name,
@@ -820,3 +883,26 @@ def test_get_pmid_returns_none_when_identifiers_not_dict():
 def test_get_pmid_returns_none_on_attribute_error():
     pub = {"dynamic_data": {"cluster_related": None}}
     assert wos.get_pmid(pub) is None
+
+
+@pytest.mark.parametrize(
+    "days,expected",
+    [
+        (0, "0D"),
+        (1, "1D"),
+        (6, "6D"),
+        (7, "1W"),
+        (8, "2W"),
+        (13, "2W"),
+        (14, "2W"),
+        (15, "3W"),
+        (364, "52W"),
+        (365, "1Y"),
+        (366, "2Y"),
+        (729, "2Y"),
+        (730, "2Y"),
+        (731, "3Y"),
+    ],
+)
+def test_format_wos_timespan(days, expected):
+    assert wos.format_wos_timespan(days) == expected

--- a/test/harvest_incremental/test_wos.py
+++ b/test/harvest_incremental/test_wos.py
@@ -15,6 +15,22 @@ wos_key = os.environ.get("AIRFLOW_VAR_WOS_KEY")
 
 
 @pytest.fixture
+def fixed_datetime(monkeypatch):
+    """
+    Mock datetime.datetime.now to return a fixed date.
+    """
+
+    class FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            fixed_now = cls(2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+            return fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(wos.datetime, "datetime", FixedDatetime)
+    return FixedDatetime
+
+
+@pytest.fixture
 def mock_wos(monkeypatch):
     """
     Mock our function for fetching publications by orcid from Web of Science.
@@ -310,7 +326,7 @@ def test_publications_from_orcid_omits_previous_harvest_date_when_none_exists(
 
 
 def test_publications_from_orcid_includes_load_time_when_previous_harvest(
-    test_incremental_session, mock_rialto_db_name, monkeypatch
+    test_incremental_session, mock_rialto_db_name, monkeypatch, fixed_datetime
 ):
     queries = []
 
@@ -320,15 +336,6 @@ def test_publications_from_orcid_includes_load_time_when_previous_harvest(
         queries.append(query_params)
         yield from ()
 
-    class FixedDatetime(datetime.datetime):
-        # sets up a mock datetime class that returns a fixed current date so that we can assert on the loadTimeSpan value
-        # that is calculated based on the current date and the previous harvest date.
-        @classmethod
-        def now(cls, tz=None):
-            fixed_now = cls(2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-            return fixed_now.astimezone(tz)
-
-    monkeypatch.setattr(wos.datetime, "datetime", FixedDatetime)
     monkeypatch.setattr(wos, "_wos_api", mock_wos_api)
     list(
         wos.publications_from_orcid(
@@ -343,7 +350,7 @@ def test_publications_from_orcid_includes_load_time_when_previous_harvest(
 
 
 def test_publications_from_orcid_includes_load_time_in_weeks_when_more_than_6_days(
-    test_incremental_session, mock_rialto_db_name, monkeypatch
+    test_incremental_session, mock_rialto_db_name, monkeypatch, fixed_datetime
 ):
     queries = []
 
@@ -353,15 +360,6 @@ def test_publications_from_orcid_includes_load_time_in_weeks_when_more_than_6_da
         queries.append(query_params)
         yield from ()
 
-    class FixedDatetime(datetime.datetime):
-        # sets up a mock datetime class that returns a fixed current date so that we can assert on the loadTimeSpan value
-        # that is calculated based on the current date and the previous harvest date.
-        @classmethod
-        def now(cls, tz=None):
-            fixed_now = cls(2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-            return fixed_now.astimezone(tz)
-
-    monkeypatch.setattr(wos.datetime, "datetime", FixedDatetime)
     monkeypatch.setattr(wos, "_wos_api", mock_wos_api)
     list(
         wos.publications_from_orcid(
@@ -377,7 +375,7 @@ def test_publications_from_orcid_includes_load_time_in_weeks_when_more_than_6_da
 
 
 def test_publications_from_orcid_does_not_call_api_when_0_days(
-    test_incremental_session, mock_rialto_db_name, monkeypatch
+    test_incremental_session, mock_rialto_db_name, monkeypatch, fixed_datetime
 ):
     queries = []
 
@@ -385,13 +383,6 @@ def test_publications_from_orcid_does_not_call_api_when_0_days(
         queries.append(query_params)
         yield from ()
 
-    class FixedDatetime(datetime.datetime):
-        @classmethod
-        def now(cls, tz=None):
-            fixed_now = cls(2026, 5, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-            return fixed_now.astimezone(tz)
-
-    monkeypatch.setattr(wos.datetime, "datetime", FixedDatetime)
     monkeypatch.setattr(wos, "_wos_api", mock_wos_api)
     list(
         wos.publications_from_orcid(


### PR DESCRIPTION
**What was changed?**

Fixes #908:

1. WoS API timespan requires weeks or years if we get too big a number of days
2. If we end up with 0 day timespan, it should be a noop instead of running a full harvest

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
