### PR TITLE
remove handling of duplicate cap_profile_ids

### DIFF
--- a/rialto_airflow/harvest_incremental/authors.py
+++ b/rialto_airflow/harvest_incremental/authors.py
@@ -2,7 +2,6 @@ import csv
 import logging
 
 from psycopg2 import Error as Psycopg2Error
-from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -53,11 +52,7 @@ def load_authors_table(data_dir) -> None:
                     )
 
                 elif constraint == "author_cap_profile_id_key":
-                    result = handle_duplicate_cap_profile_id(session, row, row_dict)
-                    if result is True:
-                        updated_authors += 1
-                    else:
-                        ignored_authors += 1
+                    raise e
 
         logging.info(
             f"processed={processed_authors} new={new_authors} updated={updated_authors} ignored={ignored_authors}"
@@ -108,57 +103,6 @@ def upsert_author(session: Session, row_dict: dict) -> str:
     session.add(author)
     session.commit()
     return "updated"
-
-
-def handle_duplicate_cap_profile_id(
-    session: Session, row: dict, row_dict: dict
-) -> bool:
-    """
-    Handle a cap_profile_id uniqueness conflict and return the number of errors
-    encountered.
-
-    If the author being added is inactive it is ignored.
-
-    If the author being added is active, and there is an inactive author with the same
-    cap_profile_id in the database already, the inactive author will be replaced
-    with the active one.
-
-    True will be returned if an author was updated, otherwise False.
-    """
-
-    cap_profile_id = row["cap_profile_id"]
-
-    if to_boolean(row["active"]) is False:
-        logging.warning(
-            f"Ignored inactive author sunet={row_dict['sunet']} with pre-existing cap_profile_id {cap_profile_id} and a different sunet"
-        )
-        return False
-
-    inactive_author = (
-        session.query(Author)
-        .where(Author.cap_profile_id == cap_profile_id)
-        .where(Author.status.is_(False))
-        .first()
-    )
-
-    if inactive_author is None:
-        logging.warning(
-            f"Unable to insert active author when there is already an active author with cap_profile_id {cap_profile_id}"
-        )
-        return False
-
-    old_sunet = inactive_author.sunet
-
-    session.execute(
-        update(Author).where(Author.id == inactive_author.id).values(row_dict)
-    )
-    session.commit()
-
-    logging.info(
-        f"Updated inactive author sunet={old_sunet} with active author sunet={row_dict['sunet']} for cap_profile_id={cap_profile_id}"
-    )
-
-    return True
 
 
 def check_headers(authors_file: str) -> None:

--- a/test/harvest_incremental/test_authors.py
+++ b/test/harvest_incremental/test_authors.py
@@ -5,7 +5,8 @@ import pandas
 import pytest
 
 from rialto_airflow.harvest_incremental.authors import load_authors_table
-from rialto_airflow.schema.rialto import Author, Publication
+from rialto_airflow.schema.rialto import Author
+from sqlalchemy.exc import IntegrityError
 
 _CSV_FIELDNAMES = [
     "sunetid",
@@ -187,90 +188,6 @@ def test_load_dupe_orcid(
     )
 
 
-def test_load_dupe_cap_id_inactive(
-    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
-):
-    """
-    If the author being added has the same cap_profile_id as an existing author
-    with a different sunet, and the author being added is inactive, then it is
-    ignored.
-    """
-    with open(authors_csv, "a", newline="") as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
-        writer.writerow(
-            {
-                "sunetid": "lelands",  # different from what was loaded by fixture
-                "cap_profile_id": "12345",  # same as what was loaded before by fixture
-                "active": False,  # the author is inactive
-                "academic_council": False,
-            }
-        )
-
-    load_authors_table(tmp_path)
-    assert "processed=2 new=1 updated=0 ignored=1" in caplog.text
-
-    assert (
-        "Ignored inactive author sunet=lelands with pre-existing cap_profile_id 12345 and a different sunet"
-        in caplog.text
-    )
-
-    with test_incremental_session.begin() as session:
-        assert session.query(Author).count() == 1
-        assert session.query(Author).where(Author.sunet == "janes").first() is not None
-
-
-def test_load_dupe_cap_id_update_inactive(
-    test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
-):
-
-    # create an inactive author linked to a publication in the database
-    with test_incremental_session.begin() as session:
-        author = Author(
-            sunet="lelands",
-            cap_profile_id="12345",
-            first_name="Leland",
-            last_name="Stanford",
-            status=False,
-        )
-        pub = Publication(title="Test pub", authors=[author])
-        session.add(pub)
-        session.add(author)
-
-    # rewrite the authors.csv with an active author with a different sunet but the same
-    # cap_profile_id
-    with open(authors_csv, "w", newline="") as csvfile:  # note: ovewriting
-        writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
-        writer.writeheader()
-        writer.writerow(
-            {
-                "sunetid": "lelands2",
-                "cap_profile_id": "12345",
-                "active": True,
-                "academic_council": False,
-            }
-        )
-
-    # load the CSV
-    load_authors_table(tmp_path)
-    assert "processed=1 new=0 updated=1 ignored=0" in caplog.text
-
-    assert (
-        "Updated inactive author sunet=lelands with active author sunet=lelands2 for cap_profile_id=12345"
-        in caplog.text
-    )
-
-    # the inactive sunet should be gone but the publications should be
-    # preserved on the new sunet
-    with test_incremental_session.begin() as session:
-        assert session.query(Author).count() == 1
-        author = session.query(Author).where(Author.sunet == "lelands2").first()
-        assert author, "found author active author"
-        assert author.status is True, "they are active"
-        assert len(author.publications) == 1, (
-            "removal of inactive author preserved their publications"
-        )
-
-
 def test_load_dupe_cap_id(
     test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
 ):
@@ -300,13 +217,8 @@ def test_load_dupe_cap_id(
             }
         )
 
-    load_authors_table(tmp_path)
-    assert "processed=2 new=1 updated=0 ignored=1" in caplog.text
-
-    assert (
-        "Unable to insert active author when there is already an active author with cap_profile_id 12345"
-        in caplog.text
-    )
+    with pytest.raises(IntegrityError):
+        load_authors_table(tmp_path)
 
     # the inactive author should have been removed
     with test_incremental_session.begin() as session:


### PR DESCRIPTION
**What was changed?**

Duplicate cap_profile_ids will be handled by rialto-orgs upstream, so that the authors.csv file should not have any.  We will raise an error if it happens now.

Part of #924

~~HOLD until data is fixed in rialto-orgs~~
Done