### PR TITLE
Add rialto export command and --database-url CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,25 @@ Or there is this mouthful if you want to run it in a running Docker environment:
 docker compose exec -u airflow -ti airflow-worker uv run rialto publications makeller
 ```
 
+You can also export all the harvested JSON for a particular provider (one of `sulpub`, `crossref`, `dim`, `wos`, `openalex`, `pubmed`) as newline-delimited JSON (JSON-L), one publication per line. It streams from the database so it can handle large result sets. Write to a file with `--output`/`-o`, or omit it to write to stdout:
+
+```
+uv run rialto export openalex --output openalex.jsonl
+```
+
+By default the commands connect to the database configured by the `AIRFLOW_VAR_RIALTO_POSTGRES` environment variable. Pass `--database-url`/`-d` (before the subcommand) to point any command at a different database, which makes it possible to run these commands locally against a remote database:
+
+```
+uv run rialto -d postgresql+psycopg2://user:password@host:5432 export openalex -o openalex.jsonl
+```
+
+If you have set up a [local tunnel](https://github.com/sul-dlss/rialto-airflow/wiki/Connecting-to-rialto%E2%80%90airflow-database) to the database from your laptop you should be able to do this:
+
+```
+uv run rialto -d postgresql+psycopg2://analyst:PASSWORD@locahost:9999 export openalex -o openalex.jsonl
+```
+
+
 ## Deployment
 
 Deployment to https://sul-rialto-airflow-XXXX.stanford.edu/ is handled like other SDR services using Capistrano. You'll need to have Ruby installed and then:

--- a/rialto_airflow/cli.py
+++ b/rialto_airflow/cli.py
@@ -1,5 +1,8 @@
 import csv
+import json
+import os
 import sys
+from typing import Optional
 
 import dotenv
 import typer
@@ -9,10 +12,38 @@ from sqlalchemy import select
 from rialto_airflow.database import get_session
 from rialto_airflow.schema.rialto import RIALTO_DB_NAME
 from rialto_airflow.schema.rialto import Author
+from rialto_airflow.schema.rialto import Publication
 
 
 dotenv.load_dotenv()
 app = typer.Typer()
+
+# The names of the harvest providers, each of which is stored in a
+# <provider>_json column on the Publication table.
+PROVIDERS = ["sulpub", "crossref", "dim", "wos", "openalex", "pubmed"]
+
+
+@app.callback()
+def main(
+    database_url: Annotated[
+        Optional[str],
+        typer.Option(
+            "--database-url",
+            "-d",
+            help=(
+                "PostgreSQL connection URL to use, without the database name, e.g. "
+                "postgresql+psycopg2://user:password@host:5432 . This overrides the "
+                "AIRFLOW_VAR_RIALTO_POSTGRES environment variable and makes it "
+                "possible to run these commands against a remote database."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """
+    Command line utilities for working with the RIALTO database.
+    """
+    if database_url is not None:
+        os.environ["AIRFLOW_VAR_RIALTO_POSTGRES"] = database_url
 
 
 @app.command()
@@ -79,7 +110,53 @@ def publications(sunet: str) -> None:
 
 
 @app.command()
-def authors(db_name: Annotated[str, typer.Option()] = "") -> None:
+def export(
+    provider: str,
+    output: Annotated[
+        str,
+        typer.Option(
+            "--output",
+            "-o",
+            help="File to write the JSON-L to. Defaults to stdout.",
+        ),
+    ] = "-",
+) -> None:
+    """
+    Export the harvested JSON for a given provider as newline-delimited JSON
+    (JSON-L), one publication per line. PROVIDER must be one of: sulpub,
+    crossref, dim, wos, openalex, pubmed.
+    """
+    if provider not in PROVIDERS:
+        print(
+            f"Unknown provider {provider!r}. Choose from: {', '.join(PROVIDERS)}",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=1)
+
+    column = getattr(Publication, f"{provider}_json")
+
+    out = sys.stdout if output == "-" else open(output, "w")
+    try:
+        with get_session(RIALTO_DB_NAME).begin() as session:
+            # Stream just the JSON column. Setting yield_per as an execution
+            # option (before execute) makes SQLAlchemy use a server-side cursor,
+            # so rows are fetched in batches as we iterate rather than the whole
+            # result set being buffered into client memory up front.
+            stmt = (
+                select(column)
+                .where(column.is_not(None))
+                .execution_options(yield_per=1000)
+            )
+            for (data,) in session.execute(stmt):
+                out.write(json.dumps(data))
+                out.write("\n")
+    finally:
+        if out is not sys.stdout:
+            out.close()
+
+
+@app.command()
+def authors() -> None:
     """
     List the SUNET IDs for authors in the database.
     """

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,3 +1,5 @@
+import json
+import os
 from io import StringIO
 
 import pandas
@@ -31,5 +33,41 @@ def test_publications_no_author(test_incremental_session, dataset_incremental):
 
 def test_authors(test_incremental_session, dataset_incremental):
     result = runner.invoke(app, ["authors"])
+    assert result.exit_code == 0
+    assert "janes" in result.output
+
+
+def test_export(test_incremental_session, dataset_incremental):
+    result = runner.invoke(app, ["export", "sulpub"])
+    assert result.exit_code == 0
+
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert len(lines) == 1, "one line per publication with sulpub json"
+
+    row = json.loads(lines[0])
+    assert row["sulpubid"] == "123456"
+    assert row["title"] == "Sometimes limes are ok"
+
+
+def test_export_to_file(test_incremental_session, dataset_incremental, tmp_path):
+    output = tmp_path / "wos.jsonl"
+    result = runner.invoke(app, ["export", "wos", "--output", str(output)])
+    assert result.exit_code == 0
+
+    lines = [line for line in output.read_text().splitlines() if line.strip()]
+    assert len(lines) == 1, "one line per publication with wos json"
+    assert json.loads(lines[0]), "each line is valid json"
+
+
+def test_export_unknown_provider(test_incremental_session, dataset_incremental):
+    result = runner.invoke(app, ["export", "bogus"])
+    assert result.exit_code == 1
+
+
+def test_database_url_option(test_incremental_session, dataset_incremental):
+    # pass the test database connection string explicitly via --database-url and
+    # confirm a command still runs against it
+    database_url = os.environ["AIRFLOW_VAR_RIALTO_POSTGRES"]
+    result = runner.invoke(app, ["--database-url", database_url, "authors"])
     assert result.exit_code == 0
     assert "janes" in result.output


### PR DESCRIPTION
**What was changed?**

Add an `export` command that streams a provider's harvested JSON to newline-delimited JSON (JSON-L), one publication per line. It selects only the <provider>_json column and uses yield_per so large result sets are fetched in batches rather than loaded into memory.

Also add a global --database-url/-d option that overrides AIRFLOW_VAR_RIALTO_POSTGRES for all commands, making it possible to run the CLI locally against a remote database.

You can run this command within one of the Docker containers. But --database-url allows to set up a [database tunnel](https://github.com/sul-dlss/rialto-airflow/wiki/Connecting-to-rialto%E2%80%90airflow-database) and then (for example) export all the OpenAlex JSON directly to your computer with something like:

```shell
uv run rialto --database-url postgresql+psycopg2://analyst:PASSWORD:9999 export openalex > openalex.jsonl
```

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)

n/a