### PR TITLE
Retry OpenAlex 504 Gateway Timeout errors

### DIFF
--- a/rialto_airflow/harvest_incremental/openalex.py
+++ b/rialto_airflow/harvest_incremental/openalex.py
@@ -21,7 +21,7 @@ from rialto_airflow.utils import normalize_doi, normalize_pmid
 
 config.max_retries = 5
 config.retry_backoff_factor = 0.1
-config.retry_http_codes = [429, 500, 503, 520]
+config.retry_http_codes = [429, 500, 503, 504, 520]
 config.api_key = os.environ.get("AIRFLOW_VAR_OPENALEX_API_KEY")
 
 


### PR DESCRIPTION
**What was changed?**

Add 504 to pyalex's retry_http_codes so Gateway Timeout responses are
retried with backoff instead of failing the harvest. We saw some 504 errors in production run on July 19, 2026.

**Notable data changes?**  Update the [Data Changelog](https://github.com/sul-dlss/rialto-web/wiki/Data-Changelog)

n/a
