### PR TITLE
Restore cap_profile_id duplicate handling

### DIFF
--- a/rialto_airflow/harvest_incremental/authors.py
+++ b/rialto_airflow/harvest_incremental/authors.py
@@ -2,6 +2,7 @@ import csv
 import logging
 
 from psycopg2 import Error as Psycopg2Error
+from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -52,7 +53,8 @@ def load_authors_table(data_dir) -> None:
                     )
 
                 elif constraint == "author_cap_profile_id_key":
-                    raise e
+                    handle_duplicate_cap_profile_id(session, row_dict)
+                    updated_authors += 1
 
         logging.info(
             f"processed={processed_authors} new={new_authors} updated={updated_authors} ignored={ignored_authors}"
@@ -103,6 +105,33 @@ def upsert_author(session: Session, row_dict: dict) -> str:
     session.add(author)
     session.commit()
     return "updated"
+
+
+def handle_duplicate_cap_profile_id(session: Session, row_dict: dict) -> None:
+    """
+    Resolve a cap_profile_id uniqueness conflict between the incoming row and
+    an existing author that already has that cap_profile_id. Overwrite the
+    existing row with the incoming values, which preserve the existing
+    author/publication relations.
+    """
+
+    cap_profile_id = row_dict["cap_profile_id"]
+
+    existing_author = (
+        session.query(Author).where(Author.cap_profile_id == cap_profile_id).one()
+    )
+
+    # save the old sunet before it gets updated, so we can log it below
+    old_sunet = existing_author.sunet
+
+    session.execute(
+        update(Author).where(Author.id == existing_author.id).values(row_dict)
+    )
+    session.commit()
+
+    logging.info(
+        f"Updated author sunet={old_sunet} with author sunet={row_dict['sunet']} for cap_profile_id={cap_profile_id}"
+    )
 
 
 def check_headers(authors_file: str) -> None:

--- a/test/harvest/test_openalex.py
+++ b/test/harvest/test_openalex.py
@@ -264,7 +264,7 @@ def test_comma():
     this starts working again we can stop ignoring them when looking them up by
     DOI when doing the fill-in process.
     """
-    with pytest.raises(pyalex.api.QueryError, match="Invalid query parameter"):
+    with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error"):
         dois = "10.1103/physrevd.72,031101"
         pyalex.Works().filter(doi=dois).get()
 

--- a/test/harvest_incremental/test_authors.py
+++ b/test/harvest_incremental/test_authors.py
@@ -5,8 +5,7 @@ import pandas
 import pytest
 
 from rialto_airflow.harvest_incremental.authors import load_authors_table
-from rialto_airflow.schema.rialto import Author
-from sqlalchemy.exc import IntegrityError
+from rialto_airflow.schema.rialto import Author, Publication
 
 _CSV_FIELDNAMES = [
     "sunetid",
@@ -191,38 +190,53 @@ def test_load_dupe_orcid(
 def test_load_dupe_cap_id(
     test_incremental_session, tmp_path, caplog, authors_csv, mock_rialto_db_name
 ):
-    """
-    Load an authors.csv with two active authors with the same cap_profile_id. We
-    should only keep the first one and ignore the second.
-    """
-    # write two rows with same cap_profile_id
-    # the first one is inactive and should be removed
-    with open(authors_csv, "w", newline="") as csvfile:  # ovewrite authors.csv
+
+    # create an inactive author linked to a publication in the database
+    with test_incremental_session.begin() as session:
+        author = Author(
+            sunet="lelands",
+            cap_profile_id="12345",
+            first_name="Leland",
+            last_name="Stanford",
+            status=False,
+        )
+        pub = Publication(title="Test pub", authors=[author])
+        session.add(pub)
+        session.add(author)
+
+    # rewrite the authors.csv with an active author with a different sunet but the same
+    # cap_profile_id
+    with open(authors_csv, "w", newline="") as csvfile:  # note: ovewriting
         writer = csv.DictWriter(csvfile, fieldnames=_CSV_FIELDNAMES)
         writer.writeheader()
         writer.writerow(
             {
-                "sunetid": "lelands",
-                "cap_profile_id": "12345",  # same as what was loaded before by fixture
-                "active": True,
-                "academic_council": False,
-            }
-        )
-        writer.writerow(
-            {
                 "sunetid": "lelands2",
-                "cap_profile_id": "12345",  # same as what was loaded before by fixture
+                "cap_profile_id": "12345",
                 "active": True,
                 "academic_council": False,
             }
         )
 
-    with pytest.raises(IntegrityError):
-        load_authors_table(tmp_path)
+    # load the CSV
+    load_authors_table(tmp_path)
+    assert "processed=1 new=0 updated=1 ignored=0" in caplog.text
 
-    # the inactive author should have been removed
+    assert (
+        "Updated author sunet=lelands with author sunet=lelands2 for cap_profile_id=12345"
+        in caplog.text
+    )
+
+    # the old sunet should be gone but the publications should be
+    # preserved on the new sunet
     with test_incremental_session.begin() as session:
         assert session.query(Author).count() == 1
+        author = session.query(Author).where(Author.sunet == "lelands2").first()
+        assert author, "found new author"
+        assert author.status is True, "they are active"
+        assert len(author.publications) == 1, (
+            "removal of old author preserved their publications"
+        )
 
 
 def test_load_null_cap_id(

--- a/test/harvest_incremental/test_openalex.py
+++ b/test/harvest_incremental/test_openalex.py
@@ -325,7 +325,7 @@ def test_comma():
     this starts working again we can stop ignoring them when looking them up by
     DOI when doing the fill-in process.
     """
-    with pytest.raises(pyalex.api.QueryError, match="Invalid query parameter"):
+    with pytest.raises(requests.exceptions.HTTPError, match="400 Client Error"):
         dois = "10.1103/physrevd.72,031101"
         pyalex.Works().filter(doi=dois).get()
 


### PR DESCRIPTION
I think we need to put back some of the code we removed in rialto_airflow author loading to handle the cap_profile_id constraint (see #927). Here's a short scenario to demonstrate why:

1. rialto-orgs gets a user from Profiles

```csv
sunet,cap_profile_id
jsmith,123
```

2. rialto-airflow loads

```csv
sunet,cap_profile_id
jsmith,123
```

3. rialto-orgs gets a new user from Profiles

```csv
sunet,cap_profile_id
jsmith,123
jsmith2,456
```

4. rialto-airflow loads

```csv
sunet,cap_profile_id
jsmith,123
jsmith2,456
```

5. rialto-orgs loads merged data from Profiles

```csv
sunet,cap_profile_id
jsmith2,123
```

6. rialto-airflow load fails

It attempts to upsert `jsmith2` but gets a constraint violation for `cap_profile_id` because a row already exists with `cap_profile_id=123` for `sunet=jsmith`.