### PR TITLE
handle duplicate cap_profile_ids

### DIFF
--- a/rialto_airflow/harvest_incremental/authors.py
+++ b/rialto_airflow/harvest_incremental/authors.py
@@ -2,7 +2,6 @@ import csv
 import logging
 
 from psycopg2 import Error as Psycopg2Error
-from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -51,13 +50,8 @@ def load_authors_table(data_dir) -> None:
                     logging.warning(
                         f"Ignored author sunet={row_dict['sunet']} because there's another author with ORCID {row_dict['orcid']}"
                     )
-
-                elif constraint == "author_cap_profile_id_key":
-                    result = handle_duplicate_cap_profile_id(session, row, row_dict)
-                    if result is True:
-                        updated_authors += 1
-                    else:
-                        ignored_authors += 1
+                else:
+                    raise
 
         logging.info(
             f"processed={processed_authors} new={new_authors} updated={updated_authors} ignored={ignored_authors}"
@@ -84,13 +78,80 @@ def row_to_dict(row: dict) -> dict:
 
 def upsert_author(session: Session, row_dict: dict) -> str:
     """
-    Insert author, or update if the sunet already exists and values have changed.
-    If there is a constraint violation related to the orcid or cap_profile_id an
-    IntegrityError exception will be raised.
+    Insert author, or update if the sunet/cap_profile_id already exists and values
+    have changed.
+
+    If there is an inactive author with the same cap_profile_id and a different
+    sunet, update that record to the active incoming row.
+
+    If there are two existing rows (one matching incoming sunet and another
+    matching cap_profile_id), merge publication links from the cap_profile_id row
+    and keep the incoming sunet row as canonical.
 
     Returns "inserted", "updated", or "noop" depending on what it did.
     """
-    author = session.query(Author).where(Author.sunet == row_dict["sunet"]).first()
+    author_by_sunet = (
+        session.query(Author).where(Author.sunet == row_dict["sunet"]).first()
+    )
+
+    author_by_cap_profile_id = None
+    if row_dict["cap_profile_id"] is not None:
+        author_by_cap_profile_id = (
+            session.query(Author)
+            .where(Author.cap_profile_id == row_dict["cap_profile_id"])
+            .first()
+        )
+
+    if (
+        author_by_sunet is not None
+        and author_by_cap_profile_id is not None
+        and author_by_sunet.id != author_by_cap_profile_id.id
+    ):
+        if row_dict["status"] is False:
+            logging.warning(
+                f"Ignored inactive author sunet={row_dict['sunet']} with pre-existing cap_profile_id {row_dict['cap_profile_id']} and a different sunet"
+            )
+            return "noop"
+
+        if author_by_cap_profile_id.status is True:
+            logging.warning(
+                f"Unable to insert active author when there is already an active author with cap_profile_id {row_dict['cap_profile_id']}"
+            )
+            return "noop"
+
+        old_sunet = author_by_cap_profile_id.sunet
+        for publication in author_by_cap_profile_id.publications:
+            if publication not in author_by_sunet.publications:
+                author_by_sunet.publications.append(publication)
+
+        session.delete(author_by_cap_profile_id)
+        session.flush()
+        logging.info(
+            f"Updated inactive author sunet={old_sunet} with active author sunet={row_dict['sunet']} for cap_profile_id={row_dict['cap_profile_id']}"
+        )
+        author = author_by_sunet
+    elif author_by_cap_profile_id is not None:
+        if author_by_cap_profile_id.sunet != row_dict["sunet"]:
+            if row_dict["status"] is False:
+                logging.warning(
+                    f"Ignored inactive author sunet={row_dict['sunet']} with pre-existing cap_profile_id {row_dict['cap_profile_id']} and a different sunet"
+                )
+                return "noop"
+
+            if author_by_cap_profile_id.status is True:
+                logging.warning(
+                    f"Unable to insert active author when there is already an active author with cap_profile_id {row_dict['cap_profile_id']}"
+                )
+                return "noop"
+
+            old_sunet = author_by_cap_profile_id.sunet
+            logging.info(
+                f"Updated inactive author sunet={old_sunet} with active author sunet={row_dict['sunet']} for cap_profile_id={row_dict['cap_profile_id']}"
+            )
+
+        author = author_by_cap_profile_id
+    else:
+        author = author_by_sunet
 
     if author is None:
         session.add(Author(**row_dict))
@@ -108,57 +169,6 @@ def upsert_author(session: Session, row_dict: dict) -> str:
     session.add(author)
     session.commit()
     return "updated"
-
-
-def handle_duplicate_cap_profile_id(
-    session: Session, row: dict, row_dict: dict
-) -> bool:
-    """
-    Handle a cap_profile_id uniqueness conflict and return the number of errors
-    encountered.
-
-    If the author being added is inactive it is ignored.
-
-    If the author being added is active, and there is an inactive author with the same
-    cap_profile_id in the database already, the inactive author will be replaced
-    with the active one.
-
-    True will be returned if an author was updated, otherwise False.
-    """
-
-    cap_profile_id = row["cap_profile_id"]
-
-    if to_boolean(row["active"]) is False:
-        logging.warning(
-            f"Ignored inactive author sunet={row_dict['sunet']} with pre-existing cap_profile_id {cap_profile_id} and a different sunet"
-        )
-        return False
-
-    inactive_author = (
-        session.query(Author)
-        .where(Author.cap_profile_id == cap_profile_id)
-        .where(Author.status.is_(False))
-        .first()
-    )
-
-    if inactive_author is None:
-        logging.warning(
-            f"Unable to insert active author when there is already an active author with cap_profile_id {cap_profile_id}"
-        )
-        return False
-
-    old_sunet = inactive_author.sunet
-
-    session.execute(
-        update(Author).where(Author.id == inactive_author.id).values(row_dict)
-    )
-    session.commit()
-
-    logging.info(
-        f"Updated inactive author sunet={old_sunet} with active author sunet={row_dict['sunet']} for cap_profile_id={cap_profile_id}"
-    )
-
-    return True
 
 
 def check_headers(authors_file: str) -> None:

--- a/test/harvest_incremental/test_authors.py
+++ b/test/harvest_incremental/test_authors.py
@@ -271,6 +271,77 @@ def test_load_dupe_cap_id_update_inactive(
         )
 
 
+def test_load_dupe_cap_id_merge_with_existing_sunet(
+    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
+):
+    """
+    Regression test for issue 924: if incoming active row matches an existing
+    active sunet row and also an existing inactive cap_profile_id row, merge the
+    inactive row into the existing sunet row without violating unique sunet.
+    """
+    with test_incremental_session.begin() as session:
+        active_author = Author(
+            sunet="tmitch11",
+            cap_profile_id="374967",
+            first_name="Thomas",
+            last_name="Mitchell",
+            status=True,
+        )
+        inactive_author = Author(
+            sunet="tmitch1",
+            cap_profile_id="350622",
+            first_name="Thomas",
+            last_name="Mitchell",
+            status=False,
+        )
+        active_pub = Publication(
+            title="Active author publication", authors=[active_author]
+        )
+        inactive_pub = Publication(
+            title="Inactive author publication", authors=[inactive_author]
+        )
+        session.add_all([active_author, inactive_author, active_pub, inactive_pub])
+
+    with open(authors_csv, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sunetid": "tmitch11",
+                "first_name": "Thomas",
+                "last_name": "Mitchell",
+                "full_name": "Thomas Mitchell",
+                "orcidid": "",
+                "orcid_update_scope": "false",
+                "cap_profile_id": "350622",
+                "role": "registry",
+                "academic_council": "false",
+                "primary_affiliation": "",
+                "primary_school": "School of Medicine",
+                "primary_department": "Neurology and Neurological Sciences",
+                "primary_division": "Pediatric Neurology",
+                "all_schools": "School of Medicine",
+                "all_departments": "Neurology and Neurological Sciences|Pediatrics",
+                "all_divisions": "Pediatric Neurology",
+                "active": "true",
+            }
+        )
+
+    load_authors_table(tmp_path)
+    assert "processed=1 new=0 updated=1 ignored=0" in caplog.text
+    assert (
+        "Updated inactive author sunet=tmitch1 with active author sunet=tmitch11 for cap_profile_id=350622"
+        in caplog.text
+    )
+
+    with test_incremental_session.begin() as session:
+        assert session.query(Author).count() == 1
+        author = session.query(Author).where(Author.sunet == "tmitch11").one()
+        assert author.cap_profile_id == "350622"
+        assert author.status is True
+        assert len(author.publications) == 2
+
+
 def test_load_dupe_cap_id(
     test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
 ):

