### PR TITLE
Speed up orphaned publication removal

### DIFF
--- a/rialto_airflow/harvest_incremental/deduplicate.py
+++ b/rialto_airflow/harvest_incremental/deduplicate.py
@@ -1,5 +1,5 @@
 import logging
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, exists, func, select
 from sqlalchemy.dialects.postgresql import insert
 
 from rialto_airflow.database import get_session
@@ -221,7 +221,11 @@ def remove_orphan_publications() -> int:
     with get_session(RIALTO_DB_NAME).begin() as session:
         result = session.execute(
             delete(Publication).where(
-                ~Publication.id.in_(select(pub_author_association.c.publication_id))
+                ~exists(
+                    select(pub_author_association.c.publication_id).where(
+                        pub_author_association.c.publication_id == Publication.id
+                    )
+                )
             )
         )
         logging.info(f"Removed {result.rowcount} publications with no authors.")


### PR DESCRIPTION
**What was changed?**

We noticed it was taking 11 hours to delete 25k orphaned publications in
production rialto-airflow. And sometimes 11 hours to delete No orphaned publications!

Claude offered this diagnosis, which seems correct, and the tests verify it still works. Whether it will be faster in prod remains to be seen...

> The problem is clear. The query at line 224:
>
> delete(Publication).where(
>     ~Publication.id.in_(select(pub_author_association.c.publication_id))
> )
>
> This generates a DELETE FROM publications WHERE id NOT IN (SELECT publication_id FROM pub_author_association). The NOT IN with a subquery has two classic performance problems on large tables:
>
> 1. NOT IN with NULLs: If any row in pub_author_association.publication_id is NULL, the entire NOT IN predicate returns UNKNOWN for every row, so nothing gets deleted — which would cause the query to hang or scan the full table pointlessly.
> 2. Subquery size: NOT IN forces the database to materialize the full subquery result and then do a sequential scan against it for every row in publications. With a large pub_author_association table, this is O(n×m).
>
> The fix is to use NOT EXISTS instead, which short-circuits on the first match and handles NULLs correctly.


**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)

n/a