--- a/test/harvest_incremental/test_authors.py
+++ b/test/harvest_incremental/test_authors.py
@@ -3,9 +3,12 @@ import logging
 
 import pandas
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from rialto_airflow.harvest_incremental.authors import load_authors_table
+from rialto_airflow.harvest_incremental import authors as authors_module
 from rialto_airflow.schema.rialto import Author, Publication
+from psycopg2 import Error as Psycopg2Error
 
 _CSV_FIELDNAMES = [
     "sunetid",
@@ -281,17 +284,17 @@ def test_load_dupe_cap_id_merge_with_existing_sunet(
     """
     with test_incremental_session.begin() as session:
         active_author = Author(
-            sunet="tmitch11",
-            cap_profile_id="374967",
+            sunet="test11",
+            cap_profile_id="99999",
             first_name="Thomas",
-            last_name="Mitchell",
+            last_name="Tester",
             status=True,
         )
         inactive_author = Author(
-            sunet="tmitch1",
-            cap_profile_id="350622",
+            sunet="test1",
+            cap_profile_id="12345",
             first_name="Thomas",
-            last_name="Mitchell",
+            last_name="Tester",
             status=False,
         )
         active_pub = Publication(
@@ -307,13 +310,13 @@ def test_load_dupe_cap_id_merge_with_existing_sunet(
         writer.writeheader()
         writer.writerow(
             {
-                "sunetid": "tmitch11",
+                "sunetid": "test11",
                 "first_name": "Thomas",
-                "last_name": "Mitchell",
-                "full_name": "Thomas Mitchell",
+                "last_name": "Tester",
+                "full_name": "Thomas Tester",
                 "orcidid": "",
                 "orcid_update_scope": "false",
-                "cap_profile_id": "350622",
+                "cap_profile_id": "12345",
                 "role": "registry",
                 "academic_council": "false",
                 "primary_affiliation": "",
@@ -330,16 +333,201 @@ def test_load_dupe_cap_id_merge_with_existing_sunet(
     load_authors_table(tmp_path)
     assert "processed=1 new=0 updated=1 ignored=0" in caplog.text
     assert (
-        "Updated inactive author sunet=tmitch1 with active author sunet=tmitch11 for cap_profile_id=350622"
+        "Updated inactive author sunet=test1 with active author sunet=test11 for cap_profile_id=12345"
         in caplog.text
     )
 
     with test_incremental_session.begin() as session:
         assert session.query(Author).count() == 1
-        author = session.query(Author).where(Author.sunet == "tmitch11").one()
-        assert author.cap_profile_id == "350622"
+        author = session.query(Author).where(Author.sunet == "test11").one()
+        assert author.cap_profile_id == "12345"
         assert author.status is True
         assert len(author.publications) == 2
+
+
+def test_load_dupe_cap_id_existing_active_conflict(
+    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
+):
+    """
+    If both the sunet row and the cap_profile_id row already exist as active
+    records, the incoming active row should be ignored.
+    """
+    with test_incremental_session.begin() as session:
+        session.add_all(
+            [
+                Author(
+                    sunet="test11",
+                    cap_profile_id="99999",
+                    first_name="Thomas",
+                    last_name="Tester",
+                    status=True,
+                ),
+                Author(
+                    sunet="test1",
+                    cap_profile_id="12345",
+                    first_name="Thomas",
+                    last_name="Tester",
+                    status=True,
+                ),
+            ]
+        )
+
+    with open(authors_csv, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sunetid": "test11",
+                "first_name": "Thomas",
+                "last_name": "Tester",
+                "full_name": "Thomas Tester",
+                "orcidid": "",
+                "orcid_update_scope": "false",
+                "cap_profile_id": "12345",
+                "role": "registry",
+                "academic_council": "false",
+                "primary_affiliation": "",
+                "primary_school": "School of Medicine",
+                "primary_department": "Neurology and Neurological Sciences",
+                "primary_division": "Pediatric Neurology",
+                "all_schools": "School of Medicine",
+                "all_departments": "Neurology and Neurological Sciences|Pediatrics",
+                "all_divisions": "Pediatric Neurology",
+                "active": "true",
+            }
+        )
+
+    load_authors_table(tmp_path)
+
+    assert "processed=1 new=0 updated=0 ignored=1" in caplog.text
+    assert (
+        "Unable to insert active author when there is already an active author with cap_profile_id 12345"
+        in caplog.text
+    )
+
+    with test_incremental_session.begin() as session:
+        assert session.query(Author).count() == 2
+
+
+def test_load_dupe_cap_id_existing_inactive_conflict(
+    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
+):
+    """
+    If both the sunet row and the cap_profile_id row already exist and the
+    incoming row is inactive, it should be ignored.
+    """
+    with test_incremental_session.begin() as session:
+        session.add_all(
+            [
+                Author(
+                    sunet="test11",
+                    cap_profile_id="99999",
+                    first_name="Thomas",
+                    last_name="Tester",
+                    status=True,
+                ),
+                Author(
+                    sunet="test1",
+                    cap_profile_id="12345",
+                    first_name="Thomas",
+                    last_name="Tester",
+                    status=False,
+                ),
+            ]
+        )
+
+    with open(authors_csv, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sunetid": "test11",
+                "first_name": "Thomas",
+                "last_name": "Tester",
+                "full_name": "Thomas Tester",
+                "orcidid": "",
+                "orcid_update_scope": "false",
+                "cap_profile_id": "12345",
+                "role": "registry",
+                "academic_council": "false",
+                "primary_affiliation": "",
+                "primary_school": "School of Medicine",
+                "primary_department": "Neurology and Neurological Sciences",
+                "primary_division": "Pediatric Neurology",
+                "all_schools": "School of Medicine",
+                "all_departments": "Neurology and Neurological Sciences|Pediatrics",
+                "all_divisions": "Pediatric Neurology",
+                "active": "false",
+            }
+        )
+
+    load_authors_table(tmp_path)
+
+    assert "processed=1 new=0 updated=0 ignored=1" in caplog.text
+    assert (
+        "Ignored inactive author sunet=test11 with pre-existing cap_profile_id 12345 and a different sunet"
+        in caplog.text
+    )
+
+    with test_incremental_session.begin() as session:
+        assert session.query(Author).count() == 2
+
+
+def test_load_authors_table_re_raises_unexpected_integrity_error(
+    test_incremental_session, tmp_path, authors_csv, mock_rialto_db_name, monkeypatch
+):
+    """
+    Unexpected constraint failures should not be swallowed by the loader.
+    """
+
+    class FakeDiag:
+        constraint_name = "author_some_other_key"
+
+    class FakeOrig(Psycopg2Error):
+        diag = FakeDiag()
+
+    def boom(session, row_dict):
+        raise IntegrityError("stmt", {"row": row_dict}, FakeOrig())
+
+    monkeypatch.setattr(authors_module, "upsert_author", boom)
+
+    with open(authors_csv, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sunetid": "janes",
+                "first_name": "Jane",
+                "last_name": "Stanford",
+                "full_name": "Jane Stanford",
+                "orcidid": "",
+                "orcid_update_scope": "false",
+                "cap_profile_id": "12345",
+                "role": "staff",
+                "academic_council": "false",
+                "primary_affiliation": "Engineering",
+                "primary_school": "School of Engineering",
+                "primary_department": "Computer Science",
+                "primary_division": "Philanthropy Division",
+                "all_schools": "School of Engineering",
+                "all_departments": "Computer Science",
+                "all_divisions": "Philanthropy Division",
+                "active": "true",
+            }
+        )
+
+    with pytest.raises(IntegrityError):
+        load_authors_table(tmp_path)
+
+
+def test_check_headers_rejects_missing_required_headers(tmp_path):
+    authors_file = tmp_path / "authors.csv"
+    with open(authors_file, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["sunetid", "first_name", "last_name"])
+
+    with pytest.raises(ValueError, match="expected to include"):
+        authors_module.check_headers(str(authors_file))
 
 
 def test_load_dupe_cap_id(


### PR DESCRIPTION
**What was changed?**

Fixes #924 

note: copilot (gpt 5.3) written code

here is the analysis I asked it to perform, what it then suggested and I had it do 

```
What is happening now:

1. The upsert updates author by sunet first in authors.py.
2. When cap_profile_id collides, it falls into handle_duplicate_cap_profile_id in the same file.
3. That handler updates the inactive cap_profile_id row to the incoming sunet, which can violate unique sunet if that sunet already exists (exactly your tmitch11/tmitch1 case).

What I suggest:

Move conflict handling from exception-recovery to pre-check logic in upsert.
Query both candidates before write:
1. by sunet
2. by cap_profile_id

If both exist and are different rows, treat as a merge case:
1. incoming row active: keep the sunet row as canonical, move any publication links from the cap row, then delete or retire the duplicate cap row, then apply incoming fields.
2. incoming row inactive: ignore with warning (current intended behavior).
3. Keep this whole merge in one transaction to avoid partial state.
4. Keep fallback IntegrityError handling only as safety net, not primary control flow.

Important implementation detail:

Author has publication many-to-many links in rialto.py, so if you delete a duplicate row, first transfer associations (similar to merge pattern in deduplicate.py).
```

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)
